### PR TITLE
Fix brand contract signing handoff and request sync

### DIFF
--- a/likelee-server/src/brand_license_requests.rs
+++ b/likelee-server/src/brand_license_requests.rs
@@ -1,6 +1,7 @@
 use axum::{extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
+use std::collections::HashMap;
 use tracing::error;
 
 use crate::{
@@ -583,13 +584,130 @@ pub async fn list_for_brand(
         return Err(sanitize_db_error(status.as_u16(), text));
     }
 
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&text).map_err(|e| {
+    let mut rows: Vec<serde_json::Value> = serde_json::from_str(&text).map_err(|e| {
         error!(error = %e, "brand_license_requests JSON parse error");
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("JSON parse error: {}", e),
         )
     })?;
+
+    let submission_ids: Vec<&str> = rows
+        .iter()
+        .filter_map(|row| row.get("submission_id").and_then(|v| v.as_str()))
+        .filter(|id| !id.trim().is_empty())
+        .collect();
+    let brand_request_ids: Vec<&str> = rows
+        .iter()
+        .filter_map(|row| row.get("id").and_then(|v| v.as_str()))
+        .filter(|id| !id.trim().is_empty())
+        .collect();
+
+    if !submission_ids.is_empty() || !brand_request_ids.is_empty() {
+        let mut supplements_by_submission_id: HashMap<String, Vec<Value>> = HashMap::new();
+        let mut supplements_by_brand_request_id: HashMap<String, Vec<Value>> = HashMap::new();
+
+        let mut query = state
+            .pg
+            .from("license_submissions")
+            .select("id,brand_request_id,docuseal_slug,client_submitter_slug,status,created_at");
+
+        if !submission_ids.is_empty() {
+            query = query.in_("id", submission_ids.clone());
+        }
+        if !brand_request_ids.is_empty() {
+            query = query.in_("brand_request_id", brand_request_ids.clone());
+        }
+
+        if let Ok(extra_resp) = query.order("created_at.desc").limit(500).execute().await {
+            if extra_resp.status().is_success() {
+                if let Ok(extra_text) = extra_resp.text().await {
+                    if let Ok(extra_rows) = serde_json::from_str::<Vec<Value>>(&extra_text) {
+                        for sub in extra_rows {
+                            if let Some(id) = sub.get("id").and_then(|v| v.as_str()) {
+                                supplements_by_submission_id
+                                    .entry(id.to_string())
+                                    .or_default()
+                                    .push(sub.clone());
+                            }
+                            if let Some(brand_request_id) =
+                                sub.get("brand_request_id").and_then(|v| v.as_str())
+                            {
+                                supplements_by_brand_request_id
+                                    .entry(brand_request_id.to_string())
+                                    .or_default()
+                                    .push(sub.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for row in &mut rows {
+            let mut merged_submissions: Vec<Value> = Vec::new();
+            let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            let push_unique = |target: &mut Vec<Value>,
+                               seen: &mut std::collections::HashSet<String>,
+                               sub: Value| {
+                let id = sub
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+                if id.is_empty() || seen.insert(id) {
+                    target.push(sub);
+                }
+            };
+
+            if let Some(existing) = row.get("license_submission").cloned() {
+                if let Some(arr) = existing.as_array() {
+                    for sub in arr.iter().cloned() {
+                        push_unique(&mut merged_submissions, &mut seen_ids, sub);
+                    }
+                } else if existing.is_object() {
+                    push_unique(&mut merged_submissions, &mut seen_ids, existing);
+                }
+            }
+
+            if let Some(existing) = row.get("license_submissions").cloned() {
+                if let Some(arr) = existing.as_array() {
+                    for sub in arr.iter().cloned() {
+                        push_unique(&mut merged_submissions, &mut seen_ids, sub);
+                    }
+                } else if existing.is_object() {
+                    push_unique(&mut merged_submissions, &mut seen_ids, existing);
+                }
+            }
+
+            if let Some(submission_id) = row.get("submission_id").and_then(|v| v.as_str()) {
+                if let Some(extra) = supplements_by_submission_id.get(submission_id) {
+                    for sub in extra.iter().cloned() {
+                        push_unique(&mut merged_submissions, &mut seen_ids, sub);
+                    }
+                }
+            }
+
+            if let Some(brand_request_id) = row.get("id").and_then(|v| v.as_str()) {
+                if let Some(extra) = supplements_by_brand_request_id.get(brand_request_id) {
+                    for sub in extra.iter().cloned() {
+                        push_unique(&mut merged_submissions, &mut seen_ids, sub);
+                    }
+                }
+            }
+
+            if let Some(obj) = row.as_object_mut() {
+                if let Some(first) = merged_submissions.first().cloned() {
+                    obj.insert("license_submission".to_string(), first);
+                }
+                obj.insert(
+                    "license_submissions".to_string(),
+                    Value::Array(merged_submissions),
+                );
+            }
+        }
+    }
 
     Ok(Json(BrandLicenseRequestListResponse { requests: rows }))
 }

--- a/likelee-ui/src/components/brand/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/brand/LicensingRequestsView.tsx
@@ -192,6 +192,21 @@ export const LicensingRequestsView: React.FC<LicensingRequestsViewProps> = ({
               ? submissions
                   .filter((sub) => sub?.status !== "draft") // Exclude drafts
                   .sort((a, b) => {
+                    const linkedSubmissionId = String(
+                      req?.submission_id || "",
+                    ).trim();
+                    const aId = String(a?.id || "").trim();
+                    const bId = String(b?.id || "").trim();
+                    const aMatchesLinked = linkedSubmissionId
+                      ? aId === linkedSubmissionId
+                      : false;
+                    const bMatchesLinked = linkedSubmissionId
+                      ? bId === linkedSubmissionId
+                      : false;
+
+                    if (aMatchesLinked && !bMatchesLinked) return -1;
+                    if (!aMatchesLinked && bMatchesLinked) return 1;
+
                     // Prioritize submissions with signing URLs
                     const aHasUrl = !!(
                       a?.client_submitter_slug || a?.docuseal_slug

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -25,6 +25,7 @@ import {
   getLicenseSubmissions,
   createLicenseSubmissionDraft,
   finalizeLicenseSubmission,
+  getLicenseSubmissionDetails,
   syncLicenseSubmissionStatus,
 } from "@/api/licenseSubmissions";
 import { getAgencyTalents, getAgencyBrandConnections } from "@/api/functions";
@@ -207,15 +208,27 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
   });
 
   const formData = watch();
+  const brandRequestId = brandRequestContext?.licensing_request_id || "";
+  const brandRequestBrandId = brandRequestContext?.brand_id || "";
+  const brandRequestBrandName = brandRequestContext?.brand_name || "";
+  const brandRequestBrandEmail = brandRequestContext?.brand_email || "";
+  const brandRequestTalentId = brandRequestContext?.talent_id || "";
+  const brandRequestTalentName = brandRequestContext?.talent_name || "";
+  const builderExternalId = useMemo(
+    () =>
+      currentTemplate?.id
+        ? `temp-${currentTemplate.id}-${Date.now()}`
+        : undefined,
+    [currentTemplate?.id, isOpen],
+  );
 
   // Auto-enable dropdown and pre-select brand when coming from brand request
   useEffect(() => {
-    const prefilledBrandId =
-      brandRequestContext?.brand_id || initialValues?.brand_id;
+    const prefilledBrandId = brandRequestBrandId || initialValues?.brand_id;
     const prefilledBrandName =
-      brandRequestContext?.brand_name || initialValues?.client_name;
+      brandRequestBrandName || initialValues?.client_name;
     const prefilledBrandEmail =
-      brandRequestContext?.brand_email || initialValues?.client_email;
+      brandRequestBrandEmail || initialValues?.client_email;
 
     if (isOpen && prefilledBrandId && brandOptions.length > 0) {
       setAllowBrandChange(true); // Turn on the toggle
@@ -231,34 +244,38 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
         if (prefilledBrandEmail) setValue("client_email", prefilledBrandEmail);
       }
     }
-  }, [isOpen, brandRequestContext, initialValues, brandOptions, setValue]);
+  }, [
+    isOpen,
+    brandRequestBrandId,
+    brandRequestBrandName,
+    brandRequestBrandEmail,
+    initialValues?.brand_id,
+    initialValues?.client_name,
+    initialValues?.client_email,
+    brandOptions,
+    setValue,
+  ]);
 
   useEffect(() => {
     if (isOpen) {
       setStep(1);
+      setDraftId(null);
       setRequiresAgencySignature(
-        brandRequestContext?.licensing_request_id
-          ? false
-          : Boolean(initialValues?.requires_agency_signature),
+        Boolean(initialValues?.requires_agency_signature),
       );
       setAgencySignOpen(false);
       setAgencySignUrl(null);
       setCurrentSubmissionId(null);
-      setAgencySignOpen(false);
-      setAgencySignUrl(null);
-      setCurrentSubmissionId(null);
       setSelectedTalentIds(
-        brandRequestContext?.talent_id
-          ? [brandRequestContext.talent_id]
+        brandRequestTalentId
+          ? [brandRequestTalentId]
           : initialValues?.talent_id
             ? [initialValues.talent_id]
             : [],
       );
       reset({
-        client_name:
-          brandRequestContext?.brand_name || initialValues?.client_name || "",
-        talent_name:
-          brandRequestContext?.talent_name || initialValues?.talent_name || "",
+        client_name: brandRequestBrandName || initialValues?.client_name || "",
+        talent_name: brandRequestTalentName || initialValues?.talent_name || "",
         start_date:
           initialValues?.start_date ||
           template.start_date ||
@@ -280,7 +297,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
           initialValues?.custom_terms || template.custom_terms || "",
         contract_body: template.contract_body || "",
         client_email:
-          brandRequestContext?.brand_email || initialValues?.client_email || "", // Reset for new field
+          brandRequestBrandEmail || initialValues?.client_email || "",
       });
 
       // Fetch agency talents
@@ -292,7 +309,28 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
           console.error(`Failed to fetch ${entityPluralLower}:`, err);
         });
     }
-  }, [isOpen, template, reset, brandRequestContext, initialValues]);
+  }, [
+    isOpen,
+    reset,
+    template,
+    initialValues?.client_name,
+    initialValues?.talent_name,
+    initialValues?.start_date,
+    initialValues?.duration_days,
+    initialValues?.territory,
+    initialValues?.exclusivity,
+    initialValues?.modifications_allowed,
+    initialValues?.license_fee,
+    initialValues?.custom_terms,
+    initialValues?.client_email,
+    initialValues?.talent_id,
+    initialValues?.requires_agency_signature,
+    brandRequestId,
+    brandRequestBrandName,
+    brandRequestBrandEmail,
+    brandRequestTalentId,
+    brandRequestTalentName,
+  ]);
 
   const replacePlaceholders = (text: string, data: any) => {
     return text.replace(/{(\w+)}/g, (match, key) => {
@@ -455,7 +493,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
       }
 
       // Step 2: Finalize the submission (this creates the licensing_request)
-      const finalizeResult = await finalizeLicenseSubmission(submissionId, {
+      let finalizeResult = await finalizeLicenseSubmission(submissionId, {
         docuseal_template_id: currentTemplate.docuseal_template_id,
         client_name: currentData.client_name,
         client_email: currentData.client_email,
@@ -467,15 +505,37 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
         licensing_request_id: brandRequestContext?.licensing_request_id,
       });
 
-      const embedUrl =
+      const finalizedSubmissionId = (finalizeResult as any)?.id || submissionId;
+      let embedUrl =
         (finalizeResult as any)?.agency_embed_src ||
         ((finalizeResult as any)?.agency_submitter_slug
           ? `https://docuseal.co/s/${(finalizeResult as any).agency_submitter_slug}`
-          : (finalizeResult as any)?.docuseal_slug
-            ? `https://docuseal.co/s/${(finalizeResult as any).docuseal_slug}`
+          : null);
+
+      // Finalize can succeed before the agency signer URL is present on the first response.
+      // Refresh once so we don't bounce the user out of the signing flow.
+      if (requiresAgencySignature && !embedUrl && finalizedSubmissionId) {
+        finalizeResult = await getLicenseSubmissionDetails(
+          finalizedSubmissionId,
+        );
+        embedUrl =
+          (finalizeResult as any)?.agency_embed_src ||
+          ((finalizeResult as any)?.agency_submitter_slug
+            ? `https://docuseal.co/s/${(finalizeResult as any).agency_submitter_slug}`
             : null);
-      if (requiresAgencySignature && embedUrl) {
-        setCurrentSubmissionId((finalizeResult as any)?.id || submissionId);
+      }
+
+      if (requiresAgencySignature) {
+        if (!embedUrl) {
+          throw new Error(
+            "The agency signature link is not ready yet. Please reopen the submission and try again.",
+          );
+        }
+
+        setCurrentSubmissionId(finalizedSubmissionId);
+        // Close the builder before opening the signing modal so we don't
+        // bounce back through the wizard state.
+        setStep(2);
         setAgencySignUrl(embedUrl);
         setAgencySignOpen(true);
         toast({
@@ -1089,7 +1149,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
           onClose={() => setStep(2)}
           templateName={currentTemplate.template_name}
           docusealTemplateId={currentTemplate.docuseal_template_id}
-          externalId={`temp-${currentTemplate.id}-${Date.now()}`}
+          externalId={builderExternalId}
           contractBody={formData.contract_body} // Pass the deal-specific body!
           builderRoles={
             requiresAgencySignature

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -1351,7 +1351,9 @@ export default function BrandDashboard() {
     let mounted = true;
     const loadBrandLicenses = async () => {
       try {
-        setLoadingBrandLicensingRequests(true);
+        if (mounted && brandLicensingRequests.length === 0) {
+          setLoadingBrandLicensingRequests(true);
+        }
         const resp = await getBrandLicensingRequests();
         console.log(
           "getBrandLicensingRequests raw response:",
@@ -1369,10 +1371,21 @@ export default function BrandDashboard() {
       }
     };
     loadBrandLicenses();
+    const refreshTimer = window.setInterval(() => {
+      if (!mounted) return;
+      loadBrandLicenses();
+    }, 8000);
+    const handleFocus = () => {
+      if (!mounted) return;
+      loadBrandLicenses();
+    };
+    window.addEventListener("focus", handleFocus);
     return () => {
       mounted = false;
+      window.clearInterval(refreshTimer);
+      window.removeEventListener("focus", handleFocus);
     };
-  }, [activeSection]);
+  }, [activeSection, brandLicensingRequests.length]);
 
   useEffect(() => {
     if (activeSection !== "billing") return;
@@ -3544,12 +3557,65 @@ export default function BrandDashboard() {
             ? `$${Number(licenseFeeValue).toLocaleString()}`
             : "\u2014";
 
-          // Submissions might be an array or object
+          // Submissions can come from either join path depending on whether the
+          // brand request was linked by submission_id directly or via brand_request_id.
           let submissions = req?.license_submissions;
           if (submissions && !Array.isArray(submissions)) {
             submissions = [submissions];
           }
-          const submission = Array.isArray(submissions) ? submissions[0] : null;
+          const directSubmission = req?.license_submission;
+          if (directSubmission) {
+            const directSubmissionList = Array.isArray(directSubmission)
+              ? directSubmission
+              : [directSubmission];
+            const existingIds = new Set(
+              (submissions || [])
+                .map((sub: any) => String(sub?.id || "").trim())
+                .filter(Boolean),
+            );
+            submissions = [
+              ...directSubmissionList.filter((sub: any) => {
+                const id = String(sub?.id || "").trim();
+                return id ? !existingIds.has(id) : true;
+              }),
+              ...(submissions || []),
+            ];
+          }
+
+          const submission = Array.isArray(submissions)
+            ? submissions
+                .filter((sub: any) => sub?.status !== "draft")
+                .sort((a: any, b: any) => {
+                  const linkedSubmissionId = String(
+                    req?.submission_id || "",
+                  ).trim();
+                  const aId = String(a?.id || "").trim();
+                  const bId = String(b?.id || "").trim();
+                  const aMatchesLinked = linkedSubmissionId
+                    ? aId === linkedSubmissionId
+                    : false;
+                  const bMatchesLinked = linkedSubmissionId
+                    ? bId === linkedSubmissionId
+                    : false;
+
+                  if (aMatchesLinked && !bMatchesLinked) return -1;
+                  if (!aMatchesLinked && bMatchesLinked) return 1;
+
+                  const aHasUrl = !!(
+                    a?.client_submitter_slug || a?.docuseal_slug
+                  );
+                  const bHasUrl = !!(
+                    b?.client_submitter_slug || b?.docuseal_slug
+                  );
+
+                  if (aHasUrl && !bHasUrl) return -1;
+                  if (!aHasUrl && bHasUrl) return 1;
+
+                  const aDate = new Date(a?.created_at || 0);
+                  const bDate = new Date(b?.created_at || 0);
+                  return bDate.getTime() - aDate.getTime();
+                })[0]
+            : null;
 
           const slug =
             submission?.client_submitter_slug || submission?.docuseal_slug;


### PR DESCRIPTION
## Summary
This PR fixes the brand-request contract flow so agency-first signing behaves correctly and the brand dashboard updates to the correct signing state.

## What changed
- fixed the agency-first contract wizard so the DocuSeal handoff stays stable during finalize/send
- prevented the submission wizard from resetting step state and signature-toggle state during re-renders
- improved the agency-sign-first flow so the agency signing modal opens reliably before the contract is released to the brand
- updated brand licensing request handling to merge linked submissions from both `submission_id` and `brand_request_id`
- aligned brand dashboard signing-state logic with the merged submission sources
- added refresh behavior for brand licensing requests while the section is open

## User-facing fixes
- `Finalize & Send` no longer bounces the wizard back or closes incorrectly in the agency-first flow
- agency-first submissions stay in the correct progression: `agency_pending` -> `client_pending`
- once the agency signs, the brand-side action changes from `Awaiting contract from agency` to `Sign Contract`
