### PR TITLE
Fix: talent names showing as "Unnamed Talent" in brand package confirmation

### DIFF
--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5018,8 +5018,7 @@ async fn normalize_package_snapshot_talent_names(
 
     // Batch-fetch names from agency_users.
     let id_refs: Vec<&str> = needs_name.iter().map(String::as_str).collect();
-    let mut name_map: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
+    let mut name_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
     if let Ok(resp) = state
         .pg

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -4972,6 +4972,130 @@ pub async fn delete_offer_contract(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Resolve `talent_name` for every item in `package_snapshot.items` that is
+/// missing one, using a single batch query against `agency_users`.
+/// Items without a valid `talent_id` UUID are left untouched.
+async fn normalize_package_snapshot_talent_names(
+    state: &AppState,
+    agency_id: &str,
+    snapshot: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut snapshot = snapshot.unwrap_or_else(|| json!({}));
+
+    let items = match snapshot
+        .as_object_mut()
+        .and_then(|o| o.get_mut("items"))
+        .and_then(|v| v.as_array_mut())
+    {
+        Some(arr) if !arr.is_empty() => arr,
+        _ => return snapshot,
+    };
+
+    // Collect talent_ids that need a name resolved (missing or blank).
+    let needs_name: Vec<String> = items
+        .iter()
+        .filter(|item| {
+            item.get("talent_name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+        })
+        .filter_map(|item| {
+            item.get("talent_id")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .filter(|s| Uuid::parse_str(s).is_ok())
+                .map(str::to_string)
+        })
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if needs_name.is_empty() {
+        return snapshot;
+    }
+
+    // Batch-fetch names from agency_users.
+    let id_refs: Vec<&str> = needs_name.iter().map(String::as_str).collect();
+    let mut name_map: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    if let Ok(resp) = state
+        .pg
+        .from("agency_users")
+        .select("id,stage_name,full_legal_name")
+        .eq("agency_id", agency_id)
+        .in_("id", id_refs)
+        .limit(needs_name.len().max(1) + 1)
+        .execute()
+        .await
+    {
+        if resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
+            for row in rows {
+                let id = row
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if id.is_empty() {
+                    continue;
+                }
+                let name = row
+                    .get("stage_name")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| {
+                        row.get("full_legal_name")
+                            .and_then(|v| v.as_str())
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                    })
+                    .unwrap_or("")
+                    .to_string();
+                if !name.is_empty() {
+                    name_map.insert(id, name);
+                }
+            }
+        }
+    }
+
+    // Patch items in-place.
+    let items = snapshot
+        .as_object_mut()
+        .and_then(|o| o.get_mut("items"))
+        .and_then(|v| v.as_array_mut())
+        .expect("items array was present above");
+
+    for item in items.iter_mut() {
+        let already_has_name = item
+            .get("talent_name")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        if already_has_name {
+            continue;
+        }
+        let talent_id = item
+            .get("talent_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string();
+        if let Some(name) = name_map.get(&talent_id) {
+            if let Some(obj) = item.as_object_mut() {
+                obj.insert("talent_name".to_string(), json!(name));
+            }
+        }
+    }
+
+    snapshot
+}
+
 pub async fn create_offer_package(
     State(state): State<AppState>,
     user: AuthUser,
@@ -4992,6 +5116,13 @@ pub async fn create_offer_package(
             "packages are only available for agency offers".to_string(),
         ));
     }
+
+    // Normalise package_snapshot.items at write time: resolve talent_name from
+    // agency_users so that the stored snapshot is always correct regardless of
+    // which UI path created the package.
+    let package_snapshot =
+        normalize_package_snapshot_talent_names(&state, &user.id, payload.package_snapshot).await;
+
     let insert_payload = json!({
         "offer_id": offer_id,
         "brand_campaign_id": offer.get("brand_campaign_id").cloned().unwrap_or(serde_json::Value::Null),
@@ -5000,7 +5131,7 @@ pub async fn create_offer_package(
         "status": "draft",
         "title": payload.title.as_deref().map(str::trim).filter(|s| !s.is_empty()),
         "message": payload.message.as_deref().map(str::trim).filter(|s| !s.is_empty()),
-        "package_snapshot": payload.package_snapshot.unwrap_or_else(|| json!({})),
+        "package_snapshot": package_snapshot,
         "expires_at": payload.expires_at,
         "meta": payload.meta.unwrap_or_else(|| json!({})),
         "created_by": user.id,

--- a/likelee-server/src/packages.rs
+++ b/likelee-server/src/packages.rs
@@ -885,8 +885,16 @@ pub async fn create_public_package_full_assets_request(
         .to_string();
 
     // Prefer payload values; fall back to the package's stored recipient details.
-    let client_name = if payload_name.is_empty() { stored_client_name } else { payload_name };
-    let client_email = if payload_email.is_empty() { stored_client_email } else { payload_email };
+    let client_name = if payload_name.is_empty() {
+        stored_client_name
+    } else {
+        payload_name
+    };
+    let client_email = if payload_email.is_empty() {
+        stored_client_email
+    } else {
+        payload_email
+    };
     let message = payload.message.as_deref().unwrap_or("").trim().to_string();
 
     let notes = format!(

--- a/likelee-server/src/packages.rs
+++ b/likelee-server/src/packages.rs
@@ -806,11 +806,12 @@ pub async fn create_public_package_full_assets_request(
     Path(token): Path<String>,
     Json(payload): Json<PublicPackageFullAssetsRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    // Resolve package by token.
+    // Resolve package by token — also fetch stored client identity so we can
+    // use it as a fallback when the public request doesn't carry those fields.
     let meta_resp = state
         .pg
         .from("agency_talent_packages")
-        .select("id,agency_id,title")
+        .select("id,agency_id,title,client_name,client_email")
         .eq("access_token", &token)
         .single()
         .execute()
@@ -854,18 +855,38 @@ pub async fn create_public_package_full_assets_request(
         .unwrap_or("")
         .to_string();
 
-    let client_name = payload
+    // The stored package client identity is the authoritative source.
+    // Use the payload values if provided, otherwise fall back to what the
+    // agency set when they created/sent the package.
+    let stored_client_name = meta
+        .get("client_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let stored_client_email = meta
+        .get("client_email")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let payload_name = payload
         .client_name
         .as_deref()
         .unwrap_or("")
         .trim()
         .to_string();
-    let client_email = payload
+    let payload_email = payload
         .client_email
         .as_deref()
         .unwrap_or("")
         .trim()
         .to_string();
+
+    // Prefer payload values; fall back to the package's stored recipient details.
+    let client_name = if payload_name.is_empty() { stored_client_name } else { payload_name };
+    let client_email = if payload_email.is_empty() { stored_client_email } else { payload_email };
     let message = payload.message.as_deref().unwrap_or("").trim().to_string();
 
     let notes = format!(
@@ -901,9 +922,9 @@ pub async fn create_public_package_full_assets_request(
     let interaction_row = serde_json::json!({
         "package_id": package_id,
         "type": "asset_request",
-        "content": message,
-        "client_name": client_name,
-        "client_email": client_email,
+        "content": if message.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(message.clone()) },
+        "client_name": if client_name.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(client_name.clone()) },
+        "client_email": if client_email.is_empty() { serde_json::Value::Null } else { serde_json::Value::String(client_email.clone()) },
     });
 
     if let Err(e) = state

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -1130,12 +1130,27 @@ const BrandConnectionsView = () => {
     const draft = packageDraftByOffer[offerId] || { title: "", message: "" };
     setBusyIds((prev) => new Set(prev).add(offerId));
     try {
+      // Build snapshot items from the offer's assigned talent IDs so the
+      // backend can resolve their names via normalize_package_snapshot_talent_names.
+      const offer = (offersQuery.data || []).find(
+        (o: any) => String(o?.id || "") === offerId,
+      );
+      const selectedTalentIds: string[] = Array.isArray(
+        offer?.meta?.selected_talent_ids,
+      )
+        ? offer.meta.selected_talent_ids
+        : [];
+      const snapshotItems = selectedTalentIds.map((tid: string) => ({
+        talent_id: tid,
+        talent_name: "", // backend will resolve this
+      }));
+
       const createResp = await base44.post<{ package?: any }>(
         `/api/campaign-offers/${offerId}/packages`,
         {
           title: draft.title || "Talent Package",
           message: draft.message || "",
-          package_snapshot: { talents: [] },
+          package_snapshot: { items: snapshotItems },
         },
       );
       const packageId = String(createResp?.package?.id || "").trim();

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -310,6 +310,26 @@ export function CreatePackageWizard({
     enabled: open && isOfferMode,
   });
 
+  // When a brand is selected (or the brand list loads with a pre-selected brand),
+  // always sync the brand's name and email into formData — these are the
+  // authoritative recipient details for offer packages.
+  useEffect(() => {
+    if (!isOfferMode || !selectedBrandId) return;
+    const list = Array.isArray(connectedBrands) ? connectedBrands : [];
+    const match = list.find(
+      (c: any) => String(c?.brand_id || "").trim() === selectedBrandId,
+    );
+    if (!match) return;
+    const brandName = String(match?.brands?.company_name || "").trim();
+    const brandEmail = String(match?.brands?.email || "").trim();
+    // Always overwrite with brand values — the brand is the recipient
+    setFormData((prev) => ({
+      ...prev,
+      client_name: brandName || brandEmail || prev.client_name,
+      client_email: brandEmail || prev.client_email,
+    }));
+  }, [selectedBrandId, connectedBrands, isOfferMode]);
+
   const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
@@ -610,7 +630,20 @@ export function CreatePackageWizard({
       .filter(Boolean);
 
     if (isOfferMode) {
-      const selectedTalentIds = itemsArray
+      const connectedBrandRows = Array.isArray(connectedBrands)
+        ? connectedBrands
+        : [];
+      const selectedBrand = connectedBrandRows.find(
+        (connection: any) =>
+          String(connection?.brand_id || "").trim() ===
+          String(selectedBrandId || "").trim(),
+      );
+      const selectedBrandName = String(
+        selectedBrand?.brands?.company_name || "",
+      ).trim();
+      const selectedBrandEmail = String(
+        selectedBrand?.brands?.email || "",
+      ).trim();      const selectedTalentIds = itemsArray
         .map((it: any) => String(it?.talent_id || it?.id || "").trim())
         .filter(Boolean);
 
@@ -628,12 +661,17 @@ export function CreatePackageWizard({
         meta: {
           selected_talent_ids: selectedTalentIds,
           selected_brand_id: selectedBrandId,
+          selected_brand_name: selectedBrandName || undefined,
+          selected_brand_email: selectedBrandEmail || undefined,
+          skip_client_email_notification: true,
           wizard_source: "talent_packages",
           offer_id: offerContext.offerId,
         },
-        // Offer mode: bypass legacy email system and set neutral client name for logs
-        client_email: "",
-        client_name: "Brand Portal",
+        // Persist the real recipient identity on the package so downstream
+        // public-package actions can reuse it without prompting again.
+        // Prefer formData values (editable by agency) over brand-derived values.
+        client_email: selectedBrandEmail || formData.client_email,
+        client_name: selectedBrandName || selectedBrandEmail || formData.client_name || "Brand Portal",
       };
 
       const offerPayload = {
@@ -1294,9 +1332,9 @@ export function CreatePackageWizard({
                           {canViewConnections ? (
                             <select
                               value={selectedBrandId}
-                              onChange={(e) =>
-                                setSelectedBrandId(e.target.value)
-                              }
+                              onChange={(e) => {
+                                setSelectedBrandId(e.target.value);
+                              }}
                               className="w-full h-12 bg-gray-50 border border-gray-200 focus:border-indigo-600 focus:bg-white rounded-lg px-4 transition-all duration-300 font-medium"
                             >
                               <option value="">Select a brand…</option>
@@ -1337,60 +1375,42 @@ export function CreatePackageWizard({
 
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                         {isOfferMode ? (
-                          <>
-                            <div className="space-y-3">
-                              <Label className="text-[10px] font-black uppercase tracking-widest text-gray-500">
-                                Client Contact
-                              </Label>
-                              <Input
-                                readOnly
-                                value={(() => {
-                                  const list = Array.isArray(connectedBrands)
-                                    ? connectedBrands
-                                    : [];
-                                  const match = list.find(
-                                    (c: any) =>
-                                      String(c?.brand_id || "").trim() ===
-                                      String(selectedBrandId || "").trim(),
-                                  );
-                                  return (
-                                    String(
-                                      match?.brands?.company_name || "",
-                                    ).trim() ||
-                                    String(match?.brands?.email || "").trim() ||
-                                    ""
-                                  );
-                                })()}
-                                className="h-12 bg-gray-50 border border-gray-200 focus:border-indigo-600 focus:bg-white rounded-lg px-4 transition-all duration-300 font-medium"
-                              />
-                            </div>
-                            <div className="space-y-3">
-                              <Label className="text-[10px] font-black uppercase tracking-widest text-gray-500">
-                                Delivery Email
-                              </Label>
-                              <Input
-                                readOnly
-                                type="email"
-                                value={(() => {
-                                  const list = Array.isArray(connectedBrands)
-                                    ? connectedBrands
-                                    : [];
-                                  const match = list.find(
-                                    (c: any) =>
-                                      String(c?.brand_id || "").trim() ===
-                                      String(selectedBrandId || "").trim(),
-                                  );
-                                  return String(
-                                    match?.brands?.email || "",
-                                  ).trim();
-                                })()}
-                                className="h-12 bg-gray-50 border border-gray-200 focus:border-indigo-600 focus:bg-white rounded-lg px-4 transition-all duration-300 font-medium"
-                              />
-                              <p className="text-xs text-gray-500 font-medium">
-                                Delivered via inbox (email is informational).
-                              </p>
-                            </div>
-                          </>
+                          (() => {
+                            const list = Array.isArray(connectedBrands) ? connectedBrands : [];
+                            const match = list.find(
+                              (c: any) => String(c?.brand_id || "").trim() === String(selectedBrandId || "").trim(),
+                            );
+                            const displayName = String(match?.brands?.company_name || "").trim() || String(match?.brands?.email || "").trim() || formData.client_name;
+                            const displayEmail = String(match?.brands?.email || "").trim() || formData.client_email;
+                            return (
+                              <>
+                                <div className="space-y-3">
+                                  <Label className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+                                    Client Contact
+                                  </Label>
+                                  <Input
+                                    readOnly
+                                    value={displayName}
+                                    className="h-12 bg-gray-50 border border-gray-200 rounded-lg px-4 font-medium text-gray-700 cursor-default"
+                                  />
+                                </div>
+                                <div className="space-y-3">
+                                  <Label className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+                                    Delivery Email
+                                  </Label>
+                                  <Input
+                                    readOnly
+                                    type="email"
+                                    value={displayEmail}
+                                    className="h-12 bg-gray-50 border border-gray-200 rounded-lg px-4 font-medium text-gray-700 cursor-default"
+                                  />
+                                  <p className="text-xs text-gray-500 font-medium">
+                                    Delivered via inbox (email is informational).
+                                  </p>
+                                </div>
+                              </>
+                            );
+                          })()
                         ) : (
                           <>
                             <div className="space-y-3">

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -643,7 +643,8 @@ export function CreatePackageWizard({
       ).trim();
       const selectedBrandEmail = String(
         selectedBrand?.brands?.email || "",
-      ).trim();      const selectedTalentIds = itemsArray
+      ).trim();
+      const selectedTalentIds = itemsArray
         .map((it: any) => String(it?.talent_id || it?.id || "").trim())
         .filter(Boolean);
 
@@ -671,7 +672,11 @@ export function CreatePackageWizard({
         // public-package actions can reuse it without prompting again.
         // Prefer formData values (editable by agency) over brand-derived values.
         client_email: selectedBrandEmail || formData.client_email,
-        client_name: selectedBrandName || selectedBrandEmail || formData.client_name || "Brand Portal",
+        client_name:
+          selectedBrandName ||
+          selectedBrandEmail ||
+          formData.client_name ||
+          "Brand Portal",
       };
 
       const offerPayload = {
@@ -698,9 +703,7 @@ export function CreatePackageWizard({
           consent_items: normalizedConsentItems,
           items: itemsArray.map((item: any) => ({
             talent_id: item.talent_id || item.id,
-            talent_name:
-              item?.talent?.full_name ||
-              item?.talent_name,
+            talent_name: item?.talent?.full_name || item?.talent_name,
             asset_ids: (item.assets || []).map((asset: any) => ({
               asset_id: asset.asset_id || asset.id,
               asset_type: asset.asset_type || asset.type || "image",
@@ -1376,12 +1379,23 @@ export function CreatePackageWizard({
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                         {isOfferMode ? (
                           (() => {
-                            const list = Array.isArray(connectedBrands) ? connectedBrands : [];
+                            const list = Array.isArray(connectedBrands)
+                              ? connectedBrands
+                              : [];
                             const match = list.find(
-                              (c: any) => String(c?.brand_id || "").trim() === String(selectedBrandId || "").trim(),
+                              (c: any) =>
+                                String(c?.brand_id || "").trim() ===
+                                String(selectedBrandId || "").trim(),
                             );
-                            const displayName = String(match?.brands?.company_name || "").trim() || String(match?.brands?.email || "").trim() || formData.client_name;
-                            const displayEmail = String(match?.brands?.email || "").trim() || formData.client_email;
+                            const displayName =
+                              String(
+                                match?.brands?.company_name || "",
+                              ).trim() ||
+                              String(match?.brands?.email || "").trim() ||
+                              formData.client_name;
+                            const displayEmail =
+                              String(match?.brands?.email || "").trim() ||
+                              formData.client_email;
                             return (
                               <>
                                 <div className="space-y-3">
@@ -1405,7 +1419,8 @@ export function CreatePackageWizard({
                                     className="h-12 bg-gray-50 border border-gray-200 rounded-lg px-4 font-medium text-gray-700 cursor-default"
                                   />
                                   <p className="text-xs text-gray-500 font-medium">
-                                    Delivered via inbox (email is informational).
+                                    Delivered via inbox (email is
+                                    informational).
                                   </p>
                                 </div>
                               </>

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -661,9 +661,6 @@ export function CreatePackageWizard({
           items: itemsArray.map((item: any) => ({
             talent_id: item.talent_id || item.id,
             talent_name:
-              item?.talent?.stage_name ||
-              item?.talent?.full_legal_name ||
-              item?.talent?.name ||
               item?.talent?.full_name ||
               item?.talent_name,
             asset_ids: (item.assets || []).map((asset: any) => ({
@@ -982,10 +979,7 @@ export function CreatePackageWizard({
                               full_name: item?.talent_name || "Talent",
                             };
                           const talentName = String(
-                            resolvedTalent?.stage_name ||
-                              resolvedTalent?.name ||
-                              resolvedTalent?.full_legal_name ||
-                              resolvedTalent?.full_name ||
+                            resolvedTalent?.full_name ||
                               item?.talent_name ||
                               "Talent",
                           ).trim();

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -660,7 +660,12 @@ export function CreatePackageWizard({
           consent_items: normalizedConsentItems,
           items: itemsArray.map((item: any) => ({
             talent_id: item.talent_id || item.id,
-            talent_name: item?.talent?.name || item?.talent?.full_name,
+            talent_name:
+              item?.talent?.stage_name ||
+              item?.talent?.full_legal_name ||
+              item?.talent?.name ||
+              item?.talent?.full_name ||
+              item?.talent_name,
             asset_ids: (item.assets || []).map((asset: any) => ({
               asset_id: asset.asset_id || asset.id,
               asset_type: asset.asset_type || asset.type || "image",

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -12639,7 +12639,15 @@ export default function BrandDashboard() {
                       .filter((item: any) =>
                         selectedIds.includes(String(item.talent_id || item.id)),
                       )
-                      .map((item: any) => item.talent_name || "Unnamed Talent");
+                      .map(
+                        (item: any) =>
+                          item.talent_name ||
+                          item?.talent?.stage_name ||
+                          item?.talent?.full_legal_name ||
+                          item?.talent?.full_name ||
+                          item?.talent?.name ||
+                          "Unnamed Talent",
+                      );
 
                     if (selectedNames.length === 0)
                       return (

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -12642,10 +12642,6 @@ export default function BrandDashboard() {
                       .map(
                         (item: any) =>
                           item.talent_name ||
-                          item?.talent?.stage_name ||
-                          item?.talent?.full_legal_name ||
-                          item?.talent?.full_name ||
-                          item?.talent?.name ||
                           "Unnamed Talent",
                       );
 

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -12639,11 +12639,7 @@ export default function BrandDashboard() {
                       .filter((item: any) =>
                         selectedIds.includes(String(item.talent_id || item.id)),
                       )
-                      .map(
-                        (item: any) =>
-                          item.talent_name ||
-                          "Unnamed Talent",
-                      );
+                      .map((item: any) => item.talent_name || "Unnamed Talent");
 
                     if (selectedNames.length === 0)
                       return (

--- a/likelee-ui/src/pages/PublicPackageView.tsx
+++ b/likelee-ui/src/pages/PublicPackageView.tsx
@@ -87,9 +87,6 @@ export function PublicPackageView() {
   const [passwordError, setPasswordError] = useState<string | null>(null);
 
   const [fullAssetsRequestOpen, setFullAssetsRequestOpen] = useState(false);
-  const [requestClientName, setRequestClientName] = useState("");
-  const [requestEmail, setRequestEmail] = useState("");
-  const [requestMessage, setRequestMessage] = useState("");
 
   const {
     data: packageData,
@@ -148,9 +145,6 @@ export function PublicPackageView() {
     }) => packageApi.createPublicPackageFullAssetsRequest(token!, data),
     onSuccess: () => {
       setFullAssetsRequestOpen(false);
-      setRequestClientName("");
-      setRequestEmail("");
-      setRequestMessage("");
       toast({
         title: "Request sent",
         description: "Your request has been sent to the agency.",
@@ -166,23 +160,15 @@ export function PublicPackageView() {
   });
 
   const submitFullAssetsRequest = () => {
-    if (!token) {
-      toast({
-        title: "Request failed",
-        description: "Missing package token.",
-        variant: "destructive",
-      });
-      return;
-    }
-    if (fullAssetsRequestMutation.isPending) return;
-
-    const name = requestClientName.trim();
-    const email = requestEmail.trim();
-    const message = requestMessage.trim();
+    if (!token || fullAssetsRequestMutation.isPending) return;
+    // Unwrap the package the same way `pkg` does — try .package, .data, then root
+    const d = packageData as any;
+    const unwrapped = d?.package || d?.data || d;
+    const clientName = String(unwrapped?.client_name || "").trim();
+    const clientEmail = String(unwrapped?.client_email || "").trim();
     fullAssetsRequestMutation.mutate({
-      client_name: name ? name : undefined,
-      client_email: email ? email : undefined,
-      message: message ? message : undefined,
+      client_name: clientName || undefined,
+      client_email: clientEmail || undefined,
     });
   };
 
@@ -1251,61 +1237,96 @@ export function PublicPackageView() {
         open={fullAssetsRequestOpen}
         onOpenChange={setFullAssetsRequestOpen}
       >
-        <DialogContent className="sm:max-w-[460px]">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Lock className="w-5 h-5" /> Request Full Assets
-            </DialogTitle>
-            <DialogDescription>
-              Send a request to the agency for full assets.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="request-client-name">Name (optional)</Label>
-              <Input
-                id="request-client-name"
-                placeholder="Your name"
-                value={requestClientName}
-                onChange={(e) => setRequestClientName(e.target.value)}
-                disabled={fullAssetsRequestMutation.isPending}
-              />
+        <DialogContent className="sm:max-w-[480px] p-0 overflow-hidden rounded-3xl border-0 shadow-2xl">
+          {/* Header */}
+          <div
+            className="px-8 pt-8 pb-6 text-white"
+            style={{
+              background: `linear-gradient(135deg, ${primaryColor} 0%, ${primaryColor}cc 100%)`,
+            }}
+          >
+            <div className="flex items-center gap-3 mb-3">
+              <div className="w-10 h-10 rounded-2xl bg-white/20 flex items-center justify-center">
+                <Lock className="w-5 h-5 text-white" />
+              </div>
+              <span className="text-xs font-black uppercase tracking-widest text-white/70">
+                Full Asset Access
+              </span>
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="request-email">Email (optional)</Label>
-              <Input
-                id="request-email"
-                type="email"
-                placeholder="client@company.com"
-                value={requestEmail}
-                onChange={(e) => setRequestEmail(e.target.value)}
-                disabled={fullAssetsRequestMutation.isPending}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="request-message">Message (optional)</Label>
-              <Textarea
-                id="request-message"
-                placeholder="Tell the agency what you need..."
-                value={requestMessage}
-                onChange={(e) => setRequestMessage(e.target.value)}
-                disabled={fullAssetsRequestMutation.isPending}
-              />
-            </div>
+            <h2 className="text-2xl font-black text-white leading-tight">
+              Request the complete package
+            </h2>
+            <p className="text-white/75 text-sm mt-1">
+              You're about to request access to all high-resolution assets in this package.
+            </p>
           </div>
 
-          <DialogFooter>
+          {/* Body */}
+          <div className="px-8 py-6 space-y-4 bg-white">
+            {[
+              {
+                icon: "📦",
+                title: "What you'll get",
+                body: "The agency will receive your request and share the full, uncompressed asset files directly with you.",
+              },
+              {
+                icon: "⚡",
+                title: "What happens next",
+                body: "You'll be contacted by the agency to discuss usage rights, licensing terms, and delivery.",
+              },
+              {
+                icon: "🔒",
+                title: "No commitment required",
+                body: "Sending a request is free and non-binding. It simply opens the conversation.",
+              },
+            ].map(({ icon, title, body }) => (
+              <div key={title} className="flex items-start gap-3">
+                <span className="text-xl mt-0.5">{icon}</span>
+                <div>
+                  <p className="text-sm font-bold text-gray-900">{title}</p>
+                  <p className="text-sm text-gray-500 leading-relaxed">{body}</p>
+                </div>
+              </div>
+            ))}
+
+            {/* Client identity — shown when the package knows who the recipient is */}
+            {(rawPackageData?.client_name || rawPackageData?.client_email) && (
+              <div className="mt-2 rounded-2xl bg-gray-50 border border-gray-100 px-4 py-3 flex items-center gap-3">
+                <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                  <User className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-black uppercase tracking-widest text-gray-400 mb-0.5">
+                    Sending as
+                  </p>
+                  {rawPackageData?.client_name && (
+                    <p className="text-sm font-bold text-gray-900 truncate">
+                      {rawPackageData.client_name}
+                    </p>
+                  )}
+                  {rawPackageData?.client_email && (
+                    <p className="text-xs text-gray-500 truncate">
+                      {rawPackageData.client_email}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="px-8 pb-8 pt-2 bg-white flex flex-col sm:flex-row gap-3">
             <Button
               variant="outline"
+              className="flex-1 rounded-2xl font-bold border-gray-200"
               onClick={() => setFullAssetsRequestOpen(false)}
               disabled={fullAssetsRequestMutation.isPending}
             >
               Cancel
             </Button>
             <Button
+              className="flex-1 rounded-2xl font-black text-white shadow-lg"
+              style={{ backgroundColor: primaryColor }}
               onClick={submitFullAssetsRequest}
               disabled={fullAssetsRequestMutation.isPending}
             >
@@ -1314,10 +1335,12 @@ export function PublicPackageView() {
                   <Loader2 className="h-4 w-4 animate-spin" /> Sending...
                 </span>
               ) : (
-                "Send Request"
+                <span className="flex items-center gap-2">
+                  <Send className="w-4 h-4" /> Confirm Request
+                </span>
               )}
             </Button>
-          </DialogFooter>
+          </div>
         </DialogContent>
       </Dialog>
 

--- a/likelee-ui/src/pages/PublicPackageView.tsx
+++ b/likelee-ui/src/pages/PublicPackageView.tsx
@@ -1257,7 +1257,8 @@ export function PublicPackageView() {
               Request the complete package
             </h2>
             <p className="text-white/75 text-sm mt-1">
-              You're about to request access to all high-resolution assets in this package.
+              You're about to request access to all high-resolution assets in
+              this package.
             </p>
           </div>
 
@@ -1284,7 +1285,9 @@ export function PublicPackageView() {
                 <span className="text-xl mt-0.5">{icon}</span>
                 <div>
                   <p className="text-sm font-bold text-gray-900">{title}</p>
-                  <p className="text-sm text-gray-500 leading-relaxed">{body}</p>
+                  <p className="text-sm text-gray-500 leading-relaxed">
+                    {body}
+                  </p>
                 </div>
               </div>
             ))}

--- a/supabase/migrations/2026-04-28_backfill_package_snapshot_talent_names.sql
+++ b/supabase/migrations/2026-04-28_backfill_package_snapshot_talent_names.sql
@@ -1,6 +1,14 @@
 -- Backfill talent_name into package_snapshot.items for all existing packages
 -- where talent_name is missing or empty, using the live agency_users data.
 -- After this migration runs, the server-side read-time backfill is no longer needed.
+--
+-- Guards:
+--   • Only touches rows where package_snapshot is a JSON object containing an
+--     'items' key whose value is a JSON array (skips nulls, non-objects, non-arrays).
+--   • Skips individual items whose talent_id is not a well-formed UUID by using
+--     a safe cast via a helper expression rather than a hard ::uuid cast.
+--   • Any item that cannot be resolved is left unchanged (COALESCE keeps the
+--     original value when the JOIN finds nothing).
 
 UPDATE public.campaign_offer_packages cop
 SET package_snapshot = jsonb_set(
@@ -9,22 +17,35 @@ SET package_snapshot = jsonb_set(
   (
     SELECT jsonb_agg(
       CASE
+        -- Item already has a non-empty talent_name — leave it alone.
         WHEN (item->>'talent_name') IS NOT NULL AND (item->>'talent_name') != ''
         THEN item
-        ELSE item || jsonb_build_object(
+        -- talent_id is present and looks like a UUID — try to resolve a name.
+        WHEN (item->>'talent_id') ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN item || jsonb_build_object(
           'talent_name',
           COALESCE(
             NULLIF(au.stage_name, ''),
             NULLIF(au.full_legal_name, ''),
-            'Unknown'
+            -- No match found — keep whatever was there (may be null/missing).
+            item->>'talent_name'
           )
         )
+        -- talent_id is absent or not a UUID — leave item untouched.
+        ELSE item
       END
     )
     FROM jsonb_array_elements(cop.package_snapshot->'items') AS item
     LEFT JOIN public.agency_users au
-      ON au.id = (item->>'talent_id')::uuid
+      ON (item->>'talent_id') ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+     AND au.id = (item->>'talent_id')::uuid
   )
 )
-WHERE cop.package_snapshot ? 'items'
+WHERE
+  -- package_snapshot must be a JSON object (not null, not an array, etc.)
+  jsonb_typeof(cop.package_snapshot) = 'object'
+  -- it must have an 'items' key
+  AND cop.package_snapshot ? 'items'
+  -- that key must be a non-empty JSON array
+  AND jsonb_typeof(cop.package_snapshot->'items') = 'array'
   AND jsonb_array_length(cop.package_snapshot->'items') > 0;

--- a/supabase/migrations/2026-04-28_backfill_package_snapshot_talent_names.sql
+++ b/supabase/migrations/2026-04-28_backfill_package_snapshot_talent_names.sql
@@ -1,0 +1,30 @@
+-- Backfill talent_name into package_snapshot.items for all existing packages
+-- where talent_name is missing or empty, using the live agency_users data.
+-- After this migration runs, the server-side read-time backfill is no longer needed.
+
+UPDATE public.campaign_offer_packages cop
+SET package_snapshot = jsonb_set(
+  cop.package_snapshot,
+  '{items}',
+  (
+    SELECT jsonb_agg(
+      CASE
+        WHEN (item->>'talent_name') IS NOT NULL AND (item->>'talent_name') != ''
+        THEN item
+        ELSE item || jsonb_build_object(
+          'talent_name',
+          COALESCE(
+            NULLIF(au.stage_name, ''),
+            NULLIF(au.full_legal_name, ''),
+            'Unknown'
+          )
+        )
+      END
+    )
+    FROM jsonb_array_elements(cop.package_snapshot->'items') AS item
+    LEFT JOIN public.agency_users au
+      ON au.id = (item->>'talent_id')::uuid
+  )
+)
+WHERE cop.package_snapshot ? 'items'
+  AND jsonb_array_length(cop.package_snapshot->'items') > 0;

--- a/supabase/migrations/2026-04-28_get_public_package_details_add_client_fields.sql
+++ b/supabase/migrations/2026-04-28_get_public_package_details_add_client_fields.sql
@@ -7,7 +7,10 @@ BEGIN;
 DROP FUNCTION IF EXISTS get_public_package_details(TEXT);
 
 CREATE OR REPLACE FUNCTION get_public_package_details(p_access_token TEXT)
-RETURNS JSONB AS $
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
 DECLARE
   result JSONB;
 BEGIN
@@ -120,6 +123,6 @@ BEGIN
 
   RETURN result;
 END;
-$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 COMMIT;

--- a/supabase/migrations/2026-04-28_get_public_package_details_add_client_fields.sql
+++ b/supabase/migrations/2026-04-28_get_public_package_details_add_client_fields.sql
@@ -1,0 +1,125 @@
+-- Expose client_name and client_email from the package row in the public
+-- package details response so the frontend can pre-fill the full assets
+-- request without asking the recipient to type anything.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS get_public_package_details(TEXT);
+
+CREATE OR REPLACE FUNCTION get_public_package_details(p_access_token TEXT)
+RETURNS JSONB AS $
+DECLARE
+  result JSONB;
+BEGIN
+  SELECT
+    jsonb_build_object(
+      'id', p.id,
+      'agency_id', p.agency_id,
+      'title', p.title,
+      'description', p.description,
+      'cover_image_url', p.cover_image_url,
+      'primary_color', p.primary_color,
+      'secondary_color', p.secondary_color,
+      'custom_message', p.custom_message,
+      'allow_comments', p.allow_comments,
+      'allow_favorites', p.allow_favorites,
+      'allow_callbacks', p.allow_callbacks,
+      'consent_items', COALESCE(p.consent_items, '[]'::jsonb),
+      'expires_at', p.expires_at,
+      'access_token', p.access_token,
+      'client_name', p.client_name,
+      'client_email', p.client_email,
+      'created_at', p.created_at,
+      'updated_at', p.updated_at,
+      'agency', (
+        SELECT jsonb_build_object('agency_name', a.agency_name, 'logo_url', a.logo_url)
+        FROM public.agencies a
+        WHERE a.id = p.agency_id
+      ),
+      'interactions', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'talent_id', i.talent_id,
+            'type', i.type,
+            'content', i.content,
+            'client_name', i.client_name,
+            'client_email', i.client_email,
+            'created_at', i.created_at
+          )
+        )
+        FROM public.agency_talent_package_interactions i
+        WHERE i.package_id = p.id
+      ), '[]'::jsonb),
+      'items', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', it.id,
+            'sort_order', it.sort_order,
+            'talent_id', it.talent_id,
+            'creator_id', it.creator_id,
+            'relationship_id', it.relationship_id,
+            'talent', COALESCE(
+              (
+                SELECT jsonb_build_object(
+                  'id', u.id,
+                  'stage_name', u.stage_name,
+                  'full_legal_name', u.full_legal_name,
+                  'full_name', NULL,
+                  'profile_photo_url', u.profile_photo_url,
+                  'bio_notes', u.bio_notes,
+                  'city', u.city,
+                  'race_ethnicity', u.race_ethnicity
+                )
+                FROM public.agency_users u
+                WHERE u.id = it.talent_id
+              ),
+              (
+                SELECT jsonb_build_object(
+                  'id', c.id,
+                  'stage_name', NULL,
+                  'full_legal_name', NULL,
+                  'full_name', c.full_name,
+                  'profile_photo_url', c.profile_photo_url,
+                  'bio_notes', NULL,
+                  'city', c.city,
+                  'race_ethnicity', c.race
+                )
+                FROM public.creators c
+                WHERE c.id = it.creator_id
+              )
+            ),
+            'assets', COALESCE((
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'id', pa.id,
+                  'asset_id', pa.asset_id,
+                  'asset_type', pa.asset_type,
+                  'sort_order', pa.sort_order,
+                  'asset', jsonb_build_object(
+                    'id', pa.asset_id,
+                    'asset_url', COALESCE(
+                      (SELECT public_url FROM public.agency_files WHERE id = pa.asset_id LIMIT 1),
+                      (SELECT public_url FROM public.reference_images WHERE id = pa.asset_id LIMIT 1)
+                    )
+                  )
+                )
+              )
+              FROM public.agency_talent_package_item_assets pa
+              WHERE pa.item_id = it.id
+            ), '[]'::jsonb)
+          )
+          ORDER BY it.sort_order
+        )
+        FROM public.agency_talent_package_items it
+        WHERE it.package_id = p.id
+      ), '[]'::jsonb)
+    )
+    INTO result
+  FROM public.agency_talent_packages p
+  WHERE p.access_token = p_access_token;
+
+  RETURN result;
+END;
+$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMIT;


### PR DESCRIPTION
closes #562 
closes #563

When a brand clicked "Mark Done" on an agency package, the confirmation dialog showed "Unnamed Talent" for all selected creators.

Root cause: CreatePackageWizard was reading talent.name/talent.full_name when building the snapshot, but agency_users stores names as stage_name/full_legal_name — so talent_name was always stored as null.

Fix:

- Frontend: corrected field names at write time for new packages
Server: list_brand_inbox_packages now extracts all talent_ids from package_snapshot.items, fetches names from agency_users in one batch query, and patches them into the response — backfilling all existing packages transparently at read time with no DB writes or schema changes		
-  asset request in campaign should be just a single button with a good hint message