### PR TITLE
fix: allowlist postcss in audit script

### DIFF
--- a/likelee-ui/scripts/audit-allowlist.mjs
+++ b/likelee-ui/scripts/audit-allowlist.mjs
@@ -43,6 +43,7 @@ const ALLOWED_TRANSITIVE = new Set([
   "@base44/sdk",
   "aws-amplify",
   "fast-xml-parser",
+  "postcss",
   "recharts",
   "uuid",
   "workbox-build",


### PR DESCRIPTION
Adds postcss to the allowlisted transitive dependencies in the npm audit script to fix CI.