### PR TITLE
Feat/campaign wizard ux and offer card fixes

### DIFF
--- a/likelee-ui/src/components/campaign-offers/CampaignBriefStep.tsx
+++ b/likelee-ui/src/components/campaign-offers/CampaignBriefStep.tsx
@@ -20,6 +20,7 @@ type Props = {
   uploading?: boolean;
   fieldErrors?: Record<string, string>;
   onFieldChange?: (field: string) => void;
+  hideBack?: boolean;
 };
 
 export default function CampaignBriefStep({
@@ -32,6 +33,7 @@ export default function CampaignBriefStep({
   uploading = false,
   fieldErrors = {},
   onFieldChange,
+  hideBack = false,
 }: Props) {
   const referenceInputRef = useRef<HTMLInputElement | null>(null);
   const assetInputRef = useRef<HTMLInputElement | null>(null);
@@ -696,14 +698,18 @@ export default function CampaignBriefStep({
       </div>
 
       <div className="flex justify-between gap-3">
-        <Button
-          variant="outline"
-          onClick={onBack}
-          className="border-2 border-gray-300 rounded-none bg-white text-black hover:bg-gray-50"
-        >
-          <ArrowLeft className="w-4 h-4 mr-2" />
-          Back
-        </Button>
+        {!hideBack ? (
+          <Button
+            variant="outline"
+            onClick={onBack}
+            className="border-2 border-gray-300 rounded-none bg-white text-black hover:bg-gray-50"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back
+          </Button>
+        ) : (
+          <div />
+        )}
         <Button
           onClick={onNext}
           disabled={uploading}

--- a/likelee-ui/src/components/campaign-offers/CampaignBriefStep.tsx
+++ b/likelee-ui/src/components/campaign-offers/CampaignBriefStep.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
 
 type CampaignBrief = {
   [key: string]: any;
@@ -18,6 +18,8 @@ type Props = {
   onReferenceImagesUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBrandAssetsUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
   uploading?: boolean;
+  fieldErrors?: Record<string, string>;
+  onFieldChange?: (field: string) => void;
 };
 
 export default function CampaignBriefStep({
@@ -28,9 +30,24 @@ export default function CampaignBriefStep({
   onReferenceImagesUpload,
   onBrandAssetsUpload,
   uploading = false,
+  fieldErrors = {},
+  onFieldChange,
 }: Props) {
   const referenceInputRef = useRef<HTMLInputElement | null>(null);
   const assetInputRef = useRef<HTMLInputElement | null>(null);
+
+  const fieldClass = (field: string) =>
+    fieldErrors[field]
+      ? "border-2 border-amber-400 bg-amber-50 rounded-none"
+      : "border-2 border-gray-300 rounded-none";
+
+  const FieldError = ({ field }: { field: string }) =>
+    fieldErrors[field] ? (
+      <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+        <AlertCircle className="w-3 h-3 shrink-0" />
+        {fieldErrors[field]}
+      </p>
+    ) : null;
 
   return (
     <div className="space-y-6">
@@ -210,19 +227,22 @@ export default function CampaignBriefStep({
             Total expected deliverables <span className="text-red-600">*</span>
           </p>
           <Input
+            id="step2-total_expected_deliverables"
             type="number"
             min={1}
             step={1}
             value={campaignBrief.total_expected_deliverables || ""}
-            onChange={(e) =>
+            onChange={(e) => {
               setCampaignBrief((prev) => ({
                 ...prev,
                 total_expected_deliverables: e.target.value,
-              }))
-            }
+              }));
+              onFieldChange?.("total_expected_deliverables");
+            }}
             placeholder="e.g. 6"
-            className="border-2 border-gray-300 rounded-none"
+            className={fieldClass("total_expected_deliverables")}
           />
+          <FieldError field="total_expected_deliverables" />
           <p className="text-xs text-gray-500">
             Required for tracking progress even when required-deliverables text
             is not detailed.
@@ -447,38 +467,46 @@ export default function CampaignBriefStep({
           </div>
           <div className="space-y-2">
             <p className="text-sm font-medium text-gray-700">
-              Campaign Duration
+              Campaign Duration <span className="text-red-600">*</span>
             </p>
             <Input
+              id="step2-overview_campaign_duration"
               type="number"
               min={1}
               step={1}
               inputMode="numeric"
               value={campaignBrief.overview_campaign_duration}
-              onChange={(e) =>
+              onChange={(e) => {
                 setCampaignBrief((prev) => ({
                   ...prev,
                   overview_campaign_duration: e.target.value,
-                }))
-              }
+                }));
+                onFieldChange?.("overview_campaign_duration");
+              }}
               placeholder="90"
-              className="border-2 border-gray-300 rounded-none"
+              className={fieldClass("overview_campaign_duration")}
             />
+            <FieldError field="overview_campaign_duration" />
           </div>
           <div className="space-y-2">
-            <p className="text-sm font-medium text-gray-700">Launch Date</p>
+            <p className="text-sm font-medium text-gray-700">
+              Launch Date <span className="text-red-600">*</span>
+            </p>
             <Input
+              id="step2-overview_launch_date"
               type="date"
               value={campaignBrief.overview_launch_date}
-              onChange={(e) =>
+              onChange={(e) => {
                 setCampaignBrief((prev) => ({
                   ...prev,
                   overview_launch_date: e.target.value,
-                }))
-              }
+                }));
+                onFieldChange?.("overview_launch_date");
+              }}
               placeholder="2025-02-15"
-              className="border-2 border-gray-300 rounded-none"
+              className={fieldClass("overview_launch_date")}
             />
+            <FieldError field="overview_launch_date" />
           </div>
         </div>
 
@@ -488,9 +516,10 @@ export default function CampaignBriefStep({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-2">
             <p className="text-sm font-medium text-gray-700">
-              Collaborator Payout (Net)
+              Collaborator Payout (Net) <span className="text-red-600">*</span>
             </p>
             <Input
+              id="step2-budget_creator_payment"
               type="number"
               min={1}
               step={1}
@@ -504,24 +533,29 @@ export default function CampaignBriefStep({
                   budget_creator_payment: e.target.value,
                   budget_total: total,
                 }));
+                onFieldChange?.("budget_creator_payment");
               }}
               placeholder="5000"
-              className="border-2 border-gray-300 rounded-none"
+              className={fieldClass("budget_creator_payment")}
             />
+            <FieldError field="budget_creator_payment" />
             <p className="text-[10px] text-gray-500">
               The exact amount the creator or agency will receive.
             </p>
           </div>
           <div className="space-y-2">
             <p className="text-sm font-medium text-gray-700">
-              Offer Amount (Gross + 2% Fee)
+              Offer Amount (Gross + 2% Fee){" "}
+              <span className="text-red-600">*</span>
             </p>
             <Input
+              id="step2-budget_total"
               type="number"
               readOnly
               value={campaignBrief.budget_total}
-              className="border-2 border-gray-300 rounded-none bg-gray-50 font-bold"
+              className={`${fieldClass("budget_total")} bg-gray-50 font-bold`}
             />
+            <FieldError field="budget_total" />
             <p className="text-[10px] text-blue-600 font-medium">
               Includes 2% Likelee platform fee ($
               {(
@@ -533,20 +567,23 @@ export default function CampaignBriefStep({
           </div>
           <div className="space-y-2">
             <p className="text-sm font-medium text-gray-700">
-              Submission Deadline
+              Submission Deadline <span className="text-red-600">*</span>
             </p>
             <Input
+              id="step2-budget_submission_deadline"
               type="date"
               value={campaignBrief.budget_submission_deadline}
-              onChange={(e) =>
+              onChange={(e) => {
                 setCampaignBrief((prev) => ({
                   ...prev,
                   budget_submission_deadline: e.target.value,
-                }))
-              }
+                }));
+                onFieldChange?.("budget_submission_deadline");
+              }}
               placeholder="12/20/2025"
-              className="border-2 border-gray-300 rounded-none"
+              className={fieldClass("budget_submission_deadline")}
             />
+            <FieldError field="budget_submission_deadline" />
           </div>
         </div>
         <div className="space-y-2">

--- a/likelee-ui/src/index.css
+++ b/likelee-ui/src/index.css
@@ -273,3 +273,16 @@ button:focus-visible {
     scrollbar-width: none; /* Firefox */
   }
 }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    15% { transform: translateX(-6px); }
+    30% { transform: translateX(6px); }
+    45% { transform: translateX(-4px); }
+    60% { transform: translateX(4px); }
+    75% { transform: translateX(-2px); }
+    90% { transform: translateX(2px); }
+  }
+  .animate-shake {
+    animation: shake 0.5s ease-in-out;
+  }

--- a/likelee-ui/src/index.css
+++ b/likelee-ui/src/index.css
@@ -274,15 +274,30 @@ button:focus-visible {
   }
 }
 
-  @keyframes shake {
-    0%, 100% { transform: translateX(0); }
-    15% { transform: translateX(-6px); }
-    30% { transform: translateX(6px); }
-    45% { transform: translateX(-4px); }
-    60% { transform: translateX(4px); }
-    75% { transform: translateX(-2px); }
-    90% { transform: translateX(2px); }
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
   }
-  .animate-shake {
-    animation: shake 0.5s ease-in-out;
+  15% {
+    transform: translateX(-6px);
   }
+  30% {
+    transform: translateX(6px);
+  }
+  45% {
+    transform: translateX(-4px);
+  }
+  60% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
+  90% {
+    transform: translateX(2px);
+  }
+}
+.animate-shake {
+  animation: shake 0.5s ease-in-out;
+}

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -351,7 +351,64 @@ export default function BrandCampaignDashboard({
 
       setNewCampaignStep(safeStep);
     } else {
+      // Full reset for a brand-new campaign — clear any state left from a previous session
+      setBrandCampaignId("");
+      setIsExistingCampaign(false);
+      setStep1FieldErrors({});
+      setStep2FieldErrors({});
+      setWizardErrorBanner(null);
       setNewCampaignStep(1);
+      setCampaignForm({
+        name: "",
+        objective: "",
+        brief_file: null,
+        category: "",
+        description: "",
+        usage_scope: "",
+        duration_days: "30",
+        territory: "Global",
+        exclusivity: "Non-exclusive",
+        budget_range: "",
+        start_date: "",
+        custom_terms: "",
+        collaborator_type: "",
+        collaborators: [],
+      });
+      setCampaignBrief({
+        voice: "",
+        tone: "",
+        personality: "",
+        key_messages: "",
+        script_opening: "",
+        script_middle: "",
+        script_closing: "",
+        dos: "",
+        donts: "",
+        required_deliverables: "",
+        total_expected_deliverables: "",
+        deliverables_reels: "",
+        deliverables_hero_image: "",
+        visual_color_palette: "",
+        visual_setting: "",
+        visual_framing: "",
+        visual_editing: "",
+        reference_images: [],
+        brand_assets: [],
+        overview_objective: "",
+        overview_target_audience: "",
+        overview_campaign_duration: "",
+        overview_launch_date: "",
+        budget_total: "",
+        budget_creator_payment: "",
+        budget_submission_deadline: "",
+        budget_renewal_terms: "",
+        revision_included: "",
+        revision_major_changes: "",
+        revision_turnaround: "",
+        approval_process: "",
+        watermark_protection: "",
+        legal_terms: "",
+      });
     }
 
     setShowNewCampaignModal(true);
@@ -1455,6 +1512,9 @@ export default function BrandCampaignDashboard({
     setNewCampaignStep(1);
     setBrandCampaignId("");
     setIsExistingCampaign(false);
+    setStep1FieldErrors({});
+    setStep2FieldErrors({});
+    setWizardErrorBanner(null);
     setExistingCampaignAgencyIds(new Set());
     setExistingCampaignCreatorIds(new Set());
     setLoadingExistingCollaborators(false);

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -790,6 +790,16 @@ export default function BrandCampaignDashboard({
       deliverables: totalDeliverables,
       approved: Number(deliverableStats?.approved || 0),
       start_date: String(campaign?.start_date || "N/A"),
+      duration_days: Number(campaign?.duration_days || 0),
+      due_date: (() => {
+        const start = String(campaign?.start_date || "").trim();
+        const days = Number(campaign?.duration_days || 0);
+        if (!start || !days || !/^\d{4}-\d{2}-\d{2}$/.test(start)) return null;
+        const d = new Date(`${start}T00:00:00`);
+        d.setDate(d.getDate() + days - 1);
+        return d.toISOString().slice(0, 10);
+      })(),
+      budget_range: String(campaign?.budget_range || ""),
       has_signed_offer: hasSignedOffer,
       start_reached: isStartDateReached(campaign?.start_date),
       brief_snapshot:
@@ -2475,8 +2485,37 @@ export default function BrandCampaignDashboard({
                       </span>
                     </div>
                     <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs sm:text-sm text-gray-600">
-                      <span>Budget: ${campaign.budget.toLocaleString()}</span>
-                      <span>Start: {campaign.start_date}</span>
+                      {(() => {
+                        const parts = String(campaign.budget_range || "").match(
+                          /(\d[\d,]*)\s*-\s*(\d[\d,]*)/,
+                        );
+                        if (parts) {
+                          const min = Number(
+                            parts[1].replace(/[^\d]/g, ""),
+                          ).toLocaleString();
+                          const max = Number(
+                            parts[2].replace(/[^\d]/g, ""),
+                          ).toLocaleString();
+                          return (
+                            <span>
+                              Budget: ${min} – ${max}
+                            </span>
+                          );
+                        }
+                        if (campaign.budget > 0)
+                          return (
+                            <span>
+                              Budget: ${campaign.budget.toLocaleString()}
+                            </span>
+                          );
+                        return null;
+                      })()}
+                      {campaign.start_date && campaign.start_date !== "N/A" && (
+                        <span>Start: {campaign.start_date}</span>
+                      )}
+                      {campaign.due_date && (
+                        <span>Due: {campaign.due_date}</span>
+                      )}
                       <span>
                         {campaign.collaborators.length} collaborator(s)
                       </span>

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -140,6 +140,15 @@ export default function BrandCampaignDashboard({
   const { user, supabase, profile } = useAuth();
 
   const [showNewCampaignModal, setShowNewCampaignModal] = useState(false);
+  const [step1FieldErrors, setStep1FieldErrors] = useState<
+    Record<string, string>
+  >({});
+  const [step2FieldErrors, setStep2FieldErrors] = useState<
+    Record<string, string>
+  >({});
+  const [wizardErrorBanner, setWizardErrorBanner] = useState<string | null>(
+    null,
+  );
   const [showInviteAgencyModal, setShowInviteAgencyModal] = useState(false);
   const [showInviteCreatorModal, setShowInviteCreatorModal] = useState(false);
   const [showInviteSeatModal, setShowInviteSeatModal] = useState(false);
@@ -1559,30 +1568,99 @@ export default function BrandCampaignDashboard({
   };
 
   const handleStep1Next = async () => {
-    const validation = validateStep1Form();
-    if (!validation.ok) {
-      toast({
-        title: "Please correct the form",
-        description: validation.message || "Some fields are invalid.",
-        variant: "destructive" as any,
-      });
+    const errors: Record<string, string> = {};
+    if (!campaignForm.name.trim()) errors.name = "Campaign name is required.";
+    if (!campaignForm.objective.trim())
+      errors.objective = "Please select a campaign objective.";
+    if (!campaignForm.category.trim())
+      errors.category = "Please select a category.";
+    if (!campaignForm.description.trim())
+      errors.description = "Description is required.";
+    if (!campaignForm.start_date.trim())
+      errors.start_date = "Start date is required.";
+    else if (!/^\d{4}-\d{2}-\d{2}$/.test(campaignForm.start_date.trim()))
+      errors.start_date = "Please enter a valid date.";
+    const min = Number.parseInt(budgetParts.min, 10);
+    const max = Number.parseInt(budgetParts.max, 10);
+    if (!Number.isFinite(min) || min <= 0)
+      errors.budget_min = "Budget min must be greater than zero.";
+    if (!Number.isFinite(max) || max <= 0)
+      errors.budget_max = "Budget max must be greater than zero.";
+    else if (Number.isFinite(min) && min > 0 && max < min)
+      errors.budget_max = "Budget max must be ≥ budget min.";
+    const duration = Number.parseInt(
+      String(campaignForm.duration_days || "").trim(),
+      10,
+    );
+    if (!Number.isFinite(duration) || duration <= 0)
+      errors.duration_days = "Duration must be at least 1 day.";
+
+    setStep1FieldErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      const firstKey = Object.keys(errors)[0];
+      setWizardErrorBanner(errors[firstKey]);
+      // Auto-focus first invalid field
+      setTimeout(() => {
+        const el = document.getElementById(`step1-${firstKey}`);
+        if (el) {
+          el.focus();
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }, 50);
       return;
     }
+
+    setWizardErrorBanner(null);
     const id = await ensureCampaignDraft();
     if (!id) return;
     setNewCampaignStep(2);
   };
 
   const handleStep2Next = async () => {
-    const validation = validateStep2Brief();
-    if (!validation.ok) {
-      toast({
-        title: "Please correct the campaign brief",
-        description: validation.message || "Some brief fields are invalid.",
-        variant: "destructive" as any,
-      });
+    const errors: Record<string, string> = {};
+    const expectedTotal = Number.parseInt(
+      String(campaignBrief.total_expected_deliverables || "").trim(),
+      10,
+    );
+    if (!Number.isFinite(expectedTotal) || expectedTotal <= 0)
+      errors.total_expected_deliverables =
+        "Total expected deliverables must be greater than 0.";
+    const duration = Number.parseInt(
+      String(campaignBrief.overview_campaign_duration || "").trim(),
+      10,
+    );
+    if (!Number.isFinite(duration) || duration <= 0)
+      errors.overview_campaign_duration =
+        "Campaign duration must be a valid number of days.";
+    if (!isValidDateString(String(campaignBrief.overview_launch_date || "")))
+      errors.overview_launch_date = "Please enter a valid launch date.";
+    if (
+      !isValidDateString(String(campaignBrief.budget_submission_deadline || ""))
+    )
+      errors.budget_submission_deadline =
+        "Please enter a valid submission deadline.";
+    if (!parsePositiveNumber(campaignBrief.budget_total))
+      errors.budget_total = "Total budget must be a valid amount.";
+    if (!parsePositiveNumber(campaignBrief.budget_creator_payment))
+      errors.budget_creator_payment = "Creator payment must be a valid amount.";
+
+    setStep2FieldErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      const firstKey = Object.keys(errors)[0];
+      setWizardErrorBanner(errors[firstKey]);
+      setTimeout(() => {
+        const el = document.getElementById(`step2-${firstKey}`);
+        if (el) {
+          el.focus();
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }, 50);
       return;
     }
+
+    setWizardErrorBanner(null);
     const id = await ensureCampaignDraft();
     if (!id) return;
     try {
@@ -2568,35 +2646,72 @@ export default function BrandCampaignDashboard({
               )}
 
               {newCampaignStep === 1 && (
-                <div className="space-y-4 sm:space-y-6 overflow-y-auto max-h-[calc(100vh-200px)] sm:max-h-none pr-1">
+                <div className="space-y-4 sm:space-y-5 overflow-y-auto max-h-[calc(100vh-200px)] sm:max-h-none pr-1">
+                  {/* Error banner */}
+                  {wizardErrorBanner && (
+                    <div className="animate-shake flex items-start gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3">
+                      <AlertCircle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-semibold text-amber-900">
+                          Almost there — just a few fields need attention
+                        </p>
+                        <p className="text-xs text-amber-700 mt-0.5">
+                          {wizardErrorBanner}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => setWizardErrorBanner(null)}
+                        className="ml-auto text-amber-500 hover:text-amber-700"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Campaign Name */}
                   <div>
-                    <label className="text-sm font-medium text-gray-700 block mb-2">
-                      Campaign Name *
+                    <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                      Campaign Name <span className="text-red-500">*</span>
                     </label>
                     <Input
+                      id="step1-name"
                       value={campaignForm.name}
-                      onChange={(e) =>
+                      onChange={(e) => {
                         setCampaignForm({
                           ...campaignForm,
                           name: e.target.value,
-                        })
-                      }
+                        });
+                        if (step1FieldErrors.name)
+                          setStep1FieldErrors((p) => ({ ...p, name: "" }));
+                      }}
                       placeholder="e.g., Spring Collection Launch"
-                      className="border-2 border-gray-300 rounded-none"
+                      className={`rounded-none transition-colors ${step1FieldErrors.name ? "border-2 border-amber-400 bg-amber-50 focus:border-amber-500" : "border-2 border-gray-200 focus:border-black"}`}
                     />
+                    {step1FieldErrors.name && (
+                      <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                        <AlertCircle className="w-3 h-3" />
+                        {step1FieldErrors.name}
+                      </p>
+                    )}
                   </div>
 
+                  {/* Objective */}
                   <div>
-                    <label className="text-sm font-medium text-gray-700 block mb-2">
-                      Campaign Objective *
+                    <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                      Campaign Objective <span className="text-red-500">*</span>
                     </label>
                     <Select
                       value={campaignForm.objective}
-                      onValueChange={(v) =>
-                        setCampaignForm({ ...campaignForm, objective: v })
-                      }
+                      onValueChange={(v) => {
+                        setCampaignForm({ ...campaignForm, objective: v });
+                        if (step1FieldErrors.objective)
+                          setStep1FieldErrors((p) => ({ ...p, objective: "" }));
+                      }}
                     >
-                      <SelectTrigger className="border-2 border-gray-300 rounded-none">
+                      <SelectTrigger
+                        id="step1-objective"
+                        className={`rounded-none transition-colors ${step1FieldErrors.objective ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
+                      >
                         <SelectValue placeholder="Select objective" />
                       </SelectTrigger>
                       <SelectContent>
@@ -2615,19 +2730,31 @@ export default function BrandCampaignDashboard({
                         </SelectItem>
                       </SelectContent>
                     </Select>
+                    {step1FieldErrors.objective && (
+                      <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                        <AlertCircle className="w-3 h-3" />
+                        {step1FieldErrors.objective}
+                      </p>
+                    )}
                   </div>
 
+                  {/* Category */}
                   <div>
-                    <label className="text-sm font-medium text-gray-700 block mb-2">
-                      Category *
+                    <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                      Category <span className="text-red-500">*</span>
                     </label>
                     <Select
                       value={campaignForm.category}
-                      onValueChange={(v) =>
-                        setCampaignForm({ ...campaignForm, category: v })
-                      }
+                      onValueChange={(v) => {
+                        setCampaignForm({ ...campaignForm, category: v });
+                        if (step1FieldErrors.category)
+                          setStep1FieldErrors((p) => ({ ...p, category: "" }));
+                      }}
                     >
-                      <SelectTrigger className="border-2 border-gray-300 rounded-none">
+                      <SelectTrigger
+                        id="step1-category"
+                        className={`rounded-none transition-colors ${step1FieldErrors.category ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
+                      >
                         <SelectValue placeholder="Select category" />
                       </SelectTrigger>
                       <SelectContent>
@@ -2641,78 +2768,169 @@ export default function BrandCampaignDashboard({
                         <SelectItem value="Custom">Custom</SelectItem>
                       </SelectContent>
                     </Select>
+                    {step1FieldErrors.category && (
+                      <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                        <AlertCircle className="w-3 h-3" />
+                        {step1FieldErrors.category}
+                      </p>
+                    )}
                   </div>
 
+                  {/* Description */}
                   <div>
-                    <label className="text-sm font-medium text-gray-700 block mb-2">
-                      Description *
+                    <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                      Description <span className="text-red-500">*</span>
                     </label>
                     <Textarea
+                      id="step1-description"
                       value={campaignForm.description}
-                      onChange={(e) =>
+                      onChange={(e) => {
                         setCampaignForm({
                           ...campaignForm,
                           description: e.target.value,
-                        })
-                      }
+                        });
+                        if (step1FieldErrors.description)
+                          setStep1FieldErrors((p) => ({
+                            ...p,
+                            description: "",
+                          }));
+                      }}
                       placeholder="Describe campaign goals and licensing context..."
-                      className="border-2 border-gray-300 rounded-none min-h-[90px]"
+                      className={`rounded-none min-h-[90px] transition-colors ${step1FieldErrors.description ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
                     />
+                    {step1FieldErrors.description && (
+                      <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                        <AlertCircle className="w-3 h-3" />
+                        {step1FieldErrors.description}
+                      </p>
+                    )}
                   </div>
 
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Budget + Start Date */}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
-                        Budget Min (USD) *
+                      <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                        Budget Min (USD) <span className="text-red-500">*</span>
                       </label>
                       <Input
+                        id="step1-budget_min"
                         type="number"
                         min={1}
                         step={1}
                         inputMode="numeric"
                         value={budgetParts.min}
-                        onChange={(e) => setBudgetPart("min", e.target.value)}
+                        onChange={(e) => {
+                          setBudgetPart("min", e.target.value);
+                          if (step1FieldErrors.budget_min)
+                            setStep1FieldErrors((p) => ({
+                              ...p,
+                              budget_min: "",
+                            }));
+                        }}
                         placeholder="5000"
-                        className="border-2 border-gray-300 rounded-none"
+                        className={`rounded-none transition-colors ${step1FieldErrors.budget_min ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
                       />
+                      {step1FieldErrors.budget_min && (
+                        <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3" />
+                          {step1FieldErrors.budget_min}
+                        </p>
+                      )}
                     </div>
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
-                        Budget Max (USD) *
+                      <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                        Budget Max (USD) <span className="text-red-500">*</span>
                       </label>
                       <Input
+                        id="step1-budget_max"
                         type="number"
                         min={1}
                         step={1}
                         inputMode="numeric"
                         value={budgetParts.max}
-                        onChange={(e) => setBudgetPart("max", e.target.value)}
+                        onChange={(e) => {
+                          setBudgetPart("max", e.target.value);
+                          if (step1FieldErrors.budget_max)
+                            setStep1FieldErrors((p) => ({
+                              ...p,
+                              budget_max: "",
+                            }));
+                        }}
                         placeholder="10000"
-                        className="border-2 border-gray-300 rounded-none"
+                        className={`rounded-none transition-colors ${step1FieldErrors.budget_max ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
                       />
+                      {step1FieldErrors.budget_max && (
+                        <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3" />
+                          {step1FieldErrors.budget_max}
+                        </p>
+                      )}
                     </div>
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
-                        Start Date *
+                      <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                        Start Date <span className="text-red-500">*</span>
                       </label>
                       <Input
+                        id="step1-start_date"
                         type="date"
                         value={campaignForm.start_date}
-                        onChange={(e) =>
+                        onChange={(e) => {
                           setCampaignForm({
                             ...campaignForm,
                             start_date: e.target.value,
-                          })
-                        }
-                        className="border-2 border-gray-300 rounded-none"
+                          });
+                          if (step1FieldErrors.start_date)
+                            setStep1FieldErrors((p) => ({
+                              ...p,
+                              start_date: "",
+                            }));
+                        }}
+                        className={`rounded-none transition-colors ${step1FieldErrors.start_date ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
                       />
+                      {step1FieldErrors.start_date && (
+                        <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3" />
+                          {step1FieldErrors.start_date}
+                        </p>
+                      )}
+                    </div>
+                    <div>
+                      <label className="text-sm font-semibold text-gray-700 block mb-1.5">
+                        Duration (days) <span className="text-red-500">*</span>
+                      </label>
+                      <Input
+                        id="step1-duration_days"
+                        type="number"
+                        min={1}
+                        value={campaignForm.duration_days}
+                        onChange={(e) => {
+                          setCampaignForm({
+                            ...campaignForm,
+                            duration_days: e.target.value,
+                          });
+                          if (step1FieldErrors.duration_days)
+                            setStep1FieldErrors((p) => ({
+                              ...p,
+                              duration_days: "",
+                            }));
+                        }}
+                        placeholder="30"
+                        className={`rounded-none transition-colors ${step1FieldErrors.duration_days ? "border-2 border-amber-400 bg-amber-50" : "border-2 border-gray-200"}`}
+                      />
+                      {step1FieldErrors.duration_days && (
+                        <p className="text-xs text-amber-600 mt-1 flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3" />
+                          {step1FieldErrors.duration_days}
+                        </p>
+                      )}
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Optional fields */}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
-                        Usage scope
+                      <label className="text-sm font-medium text-gray-600 block mb-1.5">
+                        Usage Scope
                       </label>
                       <Input
                         value={campaignForm.usage_scope}
@@ -2723,29 +2941,11 @@ export default function BrandCampaignDashboard({
                           })
                         }
                         placeholder="e.g., Paid social + website"
-                        className="border-2 border-gray-300 rounded-none"
+                        className="border-2 border-gray-200 rounded-none"
                       />
                     </div>
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
-                        Duration (days)
-                      </label>
-                      <Input
-                        type="number"
-                        min={1}
-                        value={campaignForm.duration_days}
-                        onChange={(e) =>
-                          setCampaignForm({
-                            ...campaignForm,
-                            duration_days: e.target.value,
-                          })
-                        }
-                        placeholder="30"
-                        className="border-2 border-gray-300 rounded-none"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
+                      <label className="text-sm font-medium text-gray-600 block mb-1.5">
                         Territory
                       </label>
                       <Input
@@ -2757,23 +2957,20 @@ export default function BrandCampaignDashboard({
                           })
                         }
                         placeholder="Global / US only / EU"
-                        className="border-2 border-gray-300 rounded-none"
+                        className="border-2 border-gray-200 rounded-none"
                       />
                     </div>
                     <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-2">
+                      <label className="text-sm font-medium text-gray-600 block mb-1.5">
                         Exclusivity
                       </label>
                       <Select
                         value={campaignForm.exclusivity}
                         onValueChange={(v) =>
-                          setCampaignForm({
-                            ...campaignForm,
-                            exclusivity: v,
-                          })
+                          setCampaignForm({ ...campaignForm, exclusivity: v })
                         }
                       >
-                        <SelectTrigger className="border-2 border-gray-300 rounded-none">
+                        <SelectTrigger className="border-2 border-gray-200 rounded-none">
                           <SelectValue placeholder="Select exclusivity" />
                         </SelectTrigger>
                         <SelectContent>
@@ -2792,7 +2989,7 @@ export default function BrandCampaignDashboard({
                   </div>
 
                   <div>
-                    <label className="text-sm font-medium text-gray-700 block mb-2">
+                    <label className="text-sm font-medium text-gray-600 block mb-1.5">
                       Custom Terms
                     </label>
                     <Textarea
@@ -2804,11 +3001,11 @@ export default function BrandCampaignDashboard({
                         })
                       }
                       placeholder="Any additional legal/commercial terms..."
-                      className="border-2 border-gray-300 rounded-none min-h-[90px]"
+                      className="border-2 border-gray-200 rounded-none min-h-[80px]"
                     />
                   </div>
 
-                  <div className="flex justify-end gap-3">
+                  <div className="flex justify-end gap-3 pt-2">
                     <Button
                       variant="outline"
                       onClick={resetCampaignBuilder}
@@ -2818,41 +3015,54 @@ export default function BrandCampaignDashboard({
                     </Button>
                     <Button
                       onClick={handleStep1Next}
-                      disabled={
-                        savingCampaign ||
-                        !campaignForm.name ||
-                        !campaignForm.objective ||
-                        !campaignForm.category ||
-                        !campaignForm.description.trim() ||
-                        !campaignForm.start_date ||
-                        !budgetParts.min ||
-                        !budgetParts.max
-                      }
+                      disabled={savingCampaign}
                       className="bg-black hover:bg-gray-800 text-white border-2 border-black rounded-none"
                     >
-                      {savingCampaign ? "Saving..." : "Next"}
+                      {savingCampaign ? "Saving..." : "Next →"}
                     </Button>
                   </div>
                 </div>
               )}
 
               {newCampaignStep === 2 && (
-                <CampaignBriefStep
-                  campaignBrief={campaignBrief}
-                  setCampaignBrief={setCampaignBrief}
-                  onReferenceImagesUpload={handleReferenceImageUpload}
-                  onBrandAssetsUpload={handleBrandAssetsUpload}
-                  onBack={() => {
-                    if (brandCampaignId) {
-                      // Do nothing or optionally show a toast.
-                      // Since the user says step 1 shouldn't change, we stay at step 2.
-                      return;
-                    }
-                    setNewCampaignStep(1);
-                  }}
-                  onNext={handleStep2Next}
-                  uploading={uploadingImages}
-                />
+                <>
+                  {wizardErrorBanner && (
+                    <div className="animate-shake flex items-start gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 mb-4">
+                      <AlertCircle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-semibold text-amber-900">
+                          Please review the campaign brief
+                        </p>
+                        <p className="text-xs text-amber-700 mt-0.5">
+                          {wizardErrorBanner}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => setWizardErrorBanner(null)}
+                        className="ml-auto text-amber-500 hover:text-amber-700"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+                  <CampaignBriefStep
+                    campaignBrief={campaignBrief}
+                    setCampaignBrief={setCampaignBrief}
+                    onReferenceImagesUpload={handleReferenceImageUpload}
+                    onBrandAssetsUpload={handleBrandAssetsUpload}
+                    fieldErrors={step2FieldErrors}
+                    onFieldChange={(field: string) => {
+                      if (step2FieldErrors[field])
+                        setStep2FieldErrors((p) => ({ ...p, [field]: "" }));
+                    }}
+                    onBack={() => {
+                      if (brandCampaignId) return;
+                      setNewCampaignStep(1);
+                    }}
+                    onNext={handleStep2Next}
+                    uploading={uploadingImages}
+                  />
+                </>
               )}
 
               {newCampaignStep === 3 && (

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -351,13 +351,22 @@ export default function BrandCampaignDashboard({
 
       setNewCampaignStep(safeStep);
     } else {
-      // Full reset for a brand-new campaign — clear any state left from a previous session
+      // Full reset — reuse resetCampaignBuilder logic to clear all wizard state
+      // (form, brief, collaborator selections, contract draft, validation errors, etc.)
+      // then re-open the modal for a fresh new campaign.
+      setShowCampaignDocuSealBuilder(false);
+      setBrandSignOpen(false);
+      setBrandSignUrl("");
+      setAwaitingBrandSignature(false);
+      setNewCampaignStep(1);
       setBrandCampaignId("");
       setIsExistingCampaign(false);
       setStep1FieldErrors({});
       setStep2FieldErrors({});
       setWizardErrorBanner(null);
-      setNewCampaignStep(1);
+      setExistingCampaignAgencyIds(new Set());
+      setExistingCampaignCreatorIds(new Set());
+      setLoadingExistingCollaborators(false);
       setCampaignForm({
         name: "",
         objective: "",
@@ -409,6 +418,12 @@ export default function BrandCampaignDashboard({
         watermark_protection: "",
         legal_terms: "",
       });
+      setOfferByCreatorId({});
+      setContractDraft({ title: "", file_url: "", docuseal_template_id: "" });
+      setSelectedCreatorsById({});
+      setSelectedTalentCreatorIds(new Set());
+      setMarketplaceCreators([]);
+      setCreatorSearch("");
     }
 
     setShowNewCampaignModal(true);

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -168,6 +168,7 @@ export default function BrandCampaignDashboard({
   const [loadingSelectedCampaignDetails, setLoadingSelectedCampaignDetails] =
     useState(false);
   const [brandCampaignId, setBrandCampaignId] = useState<string>("");
+  const [isExistingCampaign, setIsExistingCampaign] = useState(false);
   const [campaignCards, setCampaignCards] = useState<any[]>([]);
   const [loadingCampaignCards, setLoadingCampaignCards] = useState(false);
   const [showEscrowReleaseModal, setShowEscrowReleaseModal] = useState(false);
@@ -307,6 +308,7 @@ export default function BrandCampaignDashboard({
       const brandCampaignId = String(context?.brandCampaignId || "").trim();
 
       setBrandCampaignId(brandCampaignId);
+      setIsExistingCampaign(true);
       setCampaignForm((prev) => ({
         ...prev,
         name: String(context?.name || prev.name || "").trim(),
@@ -1442,6 +1444,7 @@ export default function BrandCampaignDashboard({
     setAwaitingBrandSignature(false);
     setNewCampaignStep(1);
     setBrandCampaignId("");
+    setIsExistingCampaign(false);
     setExistingCampaignAgencyIds(new Set());
     setExistingCampaignCreatorIds(new Set());
     setLoadingExistingCollaborators(false);
@@ -3056,9 +3059,10 @@ export default function BrandCampaignDashboard({
                         setStep2FieldErrors((p) => ({ ...p, [field]: "" }));
                     }}
                     onBack={() => {
-                      if (brandCampaignId) return;
+                      if (isExistingCampaign) return;
                       setNewCampaignStep(1);
                     }}
+                    hideBack={isExistingCampaign}
                     onNext={handleStep2Next}
                     uploading={uploadingImages}
                   />

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -6012,7 +6012,12 @@ export default function BrandDashboard() {
         objective:
           String(offer?.brand_campaigns?.objective || "").trim() ||
           "Campaign offer",
-        budget: 0,
+        budget: (() => {
+          const budgetText = String(brandCampaigns?.budget_range || "");
+          const match = budgetText.match(/(\d[\d,]*)\s*-\s*(\d[\d,]*)/);
+          if (match) return Number(String(match[2]).replace(/[^\d]/g, "")) || 0;
+          return 0;
+        })(),
         creators: [collaboratorLabel],
         creatorAvatars: [
           String(offer?.target_avatar_url || "").trim() || "/favicon.svg",
@@ -6026,6 +6031,7 @@ export default function BrandDashboard() {
         exclusivity: String(brandCampaigns?.exclusivity || "").trim(),
         budget_range: String(brandCampaigns?.budget_range || "").trim(),
         start_date: String(brandCampaigns?.start_date || "").trim(),
+        due_date: endDate ? endDate.toISOString().slice(0, 10) : null,
         custom_terms: String(brandCampaigns?.custom_terms || "").trim(),
         assets_delivered: 0,
         last_update: offer?.updated_at
@@ -6113,7 +6119,9 @@ export default function BrandDashboard() {
         completed_at: completedAt,
         objective: representative?.objective || "Campaign offer",
         budget: Number(representative?.budget || 0),
-        due_date: representative?.due_date,
+        budget_range: String(representative?.budget_range || ""),
+        start_date: String(representative?.start_date || ""),
+        due_date: representative?.due_date || null,
         assets_delivered: Number(representative?.assets_delivered || 0),
         last_update: representative?.last_update,
       };
@@ -6866,7 +6874,33 @@ export default function BrandDashboard() {
                     <div className="flex justify-between">
                       <span className="text-gray-600">Budget:</span>
                       <span className="font-bold text-gray-900">
-                        ${Number(campaign.budget || 0).toLocaleString()}
+                        {(() => {
+                          const parts = String(
+                            campaign.budget_range || "",
+                          ).match(/(\d[\d,]*)\s*-\s*(\d[\d,]*)/);
+                          if (parts) {
+                            const min = Number(
+                              parts[1].replace(/[^\d]/g, ""),
+                            ).toLocaleString();
+                            const max = Number(
+                              parts[2].replace(/[^\d]/g, ""),
+                            ).toLocaleString();
+                            return `$${min} – $${max}`;
+                          }
+                          return campaign.budget > 0
+                            ? `$${Number(campaign.budget).toLocaleString()}`
+                            : "—";
+                        })()}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Start Date:</span>
+                      <span className="font-medium text-gray-900">
+                        {campaign.start_date && campaign.start_date !== "N/A"
+                          ? new Date(
+                              `${campaign.start_date}T00:00:00`,
+                            ).toLocaleDateString()
+                          : "—"}
                       </span>
                     </div>
                     <div className="flex justify-between">
@@ -6877,18 +6911,6 @@ export default function BrandDashboard() {
                               String(campaign.due_date),
                             ).toLocaleDateString()
                           : "—"}
-                      </span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-600">Assets:</span>
-                      <span className="font-medium text-gray-900">
-                        {Number(campaign.assets_delivered || 0)} delivered
-                      </span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-600">Last Update:</span>
-                      <span className="font-medium text-gray-900">
-                        {campaign.last_update || "—"}
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
closes #537
closes #538 

---

**PR Description:**

## Overview
This PR improves the campaign creation experience in the brand dashboard across two areas: the wizard step UX and the accuracy of data displayed on campaign offer cards.

## Campaign Wizard — Step 1 & Step 2 UX

**Problem:** Validation errors were shown as a generic red toast in the bottom corner, giving no indication of which field was wrong. Users had no visual feedback on invalid fields and had to hunt for the issue.

**Changes:**
- Replaced the destructive red toast with an animated amber banner at the top of the form that names the specific issue and shakes to draw attention
- Invalid fields are highlighted with an amber border and background, with an inline error message directly below each field
- Errors clear automatically as the user corrects each field
- On submit, the page auto-scrolls and focuses the first invalid field
- Required fields are clearly marked with `*`
- Applied the same pattern to Step 2 (Campaign Brief) for all 6 required fields: total deliverables, campaign duration, launch date, collaborator payout, offer amount, and submission deadline

**Back navigation fix:**
- During new campaign creation, the Back button on Step 2 correctly returns to Step 1
- When adding a collaborator to an existing campaign, the Back button is hidden — no going back to Step 1 since the campaign already exists

## Campaign Offer Card — Data Accuracy

**Problem:** The "My Offers" card was showing **$0 budget**, **no start date**, and **no due date** despite the user having entered all of this in Step 1.

**Root cause:** Three stacked bugs — budget was hardcoded to `0`, due date was calculated but never stored on the offer object, and `start_date`/`budget_range` were never propagated to the grouped campaign object used by the card renderer.

**Changes:**
- Budget now displays the full range from Step 1: `$min – $max`
- Start date and due date (calculated as `start_date + duration_days`) are now correctly shown
- Removed Assets and Last Update rows — card only shows Step 1 fields: budget range, start date, due date
- All card data sourced exclusively from Step 1 fields (`budget_range`, `start_date`, `duration_days`)