### PR TITLE
Restrict booking pickers to agency roster rows to avoid mixed creator/talent IDs

### DIFF
--- a/likelee-server/src/agencies.rs
+++ b/likelee-server/src/agencies.rs
@@ -216,88 +216,11 @@ pub(crate) async fn resolve_effective_agency_talent_id(
         return Ok(talent_id);
     }
 
-    // Existing connections may not have an agency-scoped agency_users row yet.
-    // Create one so asset storage can be scoped per agency (Option A).
-    let creator_resp = state
-        .pg
-        .from("creators")
-        .select("full_name")
-        .eq("id", &creator_id)
-        .limit(1)
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let creator_status = creator_resp.status();
-    let creator_text = creator_resp
-        .text()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    if !creator_status.is_success() {
-        return Err((StatusCode::INTERNAL_SERVER_ERROR, creator_text));
-    }
-    let creator_rows: Vec<serde_json::Value> =
-        serde_json::from_str(&creator_text).unwrap_or_default();
-    let full_legal_name = creator_rows
-        .first()
-        .and_then(|r| r.get("full_name"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "Unknown".to_string());
-
-    let insert_payload = json!({
-        "agency_id": agency_id,
-        "creator_id": creator_id,
-        "full_legal_name": full_legal_name,
-        "status": "active",
-        "role": "talent",
-        "updated_at": chrono::Utc::now().to_rfc3339(),
-    });
-    state
-        .pg
-        .from("agency_users")
-        .insert(insert_payload.to_string())
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    let talent_id_resp = state
-        .pg
-        .from("agency_users")
-        .select("id")
-        .eq("agency_id", agency_id)
-        .eq("creator_id", &creator_id)
-        .eq("role", "talent")
-        .order("updated_at.desc")
-        .limit(1)
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let talent_id_status = talent_id_resp.status();
-    let talent_id_text = talent_id_resp
-        .text()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    if !talent_id_status.is_success() {
-        return Err((StatusCode::INTERNAL_SERVER_ERROR, talent_id_text));
-    }
-    let talent_rows: Vec<serde_json::Value> =
-        serde_json::from_str(&talent_id_text).unwrap_or_default();
-    let new_id = talent_rows
-        .first()
-        .and_then(|r| r.get("id"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_string();
-    if new_id.is_empty() {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to provision talent identity".to_string(),
-        ));
-    }
-
-    Ok(new_id)
+    Err((
+        StatusCode::FORBIDDEN,
+        "This creator is connected to the agency but does not have an agency-owned talent profile."
+            .to_string(),
+    ))
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/likelee-server/src/agency_marketplace_contracts.rs
+++ b/likelee-server/src/agency_marketplace_contracts.rs
@@ -493,34 +493,6 @@ async fn activate_connection_from_contract_row(
         return Ok(());
     }
 
-    let creator_resp = state
-        .pg
-        .from("creators")
-        .select("full_name,email")
-        .eq("id", &creator_id)
-        .limit(1)
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let creator_text = creator_resp
-        .text()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let creator_rows: Vec<Value> = serde_json::from_str(&creator_text).unwrap_or_default();
-    let creator_name = creator_rows
-        .first()
-        .and_then(|r| r.get("full_name"))
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or("Creator")
-        .to_string();
-    let creator_email = creator_rows
-        .first()
-        .and_then(|r| r.get("email"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-
     let au_lookup_resp = state
         .pg
         .from("agency_users")
@@ -536,128 +508,72 @@ async fn activate_connection_from_contract_row(
         .text()
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let mut au_rows: Vec<Value> = serde_json::from_str(&au_lookup_text).unwrap_or_default();
-
-    if au_rows.is_empty() {
-        let insert_payload = json!({
-            "agency_id": agency_id,
-            "creator_id": creator_id,
-            "full_legal_name": creator_name,
-            "email": creator_email,
-            "status": "active",
-            "role": "talent",
-            "updated_at": chrono::Utc::now().to_rfc3339(),
-        });
-        state
-            .pg
-            .from("agency_users")
-            .insert(insert_payload.to_string())
-            .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        let fresh_resp = state
-            .pg
-            .from("agency_users")
-            .select("id")
-            .eq("agency_id", &agency_id)
-            .eq("creator_id", &creator_id)
-            .eq("role", "talent")
-            .limit(1)
-            .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        let fresh_text = fresh_resp
-            .text()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        au_rows = serde_json::from_str(&fresh_text).unwrap_or_default();
-    } else {
-        let _ = state
-            .pg
-            .from("agency_users")
-            .eq("agency_id", &agency_id)
-            .eq("creator_id", &creator_id)
-            .eq("role", "talent")
-            .update(
-                json!({
-                    "status": "active",
-                    "updated_at": chrono::Utc::now().to_rfc3339(),
-                })
-                .to_string(),
-            )
-            .execute()
-            .await;
-    }
-
+    let au_rows: Vec<Value> = serde_json::from_str(&au_lookup_text).unwrap_or_default();
     let talent_id = au_rows
         .first()
         .and_then(|r| r.get("id"))
         .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+        .map(|s| s.to_string());
 
-    if !talent_id.is_empty() {
-        let existing_rel_resp = state
+    let existing_rel_resp = state
+        .pg
+        .from("agency_talent_relationships")
+        .select("id,talent_id,creator_id")
+        .eq("agency_id", &agency_id)
+        .eq("creator_id", &creator_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let existing_rel_status = existing_rel_resp.status();
+    let existing_rel_text = existing_rel_resp
+        .text()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !existing_rel_status.is_success() {
+        return Err(sanitize_db_error(
+            existing_rel_status.as_u16(),
+            existing_rel_text,
+        ));
+    }
+    let existing_rel_rows: Vec<Value> =
+        serde_json::from_str(&existing_rel_text).unwrap_or_default();
+
+    let rel_payload = json!({
+        "agency_id": agency_id,
+        "talent_id": talent_id,
+        "creator_id": creator_id,
+        "status": "active",
+        "updated_at": chrono::Utc::now().to_rfc3339(),
+    });
+
+    let rel_resp = if let Some(existing_rel_id) = existing_rel_rows
+        .first()
+        .and_then(|r| r.get("id"))
+        .and_then(|v| v.as_str())
+        .filter(|id| !id.trim().is_empty())
+    {
+        state
             .pg
             .from("agency_talent_relationships")
-            .select("id,talent_id,creator_id")
-            .eq("agency_id", &agency_id)
-            .eq("creator_id", &creator_id)
-            .limit(1)
+            .eq("id", existing_rel_id)
+            .update(rel_payload.to_string())
             .execute()
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        let existing_rel_status = existing_rel_resp.status();
-        let existing_rel_text = existing_rel_resp
-            .text()
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    } else {
+        state
+            .pg
+            .from("agency_talent_relationships")
+            .insert(rel_payload.to_string())
+            .execute()
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        if !existing_rel_status.is_success() {
-            return Err(sanitize_db_error(
-                existing_rel_status.as_u16(),
-                existing_rel_text,
-            ));
-        }
-        let existing_rel_rows: Vec<Value> =
-            serde_json::from_str(&existing_rel_text).unwrap_or_default();
-
-        let rel_payload = json!({
-            "agency_id": agency_id,
-            "talent_id": talent_id,
-            "creator_id": creator_id,
-            "status": "active",
-            "updated_at": chrono::Utc::now().to_rfc3339(),
-        });
-
-        let rel_resp = if let Some(existing_rel_id) = existing_rel_rows
-            .first()
-            .and_then(|r| r.get("id"))
-            .and_then(|v| v.as_str())
-            .filter(|id| !id.trim().is_empty())
-        {
-            state
-                .pg
-                .from("agency_talent_relationships")
-                .eq("id", existing_rel_id)
-                .update(rel_payload.to_string())
-                .execute()
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        } else {
-            state
-                .pg
-                .from("agency_talent_relationships")
-                .insert(rel_payload.to_string())
-                .execute()
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        };
-        let rel_status = rel_resp.status();
-        if !rel_status.is_success() {
-            let rel_err = rel_resp.text().await.unwrap_or_default();
-            return Err(sanitize_db_error(rel_status.as_u16(), rel_err));
-        }
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    };
+    let rel_status = rel_resp.status();
+    if !rel_status.is_success() {
+        let rel_err = rel_resp.text().await.unwrap_or_default();
+        return Err(sanitize_db_error(rel_status.as_u16(), rel_err));
     }
 
     if !invite_id.is_empty() {
@@ -702,21 +618,6 @@ pub async fn remove_live_connection_for_contract_row(state: &AppState, row: &Val
         .eq("agency_id", &agency_id)
         .eq("creator_id", &creator_id)
         .delete()
-        .execute()
-        .await;
-    let _ = state
-        .pg
-        .from("agency_users")
-        .eq("agency_id", &agency_id)
-        .eq("creator_id", &creator_id)
-        .eq("role", "talent")
-        .update(
-            json!({
-                "status": "inactive",
-                "updated_at": chrono::Utc::now().to_rfc3339(),
-            })
-            .to_string(),
-        )
         .execute()
         .await;
 }

--- a/likelee-server/src/agency_roster.rs
+++ b/likelee-server/src/agency_roster.rs
@@ -285,10 +285,13 @@ pub async fn get_roster(
 
     if let Some(array) = rows.as_array() {
         for item in array {
-            let talent = item
-                .get("agency_users")
-                .cloned()
-                .unwrap_or_else(|| serde_json::json!({}));
+            let Some(talent) = item.get("agency_users").cloned() else {
+                // The dashboard roster is backed by agency-owned talent identities only.
+                // External creator connections may exist in agency_talent_relationships
+                // without a corresponding agency_users row and should be handled through
+                // connection-aware surfaces instead of the internal roster.
+                continue;
+            };
             let get_field = |k: &str| talent.get(k).or_else(|| item.get(k));
             let talent_id_raw = item
                 .get("talent_id")
@@ -1586,7 +1589,7 @@ pub async fn create_talent(
         ));
     }
 
-    // 3. Reuse existing global talent row by email when possible, else insert identity row once.
+    // 3. Reuse an existing agency-owned talent row by email when possible, else insert a new one.
     let normalized_email = payload
         .email
         .as_deref()
@@ -1598,6 +1601,7 @@ pub async fn create_talent(
             .pg
             .from("agency_users")
             .select("id,creator_id")
+            .eq("agency_id", &effective_agency_id)
             .eq("role", "talent")
             .ilike("email", email)
             .order("updated_at.desc")

--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -124,7 +124,7 @@ async fn creator_id_by_email(state: &AppState, email: &str) -> Option<String> {
 async fn upsert_agency_talent_connection(
     state: &AppState,
     agency_id: &str,
-    talent_id: &str,
+    talent_id: Option<&str>,
     creator_id: Option<&str>,
     status: &str,
 ) -> Result<(), (StatusCode, String)> {
@@ -179,8 +179,7 @@ async fn upsert_agency_talent_connection(
     let resp = state
         .pg
         .from("agency_talent_relationships")
-        .upsert(payload.to_string())
-        .on_conflict("agency_id,talent_id")
+        .insert(payload.to_string())
         .execute()
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -1040,6 +1039,7 @@ pub async fn accept_by_token(
         .pg
         .from("agency_users")
         .select("*")
+        .eq("agency_id", &inv.agency_id)
         .eq("creator_id", &creator_id)
         .eq("role", "talent")
         .order("updated_at.desc")
@@ -1067,6 +1067,7 @@ pub async fn accept_by_token(
             .pg
             .from("agency_users")
             .select("*")
+            .eq("agency_id", &inv.agency_id)
             .eq("email", &invited_email)
             .eq("role", "talent")
             .order("updated_at.desc")
@@ -1094,6 +1095,7 @@ pub async fn accept_by_token(
             .pg
             .from("agency_users")
             .eq("id", &agency_user_id)
+            .eq("agency_id", &inv.agency_id)
             .update(
                 json!({
                     "creator_id": creator_id,
@@ -1107,93 +1109,16 @@ pub async fn accept_by_token(
             .execute()
             .await;
         existing_agency_user_id = Some(agency_user_id);
-    } else {
-        // Compute full_legal_name
-        let creator_resp = state
-            .pg
-            .from("creators")
-            .select("full_name,email")
-            .eq("id", &creator_id)
-            .single()
-            .execute()
-            .await
-            .ok();
-        let mut full_legal_name = user.email.clone().unwrap_or_else(|| "Unknown".to_string());
-        if let Some(cresp) = creator_resp {
-            if cresp.status().is_success() {
-                if let Ok(ctxt) = cresp.text().await {
-                    let v: serde_json::Value = serde_json::from_str(&ctxt).unwrap_or(json!({}));
-                    full_legal_name = v
-                        .get("full_name")
-                        .and_then(|x| x.as_str())
-                        .filter(|s| !s.trim().is_empty())
-                        .map(|s| s.to_string())
-                        .or_else(|| user.email.clone())
-                        .or_else(|| {
-                            v.get("email")
-                                .and_then(|x| x.as_str())
-                                .map(|s| s.to_string())
-                        })
-                        .unwrap_or_else(|| "Unknown".to_string());
-                }
-            }
-        }
-
-        let _ = state
-            .pg
-            .from("agency_users")
-            .insert(
-                json!({
-                    "agency_id": inv.agency_id,
-                    "creator_id": creator_id,
-                    "full_legal_name": full_legal_name,
-                    "email": user.email.clone().unwrap_or_else(|| inv.email.clone()),
-                    "status": "active",
-                    "role": "talent",
-                    "updated_at": now_rfc3339(),
-                })
-                .to_string(),
-            )
-            .execute()
-            .await;
-
-        let lookup_resp = state
-            .pg
-            .from("agency_users")
-            .select("id")
-            .eq("creator_id", &creator_id)
-            .eq("role", "talent")
-            .order("updated_at.desc")
-            .limit(1)
-            .execute()
-            .await
-            .ok();
-        if let Some(lookup_resp) = lookup_resp {
-            if lookup_resp.status().is_success() {
-                if let Ok(lookup_text) = lookup_resp.text().await {
-                    let rows: Vec<Value> = serde_json::from_str(&lookup_text).unwrap_or_default();
-                    if let Some(id) = rows
-                        .first()
-                        .and_then(|r| r.get("id"))
-                        .and_then(|v| v.as_str())
-                    {
-                        existing_agency_user_id = Some(id.to_string());
-                    }
-                }
-            }
-        }
     }
 
-    if let Some(agency_user_id) = existing_agency_user_id.as_deref() {
-        let _ = upsert_agency_talent_connection(
-            &state,
-            &inv.agency_id,
-            agency_user_id,
-            Some(&creator_id),
-            "active",
-        )
-        .await;
-    }
+    let _ = upsert_agency_talent_connection(
+        &state,
+        &inv.agency_id,
+        existing_agency_user_id.as_deref(),
+        Some(&creator_id),
+        "active",
+    )
+    .await;
 
     if let Some(row) = matched_agency_row.as_ref() {
         hydrate_creator_from_agency_row(&state, &creator_id, &inv.email, row).await;

--- a/likelee-server/src/creator_agency_connection.rs
+++ b/likelee-server/src/creator_agency_connection.rs
@@ -173,12 +173,6 @@ struct InviteRow {
 }
 
 #[derive(Serialize, Deserialize)]
-struct CreatorRow {
-    full_name: Option<String>,
-    email: Option<String>,
-}
-
-#[derive(Serialize, Deserialize)]
 struct AgencyUserRow {
     id: String,
 }
@@ -186,7 +180,7 @@ struct AgencyUserRow {
 async fn upsert_agency_talent_connection(
     state: &AppState,
     agency_id: &str,
-    talent_id: &str,
+    talent_id: Option<&str>,
     creator_id: &str,
     status: &str,
 ) -> Result<(), (StatusCode, String)> {
@@ -234,8 +228,7 @@ async fn upsert_agency_talent_connection(
         state
             .pg
             .from("agency_talent_relationships")
-            .upsert(payload.to_string())
-            .on_conflict("agency_id,talent_id")
+            .insert(payload.to_string())
             .execute()
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
@@ -350,9 +343,6 @@ pub async fn accept_invite(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // Ensure an agency-scoped agency_users talent identity row exists for this creator.
-    // This MUST be per agency to avoid cross-agency asset visibility and to make agency
-    // asset endpoints authorize correctly.
     let au_resp = state
         .pg
         .from("agency_users")
@@ -372,100 +362,9 @@ pub async fn accept_invite(
 
     let existing: Vec<AgencyUserRow> = serde_json::from_str(&au_text)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let talent_id = existing.first().map(|r| r.id.as_str());
 
-    if existing.is_empty() {
-        // Fetch creator details for full_legal_name mapping.
-        let creator_resp = state
-            .pg
-            .from("creators")
-            .select("full_name,email")
-            .eq("id", &creator_id)
-            .limit(1)
-            .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        let creator_text = creator_resp
-            .text()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        let mut creator_rows: Vec<CreatorRow> = serde_json::from_str(&creator_text)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        let creator = creator_rows.pop().unwrap_or(CreatorRow {
-            full_name: None,
-            email: None,
-        });
-
-        let full_legal_name = creator
-            .full_name
-            .filter(|s| !s.trim().is_empty())
-            .or_else(|| user.email.clone())
-            .or(creator.email)
-            .unwrap_or_else(|| "Unknown".to_string());
-
-        let insert_payload = json!({
-            "agency_id": invite.agency_id,
-            "creator_id": creator_id,
-            "full_legal_name": full_legal_name,
-            "email": user.email,
-            "status": "active",
-            "role": "talent",
-            "updated_at": chrono::Utc::now().to_rfc3339(),
-        });
-
-        state
-            .pg
-            .from("agency_users")
-            .insert(insert_payload.to_string())
-            .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    } else {
-        state
-            .pg
-            .from("agency_users")
-            .eq("agency_id", &invite.agency_id)
-            .eq("creator_id", &creator_id)
-            .eq("role", "talent")
-            .update(
-                json!({
-                    "status": "active",
-                    "email": user.email,
-                    "updated_at": chrono::Utc::now().to_rfc3339(),
-                })
-                .to_string(),
-            )
-            .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    }
-
-    let talent_id_resp = state
-        .pg
-        .from("agency_users")
-        .select("id")
-        .eq("agency_id", &invite.agency_id)
-        .eq("creator_id", &creator_id)
-        .eq("role", "talent")
-        .order("updated_at.desc")
-        .limit(1)
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let talent_id_text = talent_id_resp
-        .text()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let talent_rows: Vec<AgencyUserRow> = serde_json::from_str(&talent_id_text)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let talent_id = talent_rows.first().map(|r| r.id.clone()).ok_or((
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "failed to resolve talent row".to_string(),
-    ))?;
-
-    upsert_agency_talent_connection(&state, &invite.agency_id, &talent_id, &creator_id, "active")
+    upsert_agency_talent_connection(&state, &invite.agency_id, talent_id, &creator_id, "active")
         .await?;
 
     Ok(Json(ActionResponse {

--- a/likelee-ui/src/components/Bookings/Modals/AddBookOutModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/AddBookOutModal.tsx
@@ -19,7 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { useEffect } from "react";
-import { getAgencyTalents } from "@/api/functions";
+import { getAgencyRoster } from "@/api/functions";
 
 export const AddBookOutModal = ({
   open,
@@ -53,11 +53,18 @@ export const AddBookOutModal = ({
     let cancelled = false;
     const load = async () => {
       try {
-        const rows = await getAgencyTalents();
+        const resp = await getAgencyRoster();
         if (cancelled) return;
+        const rows = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
         const mapped = Array.isArray(rows)
           ? rows.map((r: any) => ({
-              id: r.id || r.user_id || r.creator_id,
+              id: r.id,
               name: r.full_name || r.name || r.stage_name || "Unnamed",
             }))
           : [];

--- a/likelee-ui/src/components/Bookings/Modals/ManageAvailabilityModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/ManageAvailabilityModal.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { AddBookOutModal } from "./AddBookOutModal";
-import { getAgencyTalents } from "@/api/functions";
+import { getAgencyRoster } from "@/api/functions";
 
 export const ManageAvailabilityModal = ({
   open,
@@ -41,12 +41,18 @@ export const ManageAvailabilityModal = ({
     let cancelled = false;
     const load = async () => {
       try {
-        const rows = await getAgencyTalents();
+        const resp = await getAgencyRoster();
         if (cancelled) return;
-        const arr = Array.isArray(rows) ? rows : [];
+        const arr = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
         setTalents(
           arr.map((r: any) => ({
-            id: r.id || r.user_id || r.creator_id,
+            id: r.id,
             name: r.full_name || r.name || r.stage_name || "Unnamed",
           })),
         );

--- a/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
@@ -38,7 +38,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useToast } from "@/components/ui/use-toast";
 import { parseBackendError } from "@/utils/errorParser";
 import {
-  getAgencyTalents,
+  getAgencyRoster,
   getAgencyClients,
   getAgencyCalendlySettings,
   createAgencyClient,
@@ -278,10 +278,17 @@ export const NewBookingModal = ({
     const loadTalents = async () => {
       if (!open) return;
       try {
-        const rows = await getAgencyTalents();
+        const resp = await getAgencyRoster();
+        const rows = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
         const mapped = Array.isArray(rows)
           ? rows.map((r: any) => ({
-              id: r.id || r.user_id,
+              id: r.id,
               name: r.full_name || r.name || "Unnamed",
               img: r.profile_photo_url || null,
             }))
@@ -456,13 +463,25 @@ export const NewBookingModal = ({
     let cancelled = false;
     const t = setTimeout(async () => {
       try {
-        const rows = await getAgencyTalents(
-          talentSearch ? { q: talentSearch } : undefined,
-        );
+        const resp = await getAgencyRoster();
         if (cancelled) return;
-        const mapped = Array.isArray(rows)
-          ? rows.map((r: any) => ({
-              id: r.id || r.user_id,
+        const rows = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
+        const filteredRows = talentSearch
+          ? rows.filter((r: any) =>
+              String(r.full_name || r.name || "")
+                .toLowerCase()
+                .includes(talentSearch.toLowerCase()),
+            )
+          : rows;
+        const mapped = Array.isArray(filteredRows)
+          ? filteredRows.map((r: any) => ({
+              id: r.id,
               name: r.full_name || r.name || "Unnamed",
               img: r.profile_photo_url || null,
             }))

--- a/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Clock,
   DollarSign,
+  Loader2,
   MapPin,
   Plus,
   Search,
@@ -98,6 +99,7 @@ export const NewBookingModal = ({
     return parsed;
   };
   const [talents, setTalents] = useState<any[]>([]);
+  const [talentsLoading, setTalentsLoading] = useState(false);
   const [bookingType, setBookingType] = useState("confirmed");
   const [multiTalent, setMultiTalent] = useState(false);
   const [talentSearch, setTalentSearch] = useState("");
@@ -277,6 +279,7 @@ export const NewBookingModal = ({
   useEffect(() => {
     const loadTalents = async () => {
       if (!open) return;
+      setTalentsLoading(true);
       try {
         const resp = await getAgencyRoster();
         const rows = Array.isArray(resp)
@@ -294,7 +297,11 @@ export const NewBookingModal = ({
             }))
           : [];
         setTalents(mapped);
-      } catch (_e) {}
+      } catch (_e) {
+        setTalents([]);
+      } finally {
+        setTalentsLoading(false);
+      }
     };
     loadTalents();
   }, [open]);
@@ -462,6 +469,8 @@ export const NewBookingModal = ({
   useEffect(() => {
     let cancelled = false;
     const t = setTimeout(async () => {
+      if (!open) return;
+      setTalentsLoading(true);
       try {
         const resp = await getAgencyRoster();
         if (cancelled) return;
@@ -487,7 +496,11 @@ export const NewBookingModal = ({
             }))
           : [];
         setTalents(mapped);
-      } catch (_e) {}
+      } catch (_e) {
+        if (!cancelled) setTalents([]);
+      } finally {
+        if (!cancelled) setTalentsLoading(false);
+      }
     }, 200);
     return () => {
       cancelled = true;
@@ -908,46 +921,55 @@ export const NewBookingModal = ({
               </div>
 
               <div className="border border-gray-200 rounded-lg max-h-48 overflow-y-auto bg-white">
-                {filteredTalents.map((t) => (
-                  <div
-                    key={t.id}
-                    onClick={() => handleSelectTalent(t)}
-                    className={`flex items-center gap-3 p-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-0 ${
-                      selectedTalents.find((st) => st.id === t.id)
-                        ? "bg-indigo-50/50"
-                        : ""
-                    }`}
-                  >
-                    {t.img ? (
-                      <img
-                        src={t.img}
-                        className="w-10 h-10 rounded-full object-cover border border-gray-100"
-                        alt={t.name}
-                      />
-                    ) : (
-                      <div className="w-10 h-10 rounded-full bg-gray-100 border border-gray-200 flex items-center justify-center text-gray-500">
-                        <User className="w-5 h-5" />
-                      </div>
-                    )}
-                    <div className="flex-1">
-                      <p className="text-sm font-bold text-gray-900">
-                        {t.name}
-                      </p>
-                      <div className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 rounded-full bg-green-500" />
-                        <p className="text-xs text-green-600 font-medium lowercase">
-                          available
-                        </p>
-                      </div>
+                {talentsLoading ? (
+                  <div className="p-8 text-center text-gray-500 text-sm">
+                    <div className="flex items-center justify-center gap-2">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      <span>{`Loading ${entitySingularLower}...`}</span>
                     </div>
-                    {selectedTalents.find((st) => st.id === t.id) && (
-                      <div className="text-indigo-600">
-                        <CheckCircle2 className="w-5 h-5" />
-                      </div>
-                    )}
                   </div>
-                ))}
-                {filteredTalents.length === 0 && (
+                ) : (
+                  filteredTalents.map((t) => (
+                    <div
+                      key={t.id}
+                      onClick={() => handleSelectTalent(t)}
+                      className={`flex items-center gap-3 p-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-0 ${
+                        selectedTalents.find((st) => st.id === t.id)
+                          ? "bg-indigo-50/50"
+                          : ""
+                      }`}
+                    >
+                      {t.img ? (
+                        <img
+                          src={t.img}
+                          className="w-10 h-10 rounded-full object-cover border border-gray-100"
+                          alt={t.name}
+                        />
+                      ) : (
+                        <div className="w-10 h-10 rounded-full bg-gray-100 border border-gray-200 flex items-center justify-center text-gray-500">
+                          <User className="w-5 h-5" />
+                        </div>
+                      )}
+                      <div className="flex-1">
+                        <p className="text-sm font-bold text-gray-900">
+                          {t.name}
+                        </p>
+                        <div className="flex items-center gap-1.5">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          <p className="text-xs text-green-600 font-medium lowercase">
+                            available
+                          </p>
+                        </div>
+                      </div>
+                      {selectedTalents.find((st) => st.id === t.id) && (
+                        <div className="text-indigo-600">
+                          <CheckCircle2 className="w-5 h-5" />
+                        </div>
+                      )}
+                    </div>
+                  ))
+                )}
+                {!talentsLoading && filteredTalents.length === 0 && (
                   <div className="p-8 text-center text-gray-500 text-sm">
                     {talentSearch
                       ? `No ${entitySingularLower} found matching "${talentSearch}"`

--- a/likelee-ui/src/components/Bookings/Tabs/CalendarScheduleTab.tsx
+++ b/likelee-ui/src/components/Bookings/Tabs/CalendarScheduleTab.tsx
@@ -22,7 +22,7 @@ import {
 import { ManageAvailabilityModal } from "../Modals/ManageAvailabilityModal";
 import { NewBookingModal } from "../Modals/NewBookingModal";
 import { BookingDetailsModal } from "../Modals/BookingDetailsModal";
-import { getAgencyTalents } from "@/api/functions";
+import { getAgencyRoster } from "@/api/functions";
 
 export const CalendarScheduleTab = ({
   bookings,
@@ -82,12 +82,18 @@ export const CalendarScheduleTab = ({
     let cancelled = false;
     (async () => {
       try {
-        const rows = await getAgencyTalents();
+        const resp = await getAgencyRoster();
         if (cancelled) return;
-        const arr = Array.isArray(rows) ? rows : [];
+        const arr = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
         const mapped = arr
           .map((r: any) => ({
-            id: String(r.id || r.user_id || r.creator_id || ""),
+            id: String(r.id || ""),
             name: String(r.full_name || r.name || r.stage_name || "Unnamed"),
           }))
           .filter((t: any) => t.id);

--- a/likelee-ui/src/components/Bookings/Tabs/TalentAvailabilityTab.tsx
+++ b/likelee-ui/src/components/Bookings/Tabs/TalentAvailabilityTab.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
 import { AddBookOutModal } from "../Modals/AddBookOutModal";
-import { getAgencyTalents } from "@/api/functions";
+import { getAgencyRoster } from "@/api/functions";
 
 export const TalentAvailabilityTab = ({
   bookOuts = [],
@@ -34,12 +34,18 @@ export const TalentAvailabilityTab = ({
     let cancelled = false;
     (async () => {
       try {
-        const rows = await getAgencyTalents();
+        const resp = await getAgencyRoster();
         if (cancelled) return;
-        const arr = Array.isArray(rows) ? rows : [];
+        const arr = Array.isArray(resp)
+          ? resp
+          : Array.isArray((resp as any)?.talents)
+            ? (resp as any).talents
+            : Array.isArray((resp as any)?.data?.talents)
+              ? (resp as any).data.talents
+              : [];
         setTalents(
           arr.map((r: any) => ({
-            id: r.id || r.user_id || r.creator_id,
+            id: r.id,
             name: r.full_name || r.name || r.stage_name || "Unnamed",
           })),
         );

--- a/likelee-ui/src/components/agency/AgencyDeliverablesView.tsx
+++ b/likelee-ui/src/components/agency/AgencyDeliverablesView.tsx
@@ -24,7 +24,7 @@ import {
 import {
   createOfferAssetRequest,
   createOfferTalentAssignment,
-  getAgencyRoster,
+  getAgencyTalents,
   listMyCampaignOffers,
   listOfferAssetRequests,
   listOfferDeliverables,
@@ -250,14 +250,24 @@ export function AgencyDeliverablesView() {
   const rosterQuery = useIndexedDbQuery<{ talents: any[] }>({
     queryKey: ["agency-roster", "deliverables"],
     queryFn: async () => {
-      const resp = await getAgencyRoster();
-      const talents = Array.isArray(resp)
-        ? resp
-        : Array.isArray((resp as any)?.talents)
-          ? (resp as any).talents
-          : Array.isArray((resp as any)?.data?.talents)
-            ? (resp as any).data.talents
+      const resp: any = await getAgencyTalents();
+      const rows = Array.isArray(resp?.talents)
+        ? resp.talents
+        : Array.isArray(resp?.data?.talents)
+          ? resp.data.talents
+          : Array.isArray(resp)
+            ? resp
             : [];
+      const talents = rows.map((row: any) => ({
+        id: String(row?.id || row?.creator_id || ""),
+        creator_id: String(row?.creator_id || row?.id || ""),
+        stage_name: row?.full_name || "",
+        full_legal_name: row?.full_name || "",
+        profile_photo_url: row?.profile_photo_url || "",
+        img: row?.profile_photo_url || "",
+        has_creator_account: Boolean(row?.creator_id || row?.id),
+        is_connected_creator: Boolean(row?.is_connected_creator),
+      }));
       return { talents };
     },
     maxAge: 5 * 60 * 1000, // 5 minutes

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -51,6 +51,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { getAgencyTalents } from "@/api/functions";
 
 const extractFirstNumber = (value: unknown): number => {
   const raw = String(value ?? "").trim();
@@ -294,11 +295,24 @@ const BrandConnectionsView = () => {
   const rosterQuery = useQuery({
     queryKey: ["agency", "roster"],
     queryFn: async () => {
-      const resp = await base44.get<any>("/agency/roster");
-      if (Array.isArray(resp)) return resp;
-      if (Array.isArray(resp?.talents)) return resp.talents;
-      if (Array.isArray(resp?.data?.talents)) return resp.data.talents;
-      return [];
+      const resp: any = await getAgencyTalents();
+      const rows = Array.isArray(resp?.talents)
+        ? resp.talents
+        : Array.isArray(resp?.data?.talents)
+          ? resp.data.talents
+          : Array.isArray(resp)
+            ? resp
+            : [];
+      return rows.map((row: any) => ({
+        id: String(row?.id || row?.creator_id || ""),
+        creator_id: String(row?.creator_id || row?.id || ""),
+        stage_name: row?.full_name || "",
+        full_legal_name: row?.full_name || "",
+        profile_photo_url: row?.profile_photo_url || "",
+        img: row?.profile_photo_url || "",
+        has_creator_account: Boolean(row?.creator_id || row?.id),
+        is_connected_creator: Boolean(row?.is_connected_creator),
+      }));
     },
   });
 
@@ -343,6 +357,7 @@ const BrandConnectionsView = () => {
   const assignedTalentIds = useMemo(() => {
     return new Set(
       (offerAssignmentsQuery.data || []).map((a: any) =>
+        // Offer assignments are creator-first; talent_id is a legacy fallback.
         String(
           a?.creator_id || a?.agency_users?.creator_id || a?.talent_id || "",
         ),
@@ -629,11 +644,12 @@ const BrandConnectionsView = () => {
         : [];
       const currentByCreatorId = new Map<string, string>();
       current.forEach((a: any) => {
-        const tid = String(
+        const creatorScopedId = String(
           a?.creator_id || a?.agency_users?.creator_id || a?.talent_id || "",
         ).trim();
         const aid = String(a?.id || "").trim();
-        if (tid && aid) currentByCreatorId.set(tid, aid);
+        if (creatorScopedId && aid)
+          currentByCreatorId.set(creatorScopedId, aid);
       });
 
       const desiredIds = new Set(
@@ -655,13 +671,13 @@ const BrandConnectionsView = () => {
       }
 
       await Promise.all([
-        ...toAdd.map((talentId) =>
+        ...toAdd.map((creatorId) =>
           base44.post(`/api/campaign-offers/${offerId}/assignments`, {
-            creator_id: talentId,
+            creator_id: creatorId,
           }),
         ),
-        ...toRemove.map((talentId) => {
-          const assignmentId = currentByCreatorId.get(talentId);
+        ...toRemove.map((creatorId) => {
+          const assignmentId = currentByCreatorId.get(creatorId);
           if (!assignmentId) return Promise.resolve(null);
           return base44.delete(
             `/api/campaign-offers/${offerId}/assignments/${assignmentId}`,


### PR DESCRIPTION
**Summary**
This PR addresses two related agency/creator identity issues.

First, it fixes the backend connection model so connecting a creator to an agency no longer auto-creates an `agency_users` row. External creator connections should live in `agency_talent_relationships`, while `agency_users` should remain reserved for agency-owned/internal talent created by that agency.

Second, it applies a quick UI guardrail for booking-related flows by switching those pickers from the mixed `/api/agency/talents` source to the strict agency roster source. Booking and availability flows submit `talent_id`, so they should only allow selecting agency-owned roster rows from `agency_users`.

**What changed**
- Removed auto-provisioning of `agency_users` rows from creator-to-agency connection acceptance flows.
- Kept connection writes in `agency_talent_relationships`, attaching `talent_id` only when an agency-owned roster row already exists.
- Updated booking and availability UI pickers to use `getAgencyRoster()` instead of `getAgencyTalents()`.

**Why**
This restores the intended split:

- `agency_users` = agency-owned/internal talent only
- `agency_talent_relationships` = agency connection to existing external creators

It also removes ID ambiguity in booking flows, where the UI was previously reading from a mixed talent/creator endpoint but always submitting `talent_id`.

**Affected areas**
Backend:
- creator/agency invite acceptance
- agency talent invite acceptance
- marketplace contract connection activation

Frontend:
- booking modal
- calendar schedule
- talent availability
- add/manage book-outs

**Result**
- Connecting a creator to an agency no longer silently inserts them into `agency_users`
- Booking-related pickers now only show agency-owned roster talent
- Booking payloads remain aligned with `talent_id = agency_users.id`
