### PR TITLE
fix: hide desktop navigation on dashboard pages

### DIFF
--- a/likelee-ui/src/pages/Layout.tsx
+++ b/likelee-ui/src/pages/Layout.tsx
@@ -531,10 +531,11 @@ export default function Layout({ children, currentPageName }) {
               <div className="hidden md:flex items-center gap-1">
                 <Link
                   to={createPageUrl("BrandCompany")}
-                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${location.pathname === createPageUrl("BrandCompany")
+                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${
+                    location.pathname === createPageUrl("BrandCompany")
                       ? "text-gray-900 bg-gray-100"
                       : "text-gray-700 hover:text-gray-900 hover:bg-gray-50"
-                    }`}
+                  }`}
                 >
                   Brands
                 </Link>
@@ -543,10 +544,11 @@ export default function Layout({ children, currentPageName }) {
                 <div className="relative group">
                   <Link
                     to={createPageUrl("AgencySelection")}
-                    className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${location.pathname === createPageUrl("AgencySelection")
+                    className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${
+                      location.pathname === createPageUrl("AgencySelection")
                         ? "text-gray-900 bg-gray-100"
                         : "text-gray-700 hover:text-gray-900 hover:bg-gray-50"
-                      }`}
+                    }`}
                   >
                     Agencies
                   </Link>
@@ -593,20 +595,22 @@ export default function Layout({ children, currentPageName }) {
 
                 <Link
                   to={createPageUrl("AboutUs")}
-                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${location.pathname === createPageUrl("AboutUs")
+                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${
+                    location.pathname === createPageUrl("AboutUs")
                       ? "text-gray-900 bg-gray-100"
                       : "text-gray-700 hover:text-gray-900 hover:bg-gray-50"
-                    }`}
+                  }`}
                 >
                   About Us
                 </Link>
 
                 <Link
                   to={createPageUrl("Contact")}
-                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${location.pathname === createPageUrl("Contact")
+                  className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all relative ${
+                    location.pathname === createPageUrl("Contact")
                       ? "text-gray-900 bg-gray-100"
                       : "text-gray-700 hover:text-gray-900 hover:bg-gray-50"
-                    }`}
+                  }`}
                 >
                   Contact
                 </Link>
@@ -636,10 +640,11 @@ export default function Layout({ children, currentPageName }) {
               <Link
                 to={createPageUrl("BrandCompany")}
                 onClick={() => setMobileMenuOpen(false)}
-                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${location.pathname === createPageUrl("BrandCompany")
+                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${
+                  location.pathname === createPageUrl("BrandCompany")
                     ? "text-gray-900 bg-gray-100"
                     : "text-gray-700 hover:bg-gray-50"
-                  }`}
+                }`}
               >
                 Brands
               </Link>
@@ -649,10 +654,11 @@ export default function Layout({ children, currentPageName }) {
                 <Link
                   to={createPageUrl("AgencySelection")}
                   onClick={() => setMobileMenuOpen(false)}
-                  className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${location.pathname === createPageUrl("AgencySelection")
+                  className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${
+                    location.pathname === createPageUrl("AgencySelection")
                       ? "text-gray-900 bg-gray-100"
                       : "text-gray-700 hover:bg-gray-50"
-                    }`}
+                  }`}
                 >
                   Agencies
                 </Link>
@@ -684,10 +690,11 @@ export default function Layout({ children, currentPageName }) {
               <Link
                 to={createPageUrl("AboutUs")}
                 onClick={() => setMobileMenuOpen(false)}
-                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${location.pathname === createPageUrl("AboutUs")
+                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${
+                  location.pathname === createPageUrl("AboutUs")
                     ? "text-gray-900 bg-gray-100"
                     : "text-gray-700 hover:bg-gray-50"
-                  }`}
+                }`}
               >
                 About Us
               </Link>
@@ -695,10 +702,11 @@ export default function Layout({ children, currentPageName }) {
               <Link
                 to={createPageUrl("Contact")}
                 onClick={() => setMobileMenuOpen(false)}
-                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${location.pathname === createPageUrl("Contact")
+                className={`block px-4 py-3 text-base font-semibold rounded-lg transition-all ${
+                  location.pathname === createPageUrl("Contact")
                     ? "text-gray-900 bg-gray-100"
                     : "text-gray-700 hover:bg-gray-50"
-                  }`}
+                }`}
               >
                 Contact
               </Link>


### PR DESCRIPTION
This PR closes #75 
- **UI**: Conditionally render the desktop navigation block in `Layout.tsx` based on `!isDashboardPage`.
- Aligned Select buttons on /Creatorsignupoptions 