### PR TITLE
fix(server): remove campaigns agency_percent usage

### DIFF
--- a/likelee-server/src/campaigns.rs
+++ b/likelee-server/src/campaigns.rs
@@ -10,8 +10,6 @@ use serde_json::json;
 #[derive(Deserialize)]
 pub struct UpdateCampaignSplitRequest {
     pub payment_amount: Option<f64>,
-    pub agency_percent: Option<f64>,
-    pub talent_percent: Option<f64>,
 }
 
 pub async fn update_campaign_split(
@@ -86,8 +84,6 @@ pub async fn update_campaign_split(
 
     let mut v = json!({
         "payment_amount": payload.payment_amount,
-        "agency_percent": payload.agency_percent,
-        "talent_percent": payload.talent_percent,
     });
 
     if let serde_json::Value::Object(ref mut map) = v {
@@ -122,7 +118,7 @@ pub async fn update_campaign_split(
     let get_resp = state
         .pg
         .from("campaigns")
-        .select("id,payment_amount,agency_percent,talent_percent,agency_earnings_cents,talent_earnings_cents")
+        .select("id,payment_amount,agency_earnings_cents,talent_earnings_cents")
         .eq("id", &id)
         .limit(1)
         .execute()

--- a/likelee-server/src/payment_links.rs
+++ b/likelee-server/src/payment_links.rs
@@ -135,7 +135,7 @@ pub async fn generate_payment_link(
     let lr_resp = state
         .pg
         .from("licensing_requests")
-        .select("id,agency_id,brand_id,talent_id,status,campaign_title,client_name,talent_name,brands(email,company_name),license_submissions!licensing_requests_submission_id_fkey(client_email,client_name),campaigns(id,payment_amount,agency_percent,talent_percent,agency_earnings_cents,talent_earnings_cents)")
+        .select("id,agency_id,brand_id,talent_id,status,campaign_title,client_name,talent_name,brands(email,company_name),license_submissions!licensing_requests_submission_id_fkey(client_email,client_name),campaigns(id,payment_amount,agency_earnings_cents,talent_earnings_cents)")
         .eq("agency_id", &user.id)
         .in_("id", ids.clone())
         .execute()
@@ -372,9 +372,7 @@ pub async fn generate_payment_link(
     let c_resp = state
         .pg
         .from("campaigns")
-        .select(
-            "talent_id,agency_percent,talent_percent,agency_earnings_cents,talent_earnings_cents",
-        )
+        .select("talent_id,agency_earnings_cents,talent_earnings_cents")
         .in_("licensing_request_id", ids)
         .execute()
         .await


### PR DESCRIPTION
- Stop selecting/updating removed campaigns.agency_percent and campaigns.talent_percent
- Derive commission percent from earnings cents where needed
- Disable legacy set_pay_split endpoint (no longer supported by schema)