### PR TITLE
fix(billing): validate Stripe URLs are absolute before calling API

### DIFF
--- a/likelee-server/src/billing.rs
+++ b/likelee-server/src/billing.rs
@@ -87,6 +87,22 @@ pub async fn create_checkout_session_legacy(
         ));
     }
 
+    // Validate that URLs are absolute (must have http:// or https://) to avoid Stripe rejecting them
+    let success_url = state.stripe_studio_success_url.trim().to_string();
+    let cancel_url = state.stripe_studio_cancel_url.trim().to_string();
+    if !success_url.starts_with("http://") && !success_url.starts_with("https://") {
+        return Err((
+            StatusCode::PRECONDITION_FAILED,
+            format!("stripe_studio_success_url is not an absolute URL: {success_url}"),
+        ));
+    }
+    if !cancel_url.starts_with("http://") && !cancel_url.starts_with("https://") {
+        return Err((
+            StatusCode::PRECONDITION_FAILED,
+            format!("stripe_studio_cancel_url is not an absolute URL: {cancel_url}"),
+        ));
+    }
+
     if payload.credits <= 0 {
         return Err((StatusCode::BAD_REQUEST, "invalid_credits".to_string()));
     }
@@ -133,8 +149,14 @@ pub async fn create_checkout_session_legacy(
     };
 
     let mut cs_params = stripe_sdk::CreateCheckoutSession::new();
-    cs_params.success_url = Some(state.stripe_studio_success_url.as_str());
-    cs_params.cancel_url = Some(state.stripe_studio_cancel_url.as_str());
+    cs_params.success_url = Some(success_url.as_str());
+    cs_params.cancel_url = Some(cancel_url.as_str());
+    info!(
+        user_id = %user.id,
+        success_url = %success_url,
+        cancel_url = %cancel_url,
+        "Creating Stripe checkout session"
+    );
     cs_params.mode = Some(mode);
     cs_params.subscription_data = sub_data;
     cs_params.client_reference_id = Some(user.id.as_str());

--- a/likelee-server/src/main.rs
+++ b/likelee-server/src/main.rs
@@ -33,6 +33,18 @@ async fn main() {
         "payout_config_loaded"
     );
 
+    // Validate FRONTEND_URL is an absolute URL – required for Stripe redirect URLs
+    {
+        let fu = cfg.frontend_url.trim();
+        if !fu.starts_with("http://") && !fu.starts_with("https://") {
+            warn!(
+                frontend_url = %fu,
+                "FRONTEND_URL is not an absolute URL (must start with http:// or https://). \
+                Stripe checkout success/cancel URLs will be invalid!"
+            );
+        }
+    }
+
     let pg_url =
         if cfg.supabase_url.ends_with("/rest/v1") || cfg.supabase_url.ends_with("/rest/v1/") {
             cfg.supabase_url.clone()


### PR DESCRIPTION
- Add URL validation in billing.rs: reject requests early with a clear error if success_url/cancel_url are not absolute (http:// or https://) instead of forwarding malformed URLs to Stripe which returns a cryptic 400 'Not a valid URL' error
- Log actual success_url and cancel_url on each checkout session creation request for easy debugging
- Add startup warning in main.rs if FRONTEND_URL is not an absolute URL, since fallback Stripe URLs depend on it being valid