### PR TITLE
feat(team): add remove team member functionality

### DIFF
--- a/docs/team-member-functionality.md
+++ b/docs/team-member-functionality.md
@@ -89,6 +89,7 @@ pub enum Permission {
     ViewSubscriptions,
     ManagePayOffers,
     ViewPayOffers,
+    RemoveTeamMembers,
 }
 ```
 
@@ -118,6 +119,7 @@ pub enum Permission {
 | ViewSubscriptions          | ✅    | ✅    | ✅              | ❌       |
 | ManagePayOffers            | ✅    | ✅    | ✅              | ❌       |
 | ViewPayOffers              | ✅    | ✅    | ✅              | ✅       |
+| RemoveTeamMembers          | ✅    | ✅    | ❌              | ❌       |
 | TransferOwnership          | ✅    | ❌    | ❌              | ❌       |
 | DeleteOrganisation         | ✅    | ❌    | ❌              | ❌       |
 
@@ -167,6 +169,7 @@ pub enum Permission {
 - Manage billing & subscriptions
 - Invite team members
 - Update member roles
+- Remove team members
 - Manage all organization settings
 
 **Cannot Do:**
@@ -398,6 +401,7 @@ CREATE POLICY "agency_notification_settings update own"
 | `/api/team/invites`               | GET    | List invites                                     | ViewTeamMembers     |
 | `/api/team/invites`               | POST   | Create invite                                    | InviteTeamMembers   |
 | `/api/team/members/:user_id/role` | POST   | Update member role                               | UpdateMemberRoles   |
+| `/api/team/members/:user_id`      | DELETE | Remove member from organization                  | RemoveTeamMembers   |
 | `/api/team/audit-logs`            | GET    | Get team activity                                | ViewTeamMembers     |
 
 ### Invitation (Public)

--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -1194,11 +1194,8 @@ async fn resolve_effective_creator_id(
 
 pub async fn decline_by_token(
     State(state): State<AppState>,
-    user: AuthUser,
     Path(token): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    RoleGuard::new(vec!["creator", "talent"]).check(&user.role)?;
-
     let resp = state
         .pg
         .from("agency_talent_invites")
@@ -1223,14 +1220,6 @@ pub async fn decline_by_token(
     }
     if is_expired(&inv.expires_at) {
         return Err((StatusCode::BAD_REQUEST, "invite expired".to_string()));
-    }
-
-    let user_email = user.email.clone().unwrap_or_default().trim().to_lowercase();
-    if user_email.is_empty() || user_email != inv.email.trim().to_lowercase() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "email does not match invite".to_string(),
-        ));
     }
 
     let _ = state

--- a/likelee-server/src/router.rs
+++ b/likelee-server/src/router.rs
@@ -348,6 +348,10 @@ pub fn build_router(state: AppState) -> Router {
             post(crate::team::update_member_role),
         )
         .route(
+            "/api/team/members/:user_id",
+            axum::routing::delete(crate::team::remove_member),
+        )
+        .route(
             "/api/invites/team/:token",
             get(crate::team::get_invite_by_token),
         )

--- a/likelee-server/src/team/handlers.rs
+++ b/likelee-server/src/team/handlers.rs
@@ -439,6 +439,116 @@ pub async fn update_member_role(
     Ok(Json(updated))
 }
 
+pub async fn remove_member(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(target_user_id): Path<String>,
+    Query(query): Query<TeamScopeQuery>,
+) -> Result<Json<ActionResponse>, (StatusCode, String)> {
+    let scope = resolve_scope(&state, &user, &query).await?;
+    ensure_permission(&scope.membership, Permission::RemoveTeamMembers)?;
+
+    let current_role = TeamRole::parse(scope.membership.role.as_str()).ok_or((
+        StatusCode::FORBIDDEN,
+        "Invalid actor membership role".to_string(),
+    ))?;
+
+    let target_membership = fetch_target_membership(
+        &state,
+        scope.organization_type,
+        scope.organization_id.as_str(),
+        target_user_id.as_str(),
+    )
+    .await?;
+    let target_role = TeamRole::parse(target_membership.role.as_str()).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Invalid target membership role".to_string(),
+    ))?;
+
+    if target_role == TeamRole::Owner {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Cannot remove the organization owner".to_string(),
+        ));
+    }
+
+    match current_role {
+        TeamRole::Owner => {}
+        TeamRole::Admin => {
+            if target_role == TeamRole::Admin {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    "Only the owner can remove another admin".to_string(),
+                ));
+            }
+        }
+        _ => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Only owner or admin can remove team members".to_string(),
+            ));
+        }
+    }
+
+    let resp = state
+        .pg
+        .from("organization_memberships")
+        .eq("organization_type", scope.organization_type.as_str())
+        .eq("organization_id", scope.organization_id.as_str())
+        .eq("user_id", target_user_id.as_str())
+        .delete()
+        .execute()
+        .await
+        .map_err(internal_error)?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(crate::errors::sanitize_db_error(status.as_u16(), text));
+    }
+
+    invalidate_org_access_cache(&state, &target_user_id, scope.organization_type.as_str());
+
+    tracing::info!(
+        user_id = %target_user_id,
+        org_type = %scope.organization_type.as_str(),
+        role = %target_role.as_str(),
+        "User removed from organization"
+    );
+
+    write_audit_log(
+        &state,
+        AuditLogEntry {
+            organization_type: scope.organization_type,
+            organization_id: scope.organization_id.as_str(),
+            actor_user_id: user.id.as_str(),
+            target_user_id: Some(target_user_id.as_str()),
+            target_email: Some(target_membership.email.as_str()),
+            action: "member_removed",
+            old_role: Some(target_role.as_str()),
+            new_role: None,
+            metadata: json!({}),
+        },
+    )
+    .await?;
+
+    let subject = format!("You've been removed from {}", scope.organization_name);
+    let body = format!(
+        "Hi,\n\nYou have been removed from {} on Likelee. If you believe this was an error, please contact the organization owner.",
+        scope.organization_name
+    );
+    let _ = email::send_plain_text_email(
+        &state,
+        target_membership.email.as_str(),
+        subject.as_str(),
+        body.as_str(),
+        Some(scope.organization_name.as_str()),
+    );
+
+    Ok(Json(ActionResponse {
+        status: "ok".to_string(),
+    }))
+}
+
 pub async fn accept_invite_by_token(
     State(state): State<AppState>,
     user: AuthUser,
@@ -621,7 +731,6 @@ pub async fn accept_invite_by_token(
 
 pub async fn decline_invite_by_token(
     State(state): State<AppState>,
-    user: AuthUser,
     Path(raw_token): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
     let invite = fetch_invite_by_raw_token(&state, raw_token.as_str()).await?;
@@ -633,19 +742,6 @@ pub async fn decline_invite_by_token(
             format!("Invite is {}", invite.status),
         ));
     }
-
-    let user_email = user.email.clone().unwrap_or_default().trim().to_lowercase();
-    if user_email.is_empty() || user_email != invite.email.trim().to_lowercase() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Signed-in email does not match the invitation".to_string(),
-        ));
-    }
-
-    let organization_type = OrganizationType::parse(invite.organization_type.as_str()).ok_or((
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "Invalid organization type on invite".to_string(),
-    ))?;
 
     let update_resp = state
         .pg
@@ -666,22 +762,6 @@ pub async fn decline_invite_by_token(
         let text = update_resp.text().await.unwrap_or_default();
         return Err(crate::errors::sanitize_db_error(status.as_u16(), text));
     }
-
-    write_audit_log(
-        &state,
-        AuditLogEntry {
-            organization_type,
-            organization_id: invite.organization_id.as_str(),
-            actor_user_id: user.id.as_str(),
-            target_user_id: None,
-            target_email: Some(user_email.as_str()),
-            action: "team_invite_declined",
-            old_role: None,
-            new_role: Some(invite.role.as_str()),
-            metadata: json!({ "invite_id": invite.id }),
-        },
-    )
-    .await?;
 
     Ok(Json(ActionResponse {
         status: "ok".to_string(),

--- a/likelee-server/src/team/handlers.rs
+++ b/likelee-server/src/team/handlers.rs
@@ -743,6 +743,9 @@ pub async fn decline_invite_by_token(
         ));
     }
 
+    let organization_type = OrganizationType::parse(&invite.organization_type)
+        .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, "Invalid organization_type".to_string()))?;
+
     let update_resp = state
         .pg
         .from("organization_invites")
@@ -762,6 +765,25 @@ pub async fn decline_invite_by_token(
         let text = update_resp.text().await.unwrap_or_default();
         return Err(crate::errors::sanitize_db_error(status.as_u16(), text));
     }
+
+    write_audit_log(
+        &state,
+        AuditLogEntry {
+            organization_type,
+            organization_id: invite.organization_id.as_str(),
+            actor_user_id: "anonymous",
+            target_user_id: None,
+            target_email: Some(invite.email.as_str()),
+            action: "team_invite_declined",
+            old_role: None,
+            new_role: None,
+            metadata: json!({
+                "invite_id": invite.id,
+                "declined_via": "token",
+            }),
+        },
+    )
+    .await?;
 
     Ok(Json(ActionResponse {
         status: "ok".to_string(),

--- a/likelee-server/src/team/handlers.rs
+++ b/likelee-server/src/team/handlers.rs
@@ -743,8 +743,13 @@ pub async fn decline_invite_by_token(
         ));
     }
 
-    let organization_type = OrganizationType::parse(&invite.organization_type)
-        .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, "Invalid organization_type".to_string()))?;
+    let organization_type =
+        OrganizationType::parse(&invite.organization_type).ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Invalid organization_type".to_string(),
+            )
+        })?;
 
     let update_resp = state
         .pg

--- a/likelee-server/src/team/mod.rs
+++ b/likelee-server/src/team/mod.rs
@@ -16,7 +16,8 @@ pub use access::{
 pub use connections::{check_brand_agency_connection, invalidate_brand_agency_connection_cache};
 pub use handlers::{
     accept_invite_by_token, create_invite, decline_invite_by_token, get_context,
-    get_invite_by_token, list_audit_logs, list_invites, list_members, update_member_role,
+    get_invite_by_token, list_audit_logs, list_invites, list_members, remove_member,
+    update_member_role,
 };
 pub use types::{
     ActionResponse, AuditLogRecord, BrandAgencyConnection, CreateInvitePayload, InviteRecord,

--- a/likelee-server/src/team/permissions.rs
+++ b/likelee-server/src/team/permissions.rs
@@ -58,6 +58,7 @@ pub enum Permission {
     ViewSubscriptions,
     ManagePayOffers,
     ViewPayOffers,
+    RemoveTeamMembers,
 }
 
 impl Permission {
@@ -87,6 +88,7 @@ impl Permission {
             Self::ViewSubscriptions => "view_subscriptions",
             Self::ManagePayOffers => "manage_pay_offers",
             Self::ViewPayOffers => "view_pay_offers",
+            Self::RemoveTeamMembers => "remove_team_members",
         }
     }
 }
@@ -118,6 +120,7 @@ pub fn permissions_for_role(role: TeamRole) -> Vec<Permission> {
             Permission::ViewSubscriptions,
             Permission::ManagePayOffers,
             Permission::ViewPayOffers,
+            Permission::RemoveTeamMembers,
         ],
         TeamRole::Admin => vec![
             Permission::CreateCampaigns,
@@ -142,6 +145,7 @@ pub fn permissions_for_role(role: TeamRole) -> Vec<Permission> {
             Permission::ViewSubscriptions,
             Permission::ManagePayOffers,
             Permission::ViewPayOffers,
+            Permission::RemoveTeamMembers,
         ],
         TeamRole::ProjectManager => vec![
             Permission::CreateCampaigns,

--- a/likelee-ui/src/components/dashboard/settings/GeneralSettingsView.tsx
+++ b/likelee-ui/src/components/dashboard/settings/GeneralSettingsView.tsx
@@ -7,7 +7,11 @@ import {
   getAgencyPayoutsAccountStatus,
   getTeamAuditLogs,
 } from "@/api/functions";
-import { Loader2, RefreshCw } from "lucide-react";
+import {
+  Loader2,
+  RefreshCw,
+  AlertTriangle,
+} from "lucide-react";
 import {
   Building2,
   Upload,
@@ -514,6 +518,13 @@ const ActivityLogModal = ({
           icon: XCircle,
           color: "text-red-600 bg-red-50",
         };
+      case "member_removed":
+        return {
+          label: "Member removed",
+          details: `${log.target_email || "A member"} was removed from the team`,
+          icon: User,
+          color: "text-red-600 bg-red-50",
+        };
       default:
         return {
           label: log.action.replaceAll("_", " "),
@@ -623,6 +634,8 @@ const GeneralSettingsView = (props: GeneralSettingsViewProps) => {
   const [isLoadingTeamContext, setIsLoadingTeamContext] = useState(false);
   const [isSubmittingTeamInvite, setIsSubmittingTeamInvite] = useState(false);
   const [isUpdatingTeamRole, setIsUpdatingTeamRole] = useState(false);
+  const [isDeletingTeamMember, setIsDeletingTeamMember] = useState(false);
+  const [showDeleteMemberModal, setShowDeleteMemberModal] = useState(false);
   const [teamInviteEmail, setTeamInviteEmail] = useState("");
   const [teamInviteRole, setTeamInviteRole] =
     useState<Exclude<TeamRoleValue, "owner">>("reviewer");
@@ -841,6 +854,44 @@ const GeneralSettingsView = (props: GeneralSettingsViewProps) => {
       });
     } finally {
       setIsUpdatingTeamRole(false);
+    }
+  };
+
+  const handleRemoveTeamMember = async () => {
+    if (!selectedMember) return;
+    try {
+      setIsDeletingTeamMember(true);
+      const resp = await fetch(
+        `/api/team/members/${encodeURIComponent(selectedMember.user_id)}?organization_type=agency`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${getAccessToken()}`,
+          },
+        },
+      );
+      const payload = await parseApiResponse(resp);
+      if (!resp.ok) {
+        throw new Error(
+          payload?.message || payload?.error || "Failed to remove member.",
+        );
+      }
+      setShowDeleteMemberModal(false);
+      setSelectedMember(null);
+      toast({
+        title: "Member removed",
+        description: `${selectedMember.email} has been removed from the team.`,
+      });
+      await fetchTeamContext();
+      await fetchTeamAuditLogs();
+    } catch (error: any) {
+      toast({
+        title: "Removal failed",
+        description: error?.message || "Could not remove the member.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeletingTeamMember(false);
     }
   };
 
@@ -3061,6 +3112,12 @@ const GeneralSettingsView = (props: GeneralSettingsViewProps) => {
                             ) &&
                             member.role !== "owner" &&
                             !(actorRole === "admin" && member.role === "admin");
+                          const canRemove =
+                            teamContext?.permissions?.includes(
+                              "remove_team_members",
+                            ) &&
+                            member.role !== "owner" &&
+                            !(actorRole === "admin" && member.role === "admin");
                           return (
                             <div
                               key={member.user_id}
@@ -3083,15 +3140,29 @@ const GeneralSettingsView = (props: GeneralSettingsViewProps) => {
                                     Owner
                                   </Badge>
                                 ) : (
-                                  <Button
-                                    variant="outline"
-                                    className="rounded-xl"
-                                    disabled={!canEditRole}
-                                    onClick={() => openRoleEditor(member)}
-                                  >
-                                    <Edit2 className="w-4 h-4 mr-2" />
-                                    Edit Role
-                                  </Button>
+                                  <>
+                                    <Button
+                                      variant="outline"
+                                      className="rounded-xl"
+                                      disabled={!canEditRole}
+                                      onClick={() => openRoleEditor(member)}
+                                    >
+                                      <Edit2 className="w-4 h-4 mr-2" />
+                                      Edit Role
+                                    </Button>
+                                    {canRemove && (
+                                      <Button
+                                        variant="outline"
+                                        className="rounded-xl border-red-300 text-red-600 hover:bg-red-50"
+                                        onClick={() => {
+                                          setSelectedMember(member);
+                                          setShowDeleteMemberModal(true);
+                                        }}
+                                      >
+                                        <Trash2 className="w-4 h-4" />
+                                      </Button>
+                                    )}
+                                  </>
                                 )}
                               </div>
                             </div>
@@ -3659,6 +3730,53 @@ const GeneralSettingsView = (props: GeneralSettingsViewProps) => {
           onOpenChange={setShowActivityModal}
           logs={teamAuditLogs}
         />
+        <Dialog
+          open={showDeleteMemberModal}
+          onOpenChange={setShowDeleteMemberModal}
+        >
+          <DialogContent className="max-w-md rounded-2xl">
+            <DialogHeader>
+              <DialogTitle className="text-xl font-bold text-gray-900">
+                Remove Team Member
+              </DialogTitle>
+              <DialogDescription className="text-sm text-gray-500 font-medium">
+                Are you sure you want to remove{" "}
+                {selectedMember?.email || "this member"} from the team?
+              </DialogDescription>
+            </DialogHeader>
+            <div className="p-4 bg-red-50 border border-red-100 rounded-xl">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
+                <p className="text-xs text-red-700 font-medium leading-relaxed">
+                  This action cannot be undone. The member will lose access to
+                  all organization resources immediately.
+                </p>
+              </div>
+            </div>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button
+                variant="ghost"
+                onClick={() => setShowDeleteMemberModal(false)}
+                className="font-bold"
+                disabled={isDeletingTeamMember}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleRemoveTeamMember}
+                disabled={isDeletingTeamMember}
+                className="bg-red-600 hover:bg-red-700 text-white font-bold px-6 rounded-xl flex items-center gap-2"
+              >
+                {isDeletingTeamMember ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Trash2 className="w-4 h-4" />
+                )}
+                {isDeletingTeamMember ? "Removing..." : "Remove Member"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   );

--- a/likelee-ui/src/components/dashboard/settings/GeneralSettingsView.tsx
+++ b/likelee-ui/src/components/dashboard/settings/GeneralSettingsView.tsx
@@ -7,11 +7,7 @@ import {
   getAgencyPayoutsAccountStatus,
   getTeamAuditLogs,
 } from "@/api/functions";
-import {
-  Loader2,
-  RefreshCw,
-  AlertTriangle,
-} from "lucide-react";
+import { Loader2, RefreshCw, AlertTriangle } from "lucide-react";
 import {
   Building2,
   Upload,

--- a/likelee-ui/src/features/team/TeamManagementCard.tsx
+++ b/likelee-ui/src/features/team/TeamManagementCard.tsx
@@ -1198,7 +1198,8 @@ export function TeamManagementCard({
                   : "text-sm text-gray-500 font-medium"
               }
             >
-              Are you sure you want to remove {selectedMember?.email || "this member"} from the team?
+              Are you sure you want to remove{" "}
+              {selectedMember?.email || "this member"} from the team?
             </DialogDescription>
           </DialogHeader>
           <div
@@ -1217,7 +1218,8 @@ export function TeamManagementCard({
                     : "text-xs text-red-700 font-medium leading-relaxed"
                 }
               >
-                This action cannot be undone. The member will lose access to all organization resources immediately.
+                This action cannot be undone. The member will lose access to all
+                organization resources immediately.
               </p>
             </div>
           </div>

--- a/likelee-ui/src/features/team/TeamManagementCard.tsx
+++ b/likelee-ui/src/features/team/TeamManagementCard.tsx
@@ -12,6 +12,8 @@ import {
   Edit2,
   Check,
   ArrowRight,
+  Trash2,
+  AlertTriangle,
 } from "lucide-react";
 import { useAuth } from "@/auth/AuthProvider";
 import { useToast } from "@/components/ui/use-toast";
@@ -184,6 +186,7 @@ export function TeamManagementCard({
   const [showRoleModal, setShowRoleModal] = React.useState(false);
   const [showActivityModal, setShowActivityModal] = React.useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = React.useState(false);
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false);
   const [seatLimitError, setSeatLimitError] = React.useState<string | null>(
     null,
   );
@@ -196,6 +199,7 @@ export function TeamManagementCard({
     React.useState<Exclude<TeamRoleValue, "owner">>("reviewer");
   const [submittingInvite, setSubmittingInvite] = React.useState(false);
   const [updatingRole, setUpdatingRole] = React.useState(false);
+  const [deletingMember, setDeletingMember] = React.useState(false);
 
   const seatLimitBlocked = seatLimit === 0 || seatLimitReached === true;
 
@@ -271,6 +275,9 @@ export function TeamManagementCard({
   );
   const canUpdateRoles = Boolean(
     context?.permissions?.includes("update_member_roles"),
+  );
+  const canRemoveMembers = Boolean(
+    context?.permissions?.includes("remove_team_members"),
   );
 
   const handleInviteButtonClick = () => {
@@ -396,6 +403,47 @@ export function TeamManagementCard({
     setShowRoleModal(true);
   };
 
+  const openRemoveDialog = (member: TeamMemberRecord) => {
+    setSelectedMember(member);
+    setShowDeleteModal(true);
+  };
+
+  const handleRemove = async () => {
+    if (!selectedMember) return;
+    try {
+      setDeletingMember(true);
+      const resp = await fetch(
+        `/api/team/members/${encodeURIComponent(selectedMember.user_id)}?organization_type=${encodeURIComponent(organizationType)}`,
+        {
+          method: "DELETE",
+          headers: authHeaders,
+        },
+      );
+      const payload = await parseApiResponse(resp);
+      if (!resp.ok) {
+        throw new Error(
+          payload?.message || payload?.error || "Failed to remove member.",
+        );
+      }
+      setShowDeleteModal(false);
+      setSelectedMember(null);
+      await loadContext();
+      await loadAuditLogs();
+      toast({
+        title: "Member removed",
+        description: `${selectedMember.email} has been removed from the team.`,
+      });
+    } catch (err: any) {
+      toast({
+        title: "Removal failed",
+        description: err?.message || "Could not remove the member.",
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingMember(false);
+    }
+  };
+
   const decorateActivity = (log: TeamAuditLogRecord) => {
     switch (log.action) {
       case "team_invite_created":
@@ -423,6 +471,12 @@ export function TeamManagementCard({
           label: "Invitation declined",
           details: `${log.target_email || "A member"} declined the invitation`,
           icon: XCircle,
+        };
+      case "member_removed":
+        return {
+          label: "Member removed",
+          details: `${log.target_email || "A member"} was removed from the team`,
+          icon: User,
         };
       default:
         return {
@@ -526,6 +580,10 @@ export function TeamManagementCard({
                     canUpdateRoles &&
                     member.role !== "owner" &&
                     !(actorRole === "admin" && member.role === "admin");
+                  const canRemove =
+                    canRemoveMembers &&
+                    member.role !== "owner" &&
+                    !(actorRole === "admin" && member.role === "admin");
                   return (
                     <div
                       key={member.user_id}
@@ -597,6 +655,20 @@ export function TeamManagementCard({
                             onClick={() => openRoleEditor(member)}
                           >
                             <Edit2 className="w-4 h-4" />
+                          </Button>
+                        ) : null}
+                        {canRemove ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className={
+                              organizationType === "brand"
+                                ? "rounded-none border-2 border-red-500 text-red-600 hover:bg-red-50"
+                                : "border-2 border-red-300 text-red-600 hover:bg-red-50"
+                            }
+                            onClick={() => openRemoveDialog(member)}
+                          >
+                            <Trash2 className="w-4 h-4" />
                           </Button>
                         ) : null}
                       </div>
@@ -1096,6 +1168,87 @@ export function TeamManagementCard({
             >
               Upgrade Plan
               <ArrowRight className="w-4 h-4" />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showDeleteModal} onOpenChange={setShowDeleteModal}>
+        <DialogContent
+          className={
+            organizationType === "brand"
+              ? "max-w-md rounded-none border-2 border-gray-900 shadow-[8px_8px_0px_rgba(0,0,0,0.1)]"
+              : "max-w-md rounded-2xl"
+          }
+        >
+          <DialogHeader>
+            <DialogTitle
+              className={
+                organizationType === "brand"
+                  ? "text-xl font-black text-gray-900 uppercase tracking-tighter"
+                  : "text-xl font-bold text-gray-900"
+              }
+            >
+              Remove Team Member
+            </DialogTitle>
+            <DialogDescription
+              className={
+                organizationType === "brand"
+                  ? "text-xs text-gray-500 font-bold uppercase tracking-widest"
+                  : "text-sm text-gray-500 font-medium"
+              }
+            >
+              Are you sure you want to remove {selectedMember?.email || "this member"} from the team?
+            </DialogDescription>
+          </DialogHeader>
+          <div
+            className={
+              organizationType === "brand"
+                ? "p-4 bg-red-50 border-2 border-red-200 rounded-none"
+                : "p-4 bg-red-50 border border-red-100 rounded-xl"
+            }
+          >
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
+              <p
+                className={
+                  organizationType === "brand"
+                    ? "text-xs text-red-900 font-bold leading-relaxed"
+                    : "text-xs text-red-700 font-medium leading-relaxed"
+                }
+              >
+                This action cannot be undone. The member will lose access to all organization resources immediately.
+              </p>
+            </div>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="ghost"
+              onClick={() => setShowDeleteModal(false)}
+              className={
+                organizationType === "brand"
+                  ? "font-black uppercase tracking-widest rounded-none"
+                  : "font-bold"
+              }
+              disabled={deletingMember}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRemove}
+              disabled={deletingMember}
+              className={
+                organizationType === "brand"
+                  ? "rounded-none bg-red-600 hover:bg-red-700 text-white font-black uppercase tracking-widest px-8 flex items-center gap-2"
+                  : "bg-red-600 hover:bg-red-700 text-white font-bold px-6 rounded-xl flex items-center gap-2"
+              }
+            >
+              {deletingMember ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Trash2 className="w-4 h-4" />
+              )}
+              {deletingMember ? "Removing..." : "Remove Member"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/likelee-ui/src/pages/AgencyInviteLanding.tsx
+++ b/likelee-ui/src/pages/AgencyInviteLanding.tsx
@@ -243,15 +243,14 @@ export default function AgencyInviteLanding() {
     }
   };
 
-  const declineInvite = async () => {
-    if (!effectiveToken) return;
+  const startDeclineFlow = async () => {
+    if (!effectiveToken || !isPending) return;
 
     setActionLoading(true);
     setActionError(null);
 
     try {
       await declineAgencyTalentInviteByToken(effectiveToken);
-      await supabase?.auth.signOut();
       toast({
         title: "Invitation declined",
         description: "You declined the invitation.",
@@ -392,7 +391,7 @@ export default function AgencyInviteLanding() {
                 variant="outline"
                 className="h-11 w-full"
                 disabled={!isPending || actionLoading}
-                onClick={declineInvite}
+                onClick={startDeclineFlow}
               >
                 Decline
               </Button>
@@ -418,8 +417,8 @@ export default function AgencyInviteLanding() {
 
               <div className="text-xs text-gray-500">
                 {requiresPasswordSetup
-                  ? "Create your password first, then we’ll email a 6-digit code and keep you on this page while we verify it."
-                  : "We’ll email a 6-digit sign-in code and keep you on this page while we verify it."}
+                  ? "Create your password first, then we'll email a 6-digit code and keep you on this page while we verify it."
+                  : "We'll email a 6-digit sign-in code and keep you on this page while we verify it."}
               </div>
 
               {authenticated ? (
@@ -438,7 +437,7 @@ export default function AgencyInviteLanding() {
                       !hasInviteRole ||
                       !emailMatchesInvite
                     }
-                    onClick={declineInvite}
+                    onClick={startDeclineFlow}
                   >
                     Decline
                   </Button>

--- a/likelee-ui/src/pages/TeamInviteLanding.tsx
+++ b/likelee-ui/src/pages/TeamInviteLanding.tsx
@@ -228,13 +228,12 @@ export default function TeamInviteLanding() {
     }
   };
 
-  const declineInvite = async () => {
-    if (!effectiveToken) return;
+  const startDeclineFlow = async () => {
+    if (!invite || !effectiveToken || !isPending) return;
     setActionLoading(true);
     setActionError(null);
     try {
       await declineTeamInviteByToken(effectiveToken);
-      await supabase?.auth.signOut();
       toast({
         title: "Invitation declined",
         description: "You declined the team invitation.",
@@ -359,7 +358,7 @@ export default function TeamInviteLanding() {
             variant="outline"
             className="h-11 w-full"
             disabled={!isPending || actionLoading}
-            onClick={declineInvite}
+            onClick={startDeclineFlow}
           >
             Decline
           </Button>

--- a/supabase/migrations/2026-04-17_organization_invites_add_declined_status.sql
+++ b/supabase/migrations/2026-04-17_organization_invites_add_declined_status.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.organization_invites
+DROP CONSTRAINT organization_invites_status_check;
+
+ALTER TABLE public.organization_invites
+ADD CONSTRAINT organization_invites_status_check
+CHECK (status IN ('pending', 'accepted', 'declined', 'expired', 'revoked'));


### PR DESCRIPTION
## Summary
Add ability for organization owners and admins to remove team members from their organization.

## Changes
- Add `RemoveTeamMembers` permission to Owner and Admin roles
- Add `DELETE /api/team/members/:user_id` endpoint with proper permission checks
- Add delete button and confirmation dialog in team management UI for both agencies and brands
- Send notification email to removed member
- Log removal action in audit trail

## Permission Rules
- Owners can remove any member except other owners
- Admins can remove any member except owners and other admins
- Project managers and reviewers cannot remove members