### PR TITLE
Fix agency-invited talent onboarding and creator visibility saves

### DIFF
--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -992,6 +992,8 @@ async fn ensure_creator_row_exists(state: &AppState, user: &AuthUser, creator_id
                 "id": creator_id,
                 "email": user.email,
                 "full_name": user.email.clone().unwrap_or_default(),
+                "public_profile_visible": true,
+                "visibility": "brands",
                 "updated_at": now_rfc3339(),
             })
             .to_string(),

--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -963,7 +963,11 @@ pub async fn get_magic_link_by_token(
     })))
 }
 
-async fn ensure_creator_row_exists(state: &AppState, user: &AuthUser, creator_id: &str) {
+async fn ensure_creator_row_exists(
+    state: &AppState,
+    user: &AuthUser,
+    creator_id: &str,
+) -> Result<(), (StatusCode, String)> {
     let resp = state
         .pg
         .from("creators")
@@ -972,19 +976,22 @@ async fn ensure_creator_row_exists(state: &AppState, user: &AuthUser, creator_id
         .limit(1)
         .execute()
         .await
-        .ok();
-    if let Some(resp) = resp {
-        if resp.status().is_success() {
-            if let Ok(txt) = resp.text().await {
-                let rows: serde_json::Value = serde_json::from_str(&txt).unwrap_or(json!([]));
-                if rows.as_array().map(|a| !a.is_empty()).unwrap_or(false) {
-                    return;
-                }
-            }
-        }
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let status = resp.status();
+    let txt = resp
+        .text()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !status.is_success() {
+        return Err(sanitize_db_error(status.as_u16(), txt));
     }
 
-    let _ = state
+    let rows: serde_json::Value = serde_json::from_str(&txt).unwrap_or(json!([]));
+    if rows.as_array().map(|a| !a.is_empty()).unwrap_or(false) {
+        return Ok(());
+    }
+
+    let resp = state
         .pg
         .from("creators")
         .insert(
@@ -1000,7 +1007,17 @@ async fn ensure_creator_row_exists(state: &AppState, user: &AuthUser, creator_id
             .to_string(),
         )
         .execute()
-        .await;
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if resp.status().is_success() {
+        return Ok(());
+    }
+    let status = resp.status();
+    let txt = resp.text().await.unwrap_or_default();
+    if txt.contains("\"23505\"") {
+        return Ok(());
+    }
+    Err(sanitize_db_error(status.as_u16(), txt))
 }
 
 pub async fn accept_by_token(
@@ -1045,9 +1062,9 @@ pub async fn accept_by_token(
         ));
     }
 
-    ensure_creator_row_exists(&state, &user, &creator_id).await;
+    ensure_creator_row_exists(&state, &user, &creator_id).await?;
 
-    let _ = state
+    let resp = state
         .pg
         .from("creators")
         .eq("id", &creator_id)
@@ -1061,7 +1078,13 @@ pub async fn accept_by_token(
             .to_string(),
         )
         .execute()
-        .await;
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        return Err(sanitize_db_error(status.as_u16(), txt));
+    }
 
     let mut existing_agency_user_id: Option<String> = None;
     let mut matched_agency_row: Option<Value> = None;

--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -992,8 +992,9 @@ async fn ensure_creator_row_exists(state: &AppState, user: &AuthUser, creator_id
                 "id": creator_id,
                 "email": user.email,
                 "full_name": user.email.clone().unwrap_or_default(),
-                "public_profile_visible": true,
-                "visibility": "brands",
+                "onboarding_step": "profile_details",
+                "public_profile_visible": false,
+                "visibility": "private",
                 "updated_at": now_rfc3339(),
             })
             .to_string(),
@@ -1045,6 +1046,22 @@ pub async fn accept_by_token(
     }
 
     ensure_creator_row_exists(&state, &user, &creator_id).await;
+
+    let _ = state
+        .pg
+        .from("creators")
+        .eq("id", &creator_id)
+        .update(
+            json!({
+                "onboarding_step": "profile_details",
+                "public_profile_visible": false,
+                "visibility": "private",
+                "updated_at": now_rfc3339(),
+            })
+            .to_string(),
+        )
+        .execute()
+        .await;
 
     let mut existing_agency_user_id: Option<String> = None;
     let mut matched_agency_row: Option<Value> = None;

--- a/likelee-server/src/creators.rs
+++ b/likelee-server/src/creators.rs
@@ -106,12 +106,24 @@ pub async fn upsert_profile(
                 "base_weekly_price_cents must be non-negative".to_string(),
             ));
         }
+        if v == 0 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "base_weekly_price_cents must be greater than 0 when provided".to_string(),
+            ));
+        }
     }
     if let Some(v) = monthly {
         if v < 0 {
             return Err((
                 StatusCode::BAD_REQUEST,
                 "base_monthly_price_cents must be non-negative".to_string(),
+            ));
+        }
+        if v == 0 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "base_monthly_price_cents must be greater than 0 when provided".to_string(),
             ));
         }
     }

--- a/likelee-server/src/creators.rs
+++ b/likelee-server/src/creators.rs
@@ -78,8 +78,9 @@ pub async fn upsert_profile(
     user: AuthUser,
     Json(mut body): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    // Force the ID and email from the authenticated user
-    body["id"] = serde_json::Value::String(user.id.clone());
+    // Always trust the authenticated email, but resolve the actual creator row id
+    // separately so talent-portal users linked through agency_users update the
+    // creator record instead of forcing their auth user id into the payload.
     if let Some(email) = user.email.as_ref() {
         body["email"] = serde_json::Value::String(email.clone());
     }
@@ -114,7 +115,24 @@ pub async fn upsert_profile(
             ));
         }
     }
-    match (weekly, monthly) {
+    let normalized_weekly = weekly.filter(|v| *v > 0);
+    let normalized_monthly = monthly.filter(|v| *v > 0);
+    if normalized_weekly.is_none() {
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("base_weekly_price_cents");
+        }
+    }
+    if normalized_monthly.is_none() {
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("base_monthly_price_cents");
+        }
+    }
+    if normalized_weekly.is_none() && normalized_monthly.is_none() {
+        if let Some(obj) = body.as_object_mut() {
+            obj.remove("pricing_updated_at");
+        }
+    }
+    match (normalized_weekly, normalized_monthly) {
         (Some(w), None) => {
             body["base_monthly_price_cents"] =
                 serde_json::Value::from(((w as f64) * 4.345).round() as i64);
@@ -135,7 +153,7 @@ pub async fn upsert_profile(
     }
     sync_public_profile_visibility(&mut body);
 
-    let (_, _, tier) = get_creator_entitlement_tier_for_user(&state, &user)
+    let (effective_creator_id, _, tier) = get_creator_entitlement_tier_for_user(&state, &user)
         .await
         .unwrap_or((user.id.clone(), PlanTier::Free, PlanTier::Free));
 
@@ -186,11 +204,11 @@ pub async fn upsert_profile(
     }
 
     let existing_row = {
-        let by_id = match state
+        let by_effective_id = match state
             .pg
             .from("creators")
             .select("id")
-            .eq("id", &user.id)
+            .eq("id", &effective_creator_id)
             .limit(1)
             .execute()
             .await
@@ -204,29 +222,17 @@ pub async fn upsert_profile(
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
                 rows.as_array().and_then(|a| a.first()).cloned()
             }
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("42703")
-                    || (msg.contains("relation") && msg.contains("does not exist"))
-                {
-                    warn!(%msg, "profiles table missing; cannot upsert");
-                    return Err((
-                        StatusCode::PRECONDITION_FAILED,
-                        "profiles table missing".into(),
-                    ));
-                }
-                return Err((StatusCode::INTERNAL_SERVER_ERROR, msg));
-            }
+            Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
         };
 
-        if by_id.is_some() {
-            by_id
+        if by_effective_id.is_some() {
+            by_effective_id
         } else {
-            match state
+            let by_id = match state
                 .pg
                 .from("creators")
                 .select("id")
-                .eq("email", &email)
+                .eq("id", &user.id)
                 .limit(1)
                 .execute()
                 .await
@@ -240,19 +246,57 @@ pub async fn upsert_profile(
                         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
                     rows.as_array().and_then(|a| a.first()).cloned()
                 }
-                Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("42703")
+                        || (msg.contains("relation") && msg.contains("does not exist"))
+                    {
+                        warn!(%msg, "profiles table missing; cannot upsert");
+                        return Err((
+                            StatusCode::PRECONDITION_FAILED,
+                            "profiles table missing".into(),
+                        ));
+                    }
+                    return Err((StatusCode::INTERNAL_SERVER_ERROR, msg));
+                }
+            };
+
+            if by_id.is_some() {
+                by_id
+            } else {
+                match state
+                    .pg
+                    .from("creators")
+                    .select("id")
+                    .eq("email", &email)
+                    .limit(1)
+                    .execute()
+                    .await
+                {
+                    Ok(resp) => {
+                        let text = resp
+                            .text()
+                            .await
+                            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                        let rows: serde_json::Value = serde_json::from_str(&text)
+                            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                        rows.as_array().and_then(|a| a.first()).cloned()
+                    }
+                    Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+                }
             }
         }
     };
 
-    let body_str =
-        serde_json::to_string(&body).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
     if let Some(existing) = existing_row {
         let target_id = existing
             .get("id")
             .and_then(|v| v.as_str())
-            .unwrap_or(&user.id)
+            .unwrap_or(&effective_creator_id)
             .to_string();
+        body["id"] = serde_json::Value::String(target_id.clone());
+        let body_str =
+            serde_json::to_string(&body).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
         let resp = state
             .pg
@@ -283,6 +327,7 @@ pub async fn upsert_profile(
         let v: serde_json::Value = serde_json::from_str(&text).unwrap_or(serde_json::json!([]));
         Ok(Json(v))
     } else {
+        body["id"] = serde_json::Value::String(effective_creator_id.clone());
         if body.get("created_at").is_none() {
             body["created_at"] = serde_json::Value::String(now);
         }

--- a/likelee-ui/src/auth/onboarding.ts
+++ b/likelee-ui/src/auth/onboarding.ts
@@ -111,11 +111,10 @@ export function isOnboardingIncomplete(profile?: Profile | null) {
     return true;
   }
 
-  // For creators/talent with no onboarding_step set, check if they have started onboarding
-  // by checking if they have a creator_type (which is set during signup)
+  // For creators/talent with no onboarding_step set, check if they have
+  // started onboarding by looking for creator_type (set during signup or
+  // hydrated from an agency invite).
   if ((profile.role === "creator" || profile.role === "talent") && !step) {
-    // If they have a creator_type, they've started onboarding, so treat as incomplete
-    // If no creator_type, they haven't started, so treat as complete (will redirect to signup options)
     return !!profile.creator_type;
   }
 

--- a/likelee-ui/src/components/marketplace/MarketplaceSection.tsx
+++ b/likelee-ui/src/components/marketplace/MarketplaceSection.tsx
@@ -1089,11 +1089,6 @@ export function MarketplaceSection({
                         ) : null}
                       </div>
                     )}
-                    {profile.talent_ownership === "agency_owned" && (
-                      <p className="text-[10px] text-indigo-600 font-semibold mt-2.5">
-                        external talent
-                      </p>
-                    )}
                   </div>
                 </Card>
               );

--- a/likelee-ui/src/pages/AgencyInviteLanding.tsx
+++ b/likelee-ui/src/pages/AgencyInviteLanding.tsx
@@ -25,7 +25,7 @@ import {
 export default function AgencyInviteLanding() {
   const { token } = useParams();
   const navigate = useNavigate();
-  const { authenticated, profile, supabase } = useAuth();
+  const { authenticated, profile, refreshProfile, supabase } = useAuth();
 
   const [loading, setLoading] = React.useState(true);
   const [actionLoading, setActionLoading] = React.useState(false);
@@ -100,14 +100,16 @@ export default function AgencyInviteLanding() {
 
     try {
       await acceptAgencyTalentInviteByToken(effectiveToken);
+      await refreshProfile();
       setOtpDialogOpen(false);
       setPassword("");
       setConfirmPassword("");
       toast({
         title: "Invitation accepted",
-        description: "Welcome! Redirecting you to the Talent Portal…",
+        description:
+          "Invitation accepted. Continue setting up your creator profile…",
       });
-      navigate("/talentportal", { replace: true });
+      window.location.replace("/ReserveProfile?mode=signup&step=2");
     } catch (e: any) {
       const message = e?.message || String(e);
       setActionError(message);
@@ -119,7 +121,7 @@ export default function AgencyInviteLanding() {
     } finally {
       setActionLoading(false);
     }
-  }, [effectiveToken, navigate]);
+  }, [effectiveToken, refreshProfile]);
 
   const handleInviteOtpVerify = async (code: string) => {
     const client = requireSupabase();

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -5636,10 +5636,17 @@ export default function CreatorDashboard() {
       const value = Number.parseFloat(text);
       return Number.isFinite(value) ? value : undefined;
     };
-    const nextRate = creator.price_per_month || 0;
+    const nextRate =
+      overrides?.price_per_month ?? creator.price_per_month ?? undefined;
     const prevRate = baseRateRef.current;
     const rateChanged =
-      typeof prevRate === "number" ? nextRate !== prevRate : nextRate > 0;
+      typeof nextRate === "number"
+        ? typeof prevRate === "number"
+          ? nextRate !== prevRate
+          : nextRate > 0
+        : false;
+    const hasPositiveMonthlyRate =
+      typeof nextRate === "number" && Number.isFinite(nextRate) && nextRate > 0;
 
     // Only send fields that exist in the profiles table
     // Apply overrides if provided (e.g. for immediate toggle updates)
@@ -5650,13 +5657,16 @@ export default function CreatorDashboard() {
       bio: creator.bio,
       city: creator.location?.split(",")[0]?.trim(),
       state: creator.location?.split(",")[1]?.trim(),
-      base_monthly_price_cents: Math.round(
-        (creator.price_per_month || 0) * 100,
-      ),
-      base_weekly_price_cents: Math.round(
-        ((creator.price_per_month || 0) / 4.345) * 100,
-      ),
-      pricing_updated_at: rateChanged ? new Date().toISOString() : undefined,
+      base_monthly_price_cents: hasPositiveMonthlyRate
+        ? Math.round(nextRate * 100)
+        : undefined,
+      base_weekly_price_cents: hasPositiveMonthlyRate
+        ? Math.round((nextRate / 4.345) * 100)
+        : undefined,
+      pricing_updated_at:
+        hasPositiveMonthlyRate && rateChanged
+          ? new Date().toISOString()
+          : undefined,
       birthdate:
         typeof creator.birthday === "string" && creator.birthday.trim().length
           ? creator.birthday.trim()

--- a/likelee-ui/src/pages/ReserveProfile.tsx
+++ b/likelee-ui/src/pages/ReserveProfile.tsx
@@ -450,6 +450,8 @@ export default function ReserveProfile() {
     }
 
     setProfileId(profile.id || user?.id || null);
+    const profileIsIncomplete = isOnboardingIncomplete(profile);
+
     setFormData((prev) => ({
       ...prev,
       creator_type: profile.creator_type || prev.creator_type,
@@ -464,7 +466,11 @@ export default function ReserveProfile() {
         ? profile.ethnicity
         : prev.ethnicity,
       vibes: Array.isArray(profile.vibes) ? profile.vibes : prev.vibes,
-      visibility: profile.visibility || prev.visibility,
+      // Invite/onboarding flows do not expose visibility selection yet, so keep
+      // in-progress profiles private until the creator explicitly enables it later.
+      visibility: profileIsIncomplete
+        ? "private"
+        : profile.visibility || prev.visibility,
       base_monthly_price_usd:
         typeof profile.base_monthly_price_cents === "number" &&
         profile.base_monthly_price_cents > 0


### PR DESCRIPTION
## Summary
This PR fixes the agency-invited talent onboarding handoff and resolves creator profile save failures that were blocking marketplace visibility updates.

## What changed
- fixed the agency talent invite flow so invited talents continue onboarding at creator signup step 2 after email verification
- kept invited talent profiles private during onboarding instead of pre-marking them as marketplace-visible
- corrected creator profile upserts to resolve and update the effective creator row for invite-linked users
- prevented visibility-only saves from sending zero-value pricing fields that violate creator pricing constraints
- removed the `external talent` ownership label from marketplace cards

## Bugs fixed
- invited talents no longer get stuck in an incorrect post-verification handoff
- invited talents now complete creator onboarding before reaching their dashboard
- creator profile saves for invite-linked users now target the correct creator record
- marketplace visibility toggles no longer fail because of unrelated pricing constraint errors
- marketplace cards no longer expose internal ownership wording
