### PR TITLE
Auto-Assignment, Package Selection Integrity & UX Improvements

### DIFF
--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5122,8 +5122,8 @@ pub async fn create_offer_package(
     // Normalise package_snapshot.items at write time: resolve talent_name from
     // agency_users so that the stored snapshot is always correct regardless of
     // which UI path created the package.
-    let package_snapshot =
-        normalize_package_snapshot_talent_names(&state, &user.id, payload.package_snapshot).await;
+    // The wizard already sets talent_name on each item, so we use the payload directly.
+    let package_snapshot = payload.package_snapshot.unwrap_or_else(|| json!({}));
 
     let insert_payload = json!({
         "offer_id": offer_id,

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -4972,6 +4972,132 @@ pub async fn delete_offer_contract(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Internal helper: insert a single talent assignment for an offer.
+///
+/// Called exclusively from `mark_brand_package_done` — assignments are always
+/// created automatically from the brand's package selection, never manually.
+///
+/// Returns the upserted assignment row on success.
+async fn insert_offer_talent_assignment_internal(
+    state: &AppState,
+    agency_id: &str,
+    offer_id: &str,
+    // Accepts any resolvable ID shape: agency_users.id, creator_id, or legacy roster id.
+    talent_id_or_creator_id: &str,
+) -> Result<serde_json::Value, (StatusCode, String)> {
+    let raw_id = talent_id_or_creator_id.trim();
+    if raw_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "talent_id is required".to_string()));
+    }
+
+    // Resolve to canonical agency_users row using the multi-shape resolver.
+    let talent = resolve_agency_talent(state, agency_id, raw_id).await?;
+
+    let canonical_talent_id = talent
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let creator_id = talent
+        .get("creator_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if creator_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "This talent must create a creator account before they can be assigned to a contract."
+                .to_string(),
+        ));
+    }
+
+    let insert_payload = json!({
+        "offer_id": offer_id,
+        "agency_id": agency_id,
+        "talent_id": if canonical_talent_id.is_empty() { serde_json::Value::Null } else { json!(canonical_talent_id) },
+        "creator_id": creator_id,
+        "status": "assigned",
+        "assigned_by": agency_id,
+        "meta": json!({}),
+    });
+
+    let resp = state
+        .pg
+        .from("offer_talent_assignments")
+        .upsert(insert_payload.to_string())
+        .on_conflict("offer_id,creator_id")
+        .select("*")
+        .single()
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !resp.status().is_success() {
+        let status_code = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+
+        // Backward-compat: if the UNIQUE index backing ON CONFLICT doesn't exist yet,
+        // fall back to read-then-insert.
+        if body.contains("42P10")
+            || body.contains("no unique or exclusion constraint matching the ON CONFLICT")
+        {
+            let existing_resp = state
+                .pg
+                .from("offer_talent_assignments")
+                .select("*")
+                .eq("offer_id", offer_id)
+                .eq("agency_id", agency_id)
+                .eq("creator_id", &creator_id)
+                .eq("status", "assigned")
+                .limit(1)
+                .execute()
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+            if existing_resp.status().is_success() {
+                let existing_text = existing_resp.text().await.unwrap_or_default();
+                let existing_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&existing_text).unwrap_or_default();
+                if let Some(row) = existing_rows.first().cloned() {
+                    return Ok(row);
+                }
+            }
+
+            let insert_only_resp = state
+                .pg
+                .from("offer_talent_assignments")
+                .insert(insert_payload.to_string())
+                .select("*")
+                .single()
+                .execute()
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+            if !insert_only_resp.status().is_success() {
+                return Err(sanitize_db_error(
+                    insert_only_resp.status().as_u16(),
+                    insert_only_resp.text().await.unwrap_or_default(),
+                ));
+            }
+
+            let row: serde_json::Value =
+                serde_json::from_str(&insert_only_resp.text().await.unwrap_or_default())
+                    .unwrap_or_default();
+            return Ok(row);
+        }
+
+        return Err(sanitize_db_error(status_code, body));
+    }
+
+    let row: serde_json::Value =
+        serde_json::from_str(&resp.text().await.unwrap_or_default()).unwrap_or_default();
+    Ok(row)
+}
+
 pub async fn create_offer_package(
     State(state): State<AppState>,
     user: AuthUser,
@@ -5143,13 +5269,15 @@ pub async fn mark_brand_package_done(
         return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
     }
     let now = chrono::Utc::now().to_rfc3339();
+
+    // Fetch the current package row to check status and read existing meta.
     let current_resp = state
         .pg
         .from("campaign_offer_packages")
         .eq("id", &payload.package_id)
         .eq("offer_id", &offer_id)
         .eq("brand_id", &user.id)
-        .select("meta")
+        .select("meta,status,agency_id")
         .single()
         .execute()
         .await
@@ -5157,14 +5285,48 @@ pub async fn mark_brand_package_done(
 
     let current_text = current_resp.text().await.unwrap_or_default();
     let current_row: serde_json::Value = serde_json::from_str(&current_text).unwrap_or_default();
+
+    // Idempotency guard: if the package is already finalized, reject re-submission.
+    // This prevents the brand from changing their selection after the agency has
+    // already seen it and started preparing the contract.
+    let current_status = current_row
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_lowercase();
+    if current_status == "feedback_received" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "package_already_finalized".to_string(),
+        ));
+    }
+
+    let agency_id = current_row
+        .get("agency_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
     let mut current_meta = current_row
         .get("meta")
         .cloned()
         .unwrap_or_else(|| json!({}));
 
+    // Collect selected_talent_ids before consuming payload.
+    let selected_talent_ids: Vec<String> = payload
+        .selected_talent_ids
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
     if let Some(obj) = current_meta.as_object_mut() {
-        if let Some(ids) = payload.selected_talent_ids {
-            obj.insert("selected_talent_ids".to_string(), json!(ids));
+        if !selected_talent_ids.is_empty() {
+            obj.insert("selected_talent_ids".to_string(), json!(selected_talent_ids));
         }
         if let Some(note) = payload
             .feedback_note
@@ -5205,8 +5367,49 @@ pub async fn mark_brand_package_done(
     if !status.is_success() {
         return Err(sanitize_db_error(status.as_u16(), text));
     }
-    let row: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
-    Ok(Json(json!({"status":"ok","package": row})))
+    let package_row: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+
+    // Auto-assign selected talents to the offer.
+    // This eliminates the redundant manual assignment step for the agency.
+    // Individual failures are non-fatal: we collect errors and continue so that
+    // a single unresolvable talent ID doesn't block the entire finalization.
+    let mut assignments: Vec<serde_json::Value> = Vec::new();
+    let mut assignment_errors: Vec<serde_json::Value> = Vec::new();
+
+    if !agency_id.is_empty() && !selected_talent_ids.is_empty() {
+        for talent_id in &selected_talent_ids {
+            match insert_offer_talent_assignment_internal(
+                &state,
+                &agency_id,
+                &offer_id,
+                talent_id,
+            )
+            .await
+            {
+                Ok(assignment) => assignments.push(assignment),
+                Err((_, reason)) => {
+                    warn!(
+                        offer_id = %offer_id,
+                        agency_id = %agency_id,
+                        talent_id = %talent_id,
+                        reason = %reason,
+                        "Auto-assignment failed for talent during package finalization"
+                    );
+                    assignment_errors.push(json!({
+                        "talent_id": talent_id,
+                        "reason": reason,
+                    }));
+                }
+            }
+        }
+    }
+
+    Ok(Json(json!({
+        "status": "ok",
+        "package": package_row,
+        "assignments": assignments,
+        "assignment_errors": assignment_errors,
+    })))
 }
 
 pub async fn list_agency_offer_packages(
@@ -5347,282 +5550,36 @@ pub async fn list_offer_talent_assignments(
         }
     }
 
-    Ok(Json(json!({ "assignments": rows })))
-}
-
-pub async fn create_offer_talent_assignment(
-    State(state): State<AppState>,
-    user: AuthUser,
-    Path(OfferPath { offer_id }): Path<OfferPath>,
-    Json(payload): Json<CreateOfferTalentAssignmentRequest>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if user.role != "agency" {
-        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
-    }
-    let offer = ensure_offer_access(&state, &user, &offer_id).await?;
-    let access = team::require_agency_access(&state, &user).await?;
-    let agency_id = &access.organization_id;
-    let offer_status = offer
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if offer_status == "contract_sent" || offer_status == "contract_fully_signed" {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "cannot_change_assignments_after_contract_sent".to_string(),
-        ));
-    }
-    let payment_status = offer
-        .get("payment_status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unpaid")
-        .trim()
-        .to_lowercase();
-    if payment_status != "unpaid" && !payment_status.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "cannot_change_assignments_after_payment_started".to_string(),
-        ));
-    }
-    let mut creator_id = payload
-        .creator_id
-        .as_deref()
-        .unwrap_or("")
-        .trim()
-        .to_string();
-    let mut canonical_talent_id = payload
-        .talent_id
-        .as_deref()
-        .unwrap_or("")
-        .trim()
-        .to_string();
-
-    if creator_id.is_empty() {
-        // Legacy/roster flow: resolve by talent_id (agency_users.id or alias id shapes).
-        canonical_talent_id = trim_non_empty(&canonical_talent_id, "talent_id")?;
-        let talent = resolve_agency_talent(&state, agency_id, &canonical_talent_id).await?;
-        canonical_talent_id = talent
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        creator_id = talent
-            .get("creator_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if creator_id.is_empty() {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "This talent must create a creator account before they can be assigned to a contract."
-                    .to_string(),
-            ));
-        }
-    } else {
-        // Creator-only assignment: ensure relationship exists OR creator is already on roster.
-        let rel_resp = state
+    // Assignments are always auto-populated from the brand's package selection.
+    // The is_locked flag tells the frontend that assignments exist and are read-only.
+    // Since there is no manual assignment path, is_locked is always true when
+    // assignments exist (they came from a finalized package by definition).
+    // We still query the package to be explicit and future-proof.
+    let is_locked = {
+        let pkg_resp = state
             .pg
-            .from("agency_talent_relationships")
-            .select("id,status")
-            .eq("agency_id", agency_id)
-            .eq("creator_id", &creator_id)
+            .from("campaign_offer_packages")
+            .select("id")
+            .eq("offer_id", &offer_id)
+            .eq("status", "feedback_received")
             .limit(1)
             .execute()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        if !rel_resp.status().is_success() {
-            return Err(sanitize_db_error(
-                rel_resp.status().as_u16(),
-                rel_resp.text().await.unwrap_or_default(),
-            ));
+            .await;
+        match pkg_resp {
+            Ok(r) if r.status().is_success() => {
+                let text = r.text().await.unwrap_or_default();
+                let rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&text).unwrap_or_default();
+                !rows.is_empty()
+            }
+            _ => false,
         }
-        let rel_text = rel_resp.text().await.unwrap_or_default();
-        let rel_rows: Vec<serde_json::Value> = serde_json::from_str(&rel_text).unwrap_or_default();
-        let rel_status = rel_rows
-            .first()
-            .and_then(|r| r.get("status"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        if rel_rows.is_empty() {
-            // Allow direct roster creators even if relationship row is missing.
-            let roster_resp = state
-                .pg
-                .from("agency_users")
-                .select("id")
-                .eq("agency_id", agency_id)
-                .eq("creator_id", &creator_id)
-                .limit(1)
-                .execute()
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-            if !roster_resp.status().is_success() {
-                return Err(sanitize_db_error(
-                    roster_resp.status().as_u16(),
-                    roster_resp.text().await.unwrap_or_default(),
-                ));
-            }
-            let roster_text = roster_resp.text().await.unwrap_or_default();
-            let roster_rows: Vec<serde_json::Value> =
-                serde_json::from_str(&roster_text).unwrap_or_default();
-            if roster_rows.is_empty() {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "creator is not linked to this agency".to_string(),
-                ));
-            }
-        } else if rel_status == "declined" || rel_status == "inactive" {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "creator is not linked to this agency".to_string(),
-            ));
-        }
-    }
-    let insert_payload = json!({
-        "offer_id": offer_id,
-        "agency_id": agency_id,
-        "talent_id": if canonical_talent_id.is_empty() { serde_json::Value::Null } else { json!(canonical_talent_id) },
-        "creator_id": creator_id,
-        "status": "assigned",
-        "assigned_by": user.id,
-        "meta": json!({}),
-    });
-    let resp = state
-        .pg
-        .from("offer_talent_assignments")
-        .upsert(insert_payload.to_string())
-        .on_conflict("offer_id,creator_id")
-        .select("*")
-        .single()
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    if !resp.status().is_success() {
-        let status_code = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        // Backward/partial-migration compatibility: if the UNIQUE index backing our ON CONFLICT
-        // does not exist yet, Postgres returns 42P10. In that case, fallback to a manual
-        // read-then-insert flow.
-        if body.contains("42P10")
-            || body.contains("no unique or exclusion constraint matching the ON CONFLICT")
-        {
-            let existing_resp = state
-                .pg
-                .from("offer_talent_assignments")
-                .select("*")
-                .eq("offer_id", &offer_id)
-                .eq("agency_id", agency_id)
-                .eq("creator_id", &creator_id)
-                .eq("status", "assigned")
-                .limit(1)
-                .execute()
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-            if existing_resp.status().is_success() {
-                let existing_text = existing_resp.text().await.unwrap_or_default();
-                let existing_rows: Vec<serde_json::Value> =
-                    serde_json::from_str(&existing_text).unwrap_or_default();
-                if let Some(row) = existing_rows.first().cloned() {
-                    return Ok(Json(json!({ "status": "ok", "assignment": row })));
-                }
-            }
+    };
 
-            let insert_only_resp = state
-                .pg
-                .from("offer_talent_assignments")
-                .insert(insert_payload.to_string())
-                .select("*")
-                .single()
-                .execute()
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-            if !insert_only_resp.status().is_success() {
-                return Err(sanitize_db_error(
-                    insert_only_resp.status().as_u16(),
-                    insert_only_resp.text().await.unwrap_or_default(),
-                ));
-            }
-            let row: serde_json::Value =
-                serde_json::from_str(&insert_only_resp.text().await.unwrap_or_default())
-                    .unwrap_or_default();
-            return Ok(Json(json!({ "status": "ok", "assignment": row })));
-        }
-
-        return Err(sanitize_db_error(status_code, body));
-    }
-    let row: serde_json::Value =
-        serde_json::from_str(&resp.text().await.unwrap_or_default()).unwrap_or_default();
-    Ok(Json(json!({ "status": "ok", "assignment": row })))
-}
-
-pub async fn delete_offer_talent_assignment(
-    State(state): State<AppState>,
-    user: AuthUser,
-    Path(OfferAssignmentPath {
-        offer_id,
-        assignment_id,
-    }): Path<OfferAssignmentPath>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    if user.role != "agency" {
-        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
-    }
-    let offer = ensure_offer_access(&state, &user, &offer_id).await?;
-    let access = team::require_agency_access(&state, &user).await?;
-    let agency_id = &access.organization_id;
-    let offer_status = offer
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if offer_status == "contract_sent" || offer_status == "contract_fully_signed" {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "cannot_change_assignments_after_contract_sent".to_string(),
-        ));
-    }
-    let payment_status = offer
-        .get("payment_status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unpaid")
-        .trim()
-        .to_lowercase();
-    if payment_status != "unpaid" && !payment_status.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "cannot_change_assignments_after_payment_started".to_string(),
-        ));
-    }
-    let resp = state
-        .pg
-        .from("offer_talent_assignments")
-        .eq("id", &assignment_id)
-        .eq("offer_id", &offer_id)
-        .eq("agency_id", agency_id)
-        .update(
-            json!({
-                "status": "removed",
-                "updated_at": chrono::Utc::now().to_rfc3339(),
-            })
-            .to_string(),
-        )
-        .select("*")
-        .single()
-        .execute()
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    if !resp.status().is_success() {
-        return Err(sanitize_db_error(
-            resp.status().as_u16(),
-            resp.text().await.unwrap_or_default(),
-        ));
-    }
-    let row: serde_json::Value =
-        serde_json::from_str(&resp.text().await.unwrap_or_default()).unwrap_or_default();
-    Ok(Json(json!({ "status": "ok", "assignment": row })))
+    Ok(Json(json!({
+        "assignments": rows,
+        "is_locked": is_locked,
+    })))
 }
 
 pub async fn list_offer_asset_requests(

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5341,13 +5341,8 @@ pub async fn mark_brand_package_done(
 
     if !agency_id.is_empty() && !selected_talent_ids.is_empty() {
         for talent_id in &selected_talent_ids {
-            match insert_offer_talent_assignment_internal(
-                &state,
-                &agency_id,
-                &offer_id,
-                talent_id,
-            )
-            .await
+            match insert_offer_talent_assignment_internal(&state, &agency_id, &offer_id, talent_id)
+                .await
             {
                 Ok(assignment) => assignments.push(assignment),
                 Err((_, reason)) => {

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5294,8 +5294,6 @@ pub async fn mark_brand_package_done(
     let current_row: serde_json::Value = serde_json::from_str(&current_text).unwrap_or_default();
 
     // Idempotency guard: if the package is already finalized, reject re-submission.
-    // This prevents the brand from changing their selection after the agency has
-    // already seen it and started preparing the contract.
     let current_status = current_row
         .get("status")
         .and_then(|v| v.as_str())
@@ -5316,11 +5314,6 @@ pub async fn mark_brand_package_done(
         .trim()
         .to_string();
 
-    let mut current_meta = current_row
-        .get("meta")
-        .cloned()
-        .unwrap_or_else(|| json!({}));
-
     // Collect selected_talent_ids before consuming payload.
     let selected_talent_ids: Vec<String> = payload
         .selected_talent_ids
@@ -5330,6 +5323,73 @@ pub async fn mark_brand_package_done(
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+
+    // -----------------------------------------------------------------------
+    // STEP 1: Run auto-assignments BEFORE finalizing the package.
+    //
+    // This is the critical ordering fix. Previously the package was finalized
+    // first and assignments ran after — if any assignment failed the offer was
+    // stuck: status = feedback_received, no offer_talent_assignments rows, no
+    // manual assignment route to repair it, and the contract gate blocked forever.
+    //
+    // Now: attempt all assignments first. If any fail, return the errors without
+    // touching the package status so the brand can correct the selection and retry.
+    // Only when all assignments succeed do we finalize the package.
+    // -----------------------------------------------------------------------
+    let mut assignments: Vec<serde_json::Value> = Vec::new();
+    let mut assignment_errors: Vec<serde_json::Value> = Vec::new();
+
+    if !agency_id.is_empty() && !selected_talent_ids.is_empty() {
+        for talent_id in &selected_talent_ids {
+            match insert_offer_talent_assignment_internal(
+                &state,
+                &agency_id,
+                &offer_id,
+                talent_id,
+            )
+            .await
+            {
+                Ok(assignment) => assignments.push(assignment),
+                Err((_, reason)) => {
+                    warn!(
+                        offer_id = %offer_id,
+                        agency_id = %agency_id,
+                        talent_id = %talent_id,
+                        reason = %reason,
+                        "Auto-assignment failed for talent during package finalization"
+                    );
+                    assignment_errors.push(json!({
+                        "talent_id": talent_id,
+                        "reason": reason,
+                    }));
+                }
+            }
+        }
+
+        // If any assignment failed, abort before finalizing the package.
+        // The package remains in its current status so the brand can retry
+        // after correcting the selection (e.g. removing un-onboarded talents).
+        if !assignment_errors.is_empty() {
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                serde_json::to_string(&json!({
+                    "error": "assignment_errors",
+                    "message": "One or more talents could not be assigned. The package was not finalized. Please review the errors and retry.",
+                    "assignment_errors": assignment_errors,
+                    "assignments_succeeded": assignments,
+                }))
+                .unwrap_or_else(|_| "assignment_errors".to_string()),
+            ));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // STEP 2: All assignments succeeded — now finalize the package.
+    // -----------------------------------------------------------------------
+    let mut current_meta = current_row
+        .get("meta")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
 
     if let Some(obj) = current_meta.as_object_mut() {
         if !selected_talent_ids.is_empty() {
@@ -5379,41 +5439,11 @@ pub async fn mark_brand_package_done(
     }
     let package_row: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
 
-    // Auto-assign selected talents to the offer.
-    // This eliminates the redundant manual assignment step for the agency.
-    // Individual failures are non-fatal: we collect errors and continue so that
-    // a single unresolvable talent ID doesn't block the entire finalization.
-    let mut assignments: Vec<serde_json::Value> = Vec::new();
-    let mut assignment_errors: Vec<serde_json::Value> = Vec::new();
-
-    if !agency_id.is_empty() && !selected_talent_ids.is_empty() {
-        for talent_id in &selected_talent_ids {
-            match insert_offer_talent_assignment_internal(&state, &agency_id, &offer_id, talent_id)
-                .await
-            {
-                Ok(assignment) => assignments.push(assignment),
-                Err((_, reason)) => {
-                    warn!(
-                        offer_id = %offer_id,
-                        agency_id = %agency_id,
-                        talent_id = %talent_id,
-                        reason = %reason,
-                        "Auto-assignment failed for talent during package finalization"
-                    );
-                    assignment_errors.push(json!({
-                        "talent_id": talent_id,
-                        "reason": reason,
-                    }));
-                }
-            }
-        }
-    }
-
     Ok(Json(json!({
         "status": "ok",
         "package": package_row,
         "assignments": assignments,
-        "assignment_errors": assignment_errors,
+        "assignment_errors": [],
     })))
 }
 

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5326,7 +5326,10 @@ pub async fn mark_brand_package_done(
 
     if let Some(obj) = current_meta.as_object_mut() {
         if !selected_talent_ids.is_empty() {
-            obj.insert("selected_talent_ids".to_string(), json!(selected_talent_ids));
+            obj.insert(
+                "selected_talent_ids".to_string(),
+                json!(selected_talent_ids),
+            );
         }
         if let Some(note) = payload
             .feedback_note
@@ -5378,13 +5381,8 @@ pub async fn mark_brand_package_done(
 
     if !agency_id.is_empty() && !selected_talent_ids.is_empty() {
         for talent_id in &selected_talent_ids {
-            match insert_offer_talent_assignment_internal(
-                &state,
-                &agency_id,
-                &offer_id,
-                talent_id,
-            )
-            .await
+            match insert_offer_talent_assignment_internal(&state, &agency_id, &offer_id, talent_id)
+                .await
             {
                 Ok(assignment) => assignments.push(assignment),
                 Err((_, reason)) => {
@@ -5568,8 +5566,7 @@ pub async fn list_offer_talent_assignments(
         match pkg_resp {
             Ok(r) if r.status().is_success() => {
                 let text = r.text().await.unwrap_or_default();
-                let rows: Vec<serde_json::Value> =
-                    serde_json::from_str(&text).unwrap_or_default();
+                let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
                 !rows.is_empty()
             }
             _ => false,

--- a/likelee-server/src/router.rs
+++ b/likelee-server/src/router.rs
@@ -1042,12 +1042,7 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route(
             "/api/campaign-offers/:offer_id/assignments",
-            get(crate::brand_campaigns::list_offer_talent_assignments)
-                .post(crate::brand_campaigns::create_offer_talent_assignment),
-        )
-        .route(
-            "/api/campaign-offers/:offer_id/assignments/:assignment_id",
-            delete(crate::brand_campaigns::delete_offer_talent_assignment),
+            get(crate::brand_campaigns::list_offer_talent_assignments),
         )
         .route(
             "/api/campaign-offers/:offer_id/asset-requests",

--- a/likelee-ui/package-lock.json
+++ b/likelee-ui/package-lock.json
@@ -39,7 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@stripe/react-stripe-js": "^6.2.0",
-        "@stripe/stripe-js": "^9.3.0",
+        "@stripe/stripe-js": "9.3.1",
         "@supabase/supabase-js": "^2.46.2",
         "@tanstack/react-query": "^5.90.9",
         "@tiptap/extension-link": "^2.26.1",
@@ -219,6 +219,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -313,6 +314,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1687,6 +1689,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3801,6 +3804,8 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.3.1.tgz",
       "integrity": "sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -4046,6 +4051,7 @@
     "node_modules/@tiptap/core": {
       "version": "2.27.2",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4316,6 +4322,7 @@
     "node_modules/@tiptap/pm": {
       "version": "2.27.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4422,13 +4429,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4507,9 +4514,6 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/@types/deep-eql": {
-      "dev": true
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "license": "MIT"
@@ -4556,6 +4560,7 @@
     "node_modules/@types/node": {
       "version": "22.19.17",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4586,6 +4591,7 @@
       "version": "18.3.28",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4595,6 +4601,7 @@
       "version": "18.3.7",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4685,6 +4692,7 @@
       "version": "8.59.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -5219,6 +5227,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5638,6 +5647,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6154,6 +6164,7 @@
     "node_modules/date-fns": {
       "version": "3.6.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6247,7 +6258,8 @@
     },
     "node_modules/dexie": {
       "version": "4.4.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/dexie-react-hooks": {
       "version": "4.4.0",
@@ -6292,8 +6304,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6342,7 +6353,8 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7014,6 +7026,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7805,6 +7818,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -7842,16 +7856,6 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "license": "MIT"
-    },
-    "node_modules/immer": {
-      "version": "9.0.6",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -8332,6 +8336,7 @@
     "node_modules/jiti": {
       "version": "1.21.7",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8420,6 +8425,7 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -8737,7 +8743,8 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.4",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
@@ -8857,7 +8864,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9348,6 +9354,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9529,7 +9536,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9544,7 +9550,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9556,8 +9561,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -9662,6 +9666,7 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9685,6 +9690,7 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9725,6 +9731,7 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9927,6 +9934,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9949,6 +9957,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9960,6 +9969,7 @@
     "node_modules/react-hook-form": {
       "version": "7.74.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10003,6 +10013,7 @@
     "node_modules/react-leaflet": {
       "version": "4.2.1",
       "license": "Hippocratic-2.1",
+      "peer": true,
       "dependencies": {
         "@react-leaflet/core": "^2.1.0"
       },
@@ -10380,6 +10391,7 @@
     "node_modules/rollup": {
       "version": "4.60.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11668,6 +11680,7 @@
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11834,6 +11847,7 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12023,6 +12037,7 @@
       "version": "5.6.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12278,6 +12293,7 @@
     "node_modules/vite": {
       "version": "6.4.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12406,6 +12422,7 @@
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12418,6 +12435,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -12825,6 +12843,7 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/likelee-ui/package.json
+++ b/likelee-ui/package.json
@@ -44,7 +44,7 @@
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@stripe/react-stripe-js": "^6.2.0",
-    "@stripe/stripe-js": "^9.3.0",
+    "@stripe/stripe-js": "9.3.1",
     "@supabase/supabase-js": "^2.46.2",
     "@tanstack/react-query": "^5.90.9",
     "@tiptap/extension-link": "^2.26.1",

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -47,6 +47,7 @@ import {
   Lock,
   Mail,
   UserX,
+  Clock,
 } from "lucide-react";
 import { CampaignBriefView } from "@/components/campaign-offers/CampaignBriefView";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -112,7 +113,11 @@ const extractDeliverableCount = (value: unknown): number => {
   return counted > 0 ? counted : lines.length;
 };
 
-const BrandConnectionsView = () => {
+const BrandConnectionsView = ({
+  onMessageTalent,
+}: {
+  onMessageTalent?: (creatorId: string) => void;
+}) => {
   const { toast } = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -149,26 +154,6 @@ const BrandConnectionsView = () => {
   );
   const [isUploading, setIsUploading] = useState(false);
   const [contractTab, setContractTab] = useState("submissions");
-  const [assignDialog, setAssignDialog] = useState<{
-    open: boolean;
-    offerId: string;
-    talentId: string;
-  }>({ open: false, offerId: "", talentId: "" });
-  const [assignSearch, setAssignSearch] = useState("");
-  const [assignSelectedIds, setAssignSelectedIds] = useState<string[]>([]);
-  const [assignSubmitting, setAssignSubmitting] = useState(false);
-  const [inviteRequiredDialog, setInviteRequiredDialog] = useState<{
-    open: boolean;
-    talentName: string;
-    talentId: string;
-  }>({ open: false, talentName: "", talentId: "" });
-  const [assignConfirmOpen, setAssignConfirmOpen] = useState(false);
-  const [unassignConfirm, setUnassignConfirm] = useState<{
-    open: boolean;
-    offerId: string;
-    assignmentId: string;
-    talentName: string;
-  }>({ open: false, offerId: "", assignmentId: "", talentName: "" });
   const [messageDialog, setMessageDialog] = useState<{
     open: boolean;
     offerId: string;
@@ -350,10 +335,15 @@ const BrandConnectionsView = () => {
     queryKey: ["agency", "offer-assignments", selectedOfferId],
     enabled: !!selectedOfferId,
     queryFn: async () => {
-      const resp = await base44.get<{ assignments?: any[] }>(
+      const resp = await base44.get<{ assignments?: any[]; is_locked?: boolean }>(
         `/api/campaign-offers/${selectedOfferId}/assignments`,
       );
-      return Array.isArray(resp?.assignments) ? resp.assignments : [];
+      return {
+        assignments: Array.isArray(resp?.assignments) ? resp.assignments : [],
+        // is_locked is true when the brand has finalized their package selection.
+        // When true, assignments are immutable and the agency sees a read-only view.
+        is_locked: Boolean(resp?.is_locked),
+      };
     },
   });
   const requests = useMemo(() => {
@@ -373,21 +363,10 @@ const BrandConnectionsView = () => {
     if (!Array.isArray(rosterQuery.data)) return [];
     return rosterQuery.data;
   }, [rosterQuery.data]);
-  const filteredRoster = useMemo(() => {
-    const q = assignSearch.trim().toLowerCase();
-    if (!q) return roster;
-    return roster.filter((t: any) => {
-      const name = String(
-        t?.stage_name || t?.name || t?.full_legal_name || "",
-      ).toLowerCase();
-      const email = String(t?.email || "").toLowerCase();
-      return name.includes(q) || email.includes(q);
-    });
-  }, [assignSearch, roster]);
   const assignedTalentIds = useMemo(() => {
+    const assignments = offerAssignmentsQuery.data?.assignments || [];
     return new Set(
-      (offerAssignmentsQuery.data || []).map((a: any) =>
-        // Offer assignments are creator-first; talent_id is a legacy fallback.
+      assignments.map((a: any) =>
         String(
           a?.creator_id || a?.agency_users?.creator_id || a?.talent_id || "",
         ),
@@ -400,12 +379,12 @@ const BrandConnectionsView = () => {
   }, [feedbackQuery.data]);
 
   const hasAssignedTalent = useMemo(
-    () => (offerAssignmentsQuery.data || []).length > 0,
+    () => (offerAssignmentsQuery.data?.assignments || []).length > 0,
     [offerAssignmentsQuery.data],
   );
   const selectedOfferLockInfo = useMemo(() => {
     const offerId = String(selectedOfferId || "").trim();
-    if (!offerId) return { locked: false, contractSigned: false };
+    if (!offerId) return { locked: false, contractSigned: false, packageFinalized: false };
     const offer = (offers || []).find(
       (o: any) => String(o?.id || "") === offerId,
     );
@@ -416,14 +395,19 @@ const BrandConnectionsView = () => {
       .trim()
       .toLowerCase();
     const contractSigned = status === "contract_fully_signed";
+    // Package finalized = brand has selected talents from the agency's package.
+    // Assignments are immutable from this point forward.
+    const packageFinalized = Boolean(offerAssignmentsQuery.data?.is_locked);
     const locked =
+      packageFinalized ||
       (pay !== "unpaid" && pay !== "") ||
       status === "contract_sent" ||
       contractSigned;
-    return { locked, contractSigned };
-  }, [offers, selectedOfferId]);
+    return { locked, contractSigned, packageFinalized };
+  }, [offers, selectedOfferId, offerAssignmentsQuery.data]);
   const assignmentLockedForSelectedOffer = selectedOfferLockInfo.locked;
   const selectedOfferContractSigned = selectedOfferLockInfo.contractSigned;
+  const selectedOfferPackageFinalized = selectedOfferLockInfo.packageFinalized;
 
   const agencyPayoutAccountStatusQuery = useQuery({
     queryKey: ["agency", "payouts", "account_status"],
@@ -582,21 +566,6 @@ const BrandConnectionsView = () => {
     return "";
   }, [busyIds, currentContractId, selectedOfferId]);
 
-  const assignmentLockedForOffer = useMemo(() => {
-    const offerId = assignDialog.offerId;
-    if (!offerId) return false;
-    const offer = (offers || []).find(
-      (o: any) => String(o?.id || "") === offerId,
-    );
-    const status = String(offer?.status || "")
-      .trim()
-      .toLowerCase();
-    const pay = String(offer?.payment_status || "unpaid")
-      .trim()
-      .toLowerCase();
-    if (pay !== "unpaid" && pay !== "") return true;
-    return status === "contract_sent" || status === "contract_fully_signed";
-  }, [assignDialog.offerId, offers]);
   const getTalentAvatar = (t: any) => {
     if (!t) return "";
     if (t.img) return t.img;
@@ -650,135 +619,6 @@ const BrandConnectionsView = () => {
         const next = new Set(prev);
         next.delete(id);
         return next;
-      });
-    }
-  };
-
-  const handleAssignTalents = async () => {
-    if (!assignDialog.offerId) return;
-    if (assignSubmitting) return;
-    if (assignmentLockedForOffer) {
-      toast({
-        title: "Assignments locked",
-        description:
-          "You can change assigned talents before the contract is sent. This offer is already sent, so assignments can’t be changed.",
-        variant: "destructive",
-      });
-      return;
-    }
-    setAssignSubmitting(true);
-    try {
-      const offerId = assignDialog.offerId;
-      const current = Array.isArray(offerAssignmentsQuery.data)
-        ? offerAssignmentsQuery.data
-        : [];
-      const currentByCreatorId = new Map<string, string>();
-      current.forEach((a: any) => {
-        const creatorScopedId = String(
-          a?.creator_id || a?.agency_users?.creator_id || a?.talent_id || "",
-        ).trim();
-        const aid = String(a?.id || "").trim();
-        if (creatorScopedId && aid)
-          currentByCreatorId.set(creatorScopedId, aid);
-      });
-
-      const desiredIds = new Set(
-        assignSelectedIds.map((id) => String(id || "").trim()).filter(Boolean),
-      );
-      const currentIds = new Set([...currentByCreatorId.keys()]);
-      const toAdd = [...desiredIds].filter((id) => !currentIds.has(id));
-      const toRemove = [...currentIds].filter((id) => !desiredIds.has(id));
-
-      if (toAdd.length === 0 && toRemove.length === 0) {
-        toast({
-          title: "No changes",
-          description: "Talent assignments are already up to date.",
-        });
-        setAssignDialog({ open: false, offerId: "", talentId: "" });
-        setAssignSelectedIds([]);
-        setAssignSearch("");
-        return;
-      }
-
-      await Promise.all([
-        ...toAdd.map((creatorId) =>
-          base44.post(`/api/campaign-offers/${offerId}/assignments`, {
-            creator_id: creatorId,
-          }),
-        ),
-        ...toRemove.map((creatorId) => {
-          const assignmentId = currentByCreatorId.get(creatorId);
-          if (!assignmentId) return Promise.resolve(null);
-          return base44.delete(
-            `/api/campaign-offers/${offerId}/assignments/${assignmentId}`,
-          );
-        }),
-      ]);
-      queryClient.invalidateQueries({
-        queryKey: ["agency", "offer-assignments", assignDialog.offerId],
-      });
-      setAssignDialog({ open: false, offerId: "", talentId: "" });
-      setAssignSelectedIds([]);
-      setAssignSearch("");
-      toast({
-        title: "Assignments updated",
-        description: "Talent assignments saved successfully.",
-      });
-    } catch (e: any) {
-      const msg = String(e?.message || "");
-      toast({
-        title: "Assignment failed",
-        description: msg.includes(
-          "cannot_change_assignments_after_contract_sent",
-        )
-          ? "You can’t change assigned talents after the contract is sent."
-          : msg || "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setAssignSubmitting(false);
-    }
-  };
-
-  const handleUnassignTalent = async () => {
-    const offerId = String(unassignConfirm.offerId || "").trim();
-    const assignmentId = String(unassignConfirm.assignmentId || "").trim();
-    if (!offerId || !assignmentId) return;
-    if (assignmentLockedForSelectedOffer) {
-      toast({
-        title: "Assignments locked",
-        description: selectedOfferContractSigned
-          ? "Contract is already signed and you can’t change assigned talents."
-          : "You can’t unassign talent after the contract is sent.",
-        variant: "destructive",
-      });
-      return;
-    }
-    setAssignSubmitting(true);
-    try {
-      await base44.delete(
-        `/api/campaign-offers/${encodeURIComponent(offerId)}/assignments/${encodeURIComponent(assignmentId)}`,
-      );
-      queryClient.invalidateQueries({
-        queryKey: ["agency", "offer-assignments", offerId],
-      });
-      toast({
-        title: "Talent unassigned",
-        description: "Talent was removed from this offer.",
-      });
-    } catch (e: any) {
-      toast({
-        title: "Unassign failed",
-        description: e?.message || "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setAssignSubmitting(false);
-      setUnassignConfirm({
-        open: false,
-        offerId: "",
-        assignmentId: "",
-        talentName: "",
       });
     }
   };
@@ -1840,46 +1680,6 @@ const BrandConnectionsView = () => {
                                 </span>
                               </div>
                             )}
-                          {(() => {
-                            const pay = String(
-                              offer?.payment_status || "unpaid",
-                            ).toLowerCase();
-                            const canEdit =
-                              pay !== "processing" &&
-                              pay !== "paid" &&
-                              !assignmentLockedForSelectedOffer;
-                            return (
-                              <Button
-                                variant="outline"
-                                className="bg-white border-indigo-200 text-indigo-700 font-bold h-8 sm:h-10 text-xs sm:text-sm"
-                                disabled={!canEdit}
-                                onClick={() =>
-                                  setAssignDialog({
-                                    open: true,
-                                    offerId: selectedOfferId,
-                                    talentId: "",
-                                  })
-                                }
-                                title={
-                                  assignmentLockedForSelectedOffer
-                                    ? selectedOfferContractSigned
-                                      ? "Contract is already signed. Assigned talents can’t be changed."
-                                      : "Assignments are locked after the contract is sent."
-                                    : undefined
-                                }
-                              >
-                                <User className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1.5 sm:mr-2" />
-                                Assign Talent
-                              </Button>
-                            );
-                          })()}
-                          {assignmentLockedForSelectedOffer && (
-                            <p className="text-[10px] sm:text-xs text-gray-500">
-                              {selectedOfferContractSigned
-                                ? "Contract is already signed."
-                                : "Assignments are locked."}
-                            </p>
-                          )}
                         </div>
 
                         <div className="rounded-xl border border-indigo-100 bg-white p-3 sm:p-4 space-y-3">
@@ -1888,85 +1688,95 @@ const BrandConnectionsView = () => {
                               Assigned Talent
                             </p>
                           </div>
-                          {(offerAssignmentsQuery.data || []).length === 0 ? (
-                            <p className="text-xs text-gray-500">
-                              Assign at least 1 talent before preparing/sending
-                              the contract and before the brand can pay.
-                            </p>
-                          ) : (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                              {(offerAssignmentsQuery.data || []).map(
-                                (a: any) => {
-                                  const talent = a?.agency_users || {};
-                                  const tid = String(a?.talent_id || "");
-                                  const assignmentId = String(a?.id || "");
-                                  return (
-                                    <div
-                                      key={String(a?.id)}
-                                      className="border border-gray-200 rounded-lg p-3 flex items-center justify-between gap-3"
-                                    >
-                                      <div className="flex items-center gap-3">
-                                        <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
-                                          <User className="h-4 w-4 text-gray-500" />
-                                        </div>
-                                        <div>
-                                          <p className="text-sm font-semibold text-gray-900">
-                                            {talent?.stage_name ||
-                                              talent?.full_legal_name ||
-                                              "Talent"}
-                                          </p>
-                                          <p className="text-xs text-gray-500">
-                                            Assigned
-                                          </p>
-                                        </div>
-                                      </div>
-                                      <div className="flex items-center gap-2">
-                                        {!assignmentLockedForSelectedOffer ? (
-                                          <Button
-                                            size="icon"
-                                            variant="outline"
-                                            className="h-9 w-9"
-                                            title="Unassign talent"
-                                            disabled={assignSubmitting}
-                                            onClick={(e) => {
-                                              e.preventDefault();
-                                              e.stopPropagation();
-                                              setUnassignConfirm({
-                                                open: true,
-                                                offerId: selectedOfferId,
-                                                assignmentId,
-                                                talentName:
-                                                  talent?.stage_name ||
-                                                  talent?.full_legal_name ||
-                                                  "Talent",
-                                              });
-                                            }}
-                                          >
-                                            <X className="h-4 w-4" />
-                                          </Button>
-                                        ) : null}
-                                        <Button
-                                          size="sm"
-                                          variant="outline"
-                                          onClick={() =>
-                                            setMessageDialog({
-                                              open: true,
-                                              offerId: selectedOfferId,
-                                              talentId: tid,
-                                              title: "",
-                                              message: "",
-                                              file: null,
-                                              sending: false,
-                                            })
-                                          }
+                          {selectedOfferPackageFinalized ? (
+                            <>
+                              <div className="flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-lg">
+                                <Lock className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
+                                <p className="text-xs font-semibold text-indigo-800">
+                                  The brand has reviewed your package and finalized their talent selection. These talents are automatically assigned to the contract.
+                                </p>
+                              </div>
+                              {(offerAssignmentsQuery.data?.assignments || []).length === 0 ? (
+                                <p className="text-xs text-gray-500">
+                                  No talents were auto-assigned. Contact support if this is unexpected.
+                                </p>
+                              ) : (
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                  {(offerAssignmentsQuery.data?.assignments || []).map(
+                                    (a: any) => {
+                                      const talent = a?.agency_users || {};
+                                      const tid = String(a?.talent_id || "");
+                                      const assignmentId = String(a?.id || "");
+                                      const creatorId = String(
+                                        a?.creator_id ||
+                                          a?.agency_users?.creator_id ||
+                                          "",
+                                      ).trim();
+                                      return (
+                                        <div
+                                          key={String(a?.id)}
+                                          className="border border-gray-200 rounded-lg p-3 flex items-center justify-between gap-3"
                                         >
-                                          Send Message
-                                        </Button>
-                                      </div>
-                                    </div>
-                                  );
-                                },
+                                          <div className="flex items-center gap-3">
+                                            <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
+                                              <User className="h-4 w-4 text-gray-500" />
+                                            </div>
+                                            <div>
+                                              <p className="text-sm font-semibold text-gray-900">
+                                                {talent?.stage_name ||
+                                                  talent?.full_legal_name ||
+                                                  "Talent"}
+                                              </p>
+                                              <p className="text-xs text-green-600 font-medium">
+                                                Selected by brand
+                                              </p>
+                                            </div>
+                                          </div>
+                                          <div className="flex items-center gap-2">
+                                            <Button
+                                              size="sm"
+                                              variant="outline"
+                                              onClick={() => {
+                                                if (creatorId && onMessageTalent) {
+                                                  onMessageTalent(creatorId);
+                                                } else {
+                                                  // Fallback: open asset request dialog
+                                                  setMessageDialog({
+                                                    open: true,
+                                                    offerId: selectedOfferId,
+                                                    talentId: tid,
+                                                    title: "",
+                                                    message: "",
+                                                    file: null,
+                                                    sending: false,
+                                                  });
+                                                }
+                                              }}
+                                            >
+                                              Send Message
+                                            </Button>
+                                          </div>
+                                        </div>
+                                      );
+                                    },
+                                  )}
+                                </div>
                               )}
+                            </>
+                          ) : (
+                            // Package sent but brand hasn't reviewed yet
+                            <div className="flex flex-col items-center gap-3 py-4 px-3 bg-amber-50 border border-amber-200 rounded-lg text-center">
+                              <div className="w-9 h-9 rounded-full bg-amber-100 flex items-center justify-center">
+                                <Clock className="h-4 w-4 text-amber-600" />
+                              </div>
+                              <div>
+                                <p className="text-sm font-bold text-amber-900">
+                                  Waiting for brand to select talents
+                                </p>
+                                <p className="text-xs text-amber-700 mt-1">
+                                  The brand will review your package and choose which talents they want. Once they confirm their selection, the talents will be automatically assigned here and you can proceed to create the contract.
+                                </p>
+                              </div>
                             </div>
                           )}
                         </div>
@@ -2169,28 +1979,100 @@ const BrandConnectionsView = () => {
                                 if (offerPkg) {
                                   const token =
                                     offerPkg.meta?.agency_package_token;
+                                  const isFinalized =
+                                    offerPkg.status === "feedback_received";
+                                  // Resolve selected talent names from the package
+                                  const selectedIds: string[] = Array.isArray(
+                                    offerPkg.meta?.selected_talent_ids,
+                                  )
+                                    ? offerPkg.meta.selected_talent_ids.map(
+                                        (id: any) => String(id || "").trim(),
+                                      ).filter(Boolean)
+                                    : [];
+                                  const pkgItems: any[] = Array.isArray(
+                                    offerPkg.package_snapshot?.items,
+                                  )
+                                    ? offerPkg.package_snapshot.items
+                                    : [];
+                                  const selectedTalentNames = pkgItems
+                                    .filter((item: any) => {
+                                      const id = String(
+                                        item?.talent_id || item?.id || "",
+                                      ).trim();
+                                      return id && selectedIds.includes(id);
+                                    })
+                                    .map(
+                                      (item: any) =>
+                                        item?.talent_name ||
+                                        item?.talent?.stage_name ||
+                                        item?.talent?.full_legal_name ||
+                                        item?.talent?.full_name ||
+                                        "Talent",
+                                    );
+
                                   return (
-                                    <div className="flex items-center gap-2">
-                                      <Badge className="bg-emerald-50 text-emerald-700 border-emerald-200 flex items-center gap-1.5 px-3 py-1">
-                                        <CheckCircle2 className="h-3 w-3" />
-                                        Package Sent
-                                      </Badge>
-                                      {token && (
-                                        <Button
-                                          size="sm"
-                                          variant="outline"
-                                          className="font-bold text-xs"
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            window.open(
-                                              `/share/package/${token}`,
-                                              "_blank",
-                                            );
-                                          }}
-                                        >
-                                          View Package
-                                        </Button>
-                                      )}
+                                    <div className="flex flex-col gap-2 w-full">
+                                      <div className="flex items-center gap-2 flex-wrap">
+                                        {isFinalized ? (
+                                          <Badge className="bg-indigo-100 text-indigo-800 border-indigo-200 flex items-center gap-1.5 px-3 py-1">
+                                            <Lock className="h-3 w-3" />
+                                            Brand Selected Talents
+                                          </Badge>
+                                        ) : (
+                                          <Badge className="bg-emerald-50 text-emerald-700 border-emerald-200 flex items-center gap-1.5 px-3 py-1">
+                                            <CheckCircle2 className="h-3 w-3" />
+                                            Package Sent — Awaiting Brand Review
+                                          </Badge>
+                                        )}
+                                        {token && !isFinalized && (
+                                          <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="font-bold text-xs"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              window.open(
+                                                `/share/package/${token}`,
+                                                "_blank",
+                                              );
+                                            }}
+                                          >
+                                            View Package
+                                          </Button>
+                                        )}
+                                      </div>
+                                      {isFinalized &&
+                                        selectedTalentNames.length > 0 && (
+                                          <div className="flex flex-wrap gap-1.5 mt-1">
+                                            {selectedTalentNames.map(
+                                              (name: string, idx: number) => (
+                                                <span
+                                                  key={idx}
+                                                  className="inline-flex items-center gap-1 bg-indigo-50 border border-indigo-200 text-indigo-800 text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                                                >
+                                                  <CheckCircle2 className="h-2.5 w-2.5 text-indigo-600" />
+                                                  {name}
+                                                </span>
+                                              ),
+                                            )}
+                                            <button
+                                              className="text-[11px] font-bold text-indigo-600 underline underline-offset-2 ml-1"
+                                              onClick={(e) => {
+                                                e.stopPropagation();
+                                                setSelectedOfferId(offerId);
+                                              }}
+                                            >
+                                              View details →
+                                            </button>
+                                          </div>
+                                        )}
+                                      {isFinalized &&
+                                        selectedTalentNames.length === 0 && (
+                                          <p className="text-[11px] text-indigo-700 font-medium">
+                                            Open offer details to see assigned
+                                            talents.
+                                          </p>
+                                        )}
                                     </div>
                                   );
                                 }
@@ -2217,24 +2099,6 @@ const BrandConnectionsView = () => {
                                   </Button>
                                 );
                               })()}
-                            {isFullySigned && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="border-indigo-200 text-indigo-700 font-bold"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setAssignDialog({
-                                    open: true,
-                                    offerId,
-                                    talentId: "",
-                                  });
-                                }}
-                              >
-                                <User className="h-4 w-4 mr-2" />
-                                Assign Talent
-                              </Button>
-                            )}
                           </div>
                         </div>
 
@@ -3115,298 +2979,6 @@ const BrandConnectionsView = () => {
         </Card>
       )}
 
-      <Dialog
-        open={assignDialog.open}
-        onOpenChange={(open) => {
-          setAssignDialog((prev) => ({ ...prev, open }));
-          if (open) {
-            // Preselect currently assigned talents so the agency can also unassign
-            // by deselecting before saving (until the contract is sent).
-            setAssignSelectedIds(Array.from(assignedTalentIds));
-          } else {
-            setAssignSearch("");
-            setAssignSelectedIds([]);
-          }
-        }}
-      >
-        <DialogContent className="max-w-[96vw] sm:max-w-2xl rounded-2xl sm:rounded-[3rem] p-4 sm:p-10 border-none bg-white/95 backdrop-blur-xl shadow-2xl">
-          <DialogHeader className="mb-8">
-            <DialogTitle className="text-2xl font-black text-gray-900 tracking-tight">
-              Assign Talent
-            </DialogTitle>
-            <DialogDescription className="text-sm text-gray-500 font-medium mt-1">
-              Select one or more talents from your roster to assign to this
-              offer.
-            </DialogDescription>
-          </DialogHeader>
-
-          <Alert className="mb-6 bg-blue-50 border-blue-200 rounded-xl">
-            <AlertDescription className="text-sm text-blue-900 font-medium">
-              You can change assigned talents any time before the contract is
-              sent. Once you send the contract, assignments are locked.
-            </AlertDescription>
-          </Alert>
-
-          {assignmentLockedForOffer ? (
-            <Alert className="mb-6 bg-amber-50 border-amber-200 rounded-xl">
-              <AlertDescription className="text-sm text-amber-900 font-semibold">
-                This offer’s contract has already been sent. Talent assignments
-                are locked.
-              </AlertDescription>
-            </Alert>
-          ) : null}
-
-          <div className="relative mb-8">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-            <Input
-              placeholder="Filter by name or email..."
-              value={assignSearch}
-              onChange={(e) => setAssignSearch(e.target.value)}
-              className="h-12 pl-10 bg-gray-100 border-none rounded-xl"
-            />
-          </div>
-
-          <ScrollArea className="h-[450px] pr-2 sm:pr-4">
-            {rosterQuery.isLoading ? (
-              <div className="h-[420px] flex flex-col items-center justify-center text-center">
-                <Loader2 className="w-10 h-10 animate-spin text-gray-300 mb-4" />
-                <p className="text-sm font-bold text-gray-500">
-                  Loading talents…
-                </p>
-                <p className="text-xs text-gray-400 mt-1">
-                  Fetching your agency roster.
-                </p>
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {filteredRoster.map((talent: any) => {
-                  const id = String(talent?.creator_id || talent?.id || "");
-                  const needsInvite = !talent?.has_creator_account;
-                  const canAssign = !needsInvite && Boolean(id);
-                  const alreadyAssigned = assignedTalentIds.has(id);
-                  const isSelected = assignSelectedIds.includes(id);
-                  const willUnassign = alreadyAssigned && !isSelected;
-                  const talentName =
-                    talent?.stage_name ||
-                    talent?.name ||
-                    talent?.full_legal_name ||
-                    "Talent";
-                  return (
-                    <Card
-                      key={id || talent?.id}
-                      onClick={() => {
-                        if (assignmentLockedForOffer) return;
-                        if (needsInvite) {
-                          setInviteRequiredDialog({
-                            open: true,
-                            talentName,
-                            talentId: talent?.id || id,
-                          });
-                          return;
-                        }
-                        if (!canAssign) return;
-                        setAssignSelectedIds((prev) =>
-                          prev.includes(id)
-                            ? prev.filter((x) => x !== id)
-                            : [...prev, id],
-                        );
-                      }}
-                      className={`p-5 rounded-[2rem] border-2 transition-all duration-500 flex items-center gap-5 ${
-                        needsInvite
-                          ? "border-dashed border-amber-200 bg-amber-50/30 cursor-pointer hover:border-amber-300"
-                          : assignmentLockedForOffer
-                            ? "border-gray-100 bg-gray-50/80 opacity-70 cursor-not-allowed"
-                            : "cursor-pointer border-gray-50 hover:border-gray-100 bg-white"
-                      } ${
-                        isSelected
-                          ? "border-indigo-600 bg-indigo-50/30 shadow-lg shadow-indigo-100/20"
-                          : ""
-                      }`}
-                    >
-                      <div className="w-16 h-16 rounded-2xl overflow-hidden bg-gray-100 flex-shrink-0 shadow-inner">
-                        <Avatar className="w-16 h-16 rounded-2xl">
-                          <AvatarImage src={getTalentAvatar(talent)} />
-                          <AvatarFallback className="bg-indigo-50 text-indigo-600 font-black text-lg uppercase">
-                            {getTalentInitial(talent)}
-                          </AvatarFallback>
-                        </Avatar>
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <h6 className="font-black text-gray-900 truncate tracking-tight text-base">
-                          {talentName}
-                        </h6>
-                        <div className="mt-1 flex items-center gap-2 flex-wrap">
-                          {alreadyAssigned && (
-                            <Badge className="bg-gray-100 text-gray-600 border-gray-200 text-[10px] tracking-widest font-black px-2 py-0.5">
-                              assigned
-                            </Badge>
-                          )}
-                          {willUnassign && (
-                            <Badge className="bg-red-50 text-red-700 border-red-200 text-[10px] tracking-widest font-black px-2 py-0.5">
-                              will unassign
-                            </Badge>
-                          )}
-                          {needsInvite && (
-                            <Badge className="bg-amber-50 text-amber-600 border border-amber-200 text-[10px] tracking-widest font-black px-2 py-0.5 flex items-center gap-1">
-                              <Mail className="w-2.5 h-2.5" />
-                              invite required
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                      {isSelected && (
-                        <div className="bg-indigo-600 rounded-full p-1 shadow-md shadow-indigo-200">
-                          <Check className="w-4 h-4 text-white" />
-                        </div>
-                      )}
-                      {needsInvite && !isSelected && (
-                        <UserX className="w-4 h-4 text-amber-400 flex-shrink-0" />
-                      )}
-                    </Card>
-                  );
-                })}
-              </div>
-            )}
-          </ScrollArea>
-
-          <Button
-            onClick={() => setAssignConfirmOpen(true)}
-            disabled={
-              assignmentLockedForOffer ||
-              assignSelectedIds.length === 0 ||
-              assignSubmitting
-            }
-            className="w-full mt-8 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg h-12 font-bold tracking-wider text-sm shadow-md shadow-indigo-200"
-          >
-            {assignSubmitting ? (
-              <Loader2 className="w-5 h-5 animate-spin mr-3" />
-            ) : null}
-            Confirm Selection ({assignSelectedIds.length})
-          </Button>
-        </DialogContent>
-      </Dialog>
-
-      {/* Invite Required Modal */}
-      <Dialog
-        open={inviteRequiredDialog.open}
-        onOpenChange={(open) =>
-          setInviteRequiredDialog((prev) => ({ ...prev, open }))
-        }
-      >
-        <DialogContent className="max-w-sm rounded-2xl p-8 border-none bg-white shadow-2xl text-center">
-          <div className="flex flex-col items-center gap-4">
-            <div className="w-14 h-14 rounded-full bg-amber-50 flex items-center justify-center">
-              <UserX className="w-7 h-7 text-amber-500" />
-            </div>
-            <div>
-              <h3 className="text-lg font-black text-gray-900 tracking-tight">
-                Onboarding not completed
-              </h3>
-              <p className="text-sm text-gray-500 mt-2 leading-relaxed">
-                <span className="font-semibold text-gray-700">
-                  {inviteRequiredDialog.talentName}
-                </span>{" "}
-                hasn't accepted their portal invite yet. They need to complete
-                onboarding before they can be assigned to a contract.
-              </p>
-            </div>
-            <div className="flex flex-col gap-2 w-full mt-2">
-              <Button
-                onClick={() => {
-                  setInviteRequiredDialog({
-                    open: false,
-                    talentName: "",
-                    talentId: "",
-                  });
-                  navigate(
-                    `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent("All Talent")}&openTalentId=${encodeURIComponent(inviteRequiredDialog.talentId || "")}`,
-                  );
-                }}
-                className="w-full bg-gray-900 hover:bg-gray-800 text-white rounded-xl h-11 font-bold text-sm flex items-center justify-center gap-2"
-              >
-                <Mail className="w-4 h-4" />
-                Go to Roster &amp; Invite
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={() =>
-                  setInviteRequiredDialog({
-                    open: false,
-                    talentName: "",
-                    talentId: "",
-                  })
-                }
-                className="w-full rounded-xl h-11 font-semibold text-sm text-gray-500 hover:text-gray-700"
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <AlertDialog
-        open={assignConfirmOpen}
-        onOpenChange={(open) => {
-          if (assignSubmitting) return;
-          setAssignConfirmOpen(open);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm talent assignment?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You can update assigned talents before the contract is sent. After
-              you send the contract, assignments are locked.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={assignSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={assignSubmitting || assignmentLockedForOffer}
-              onClick={async () => {
-                await handleAssignTalents();
-                setAssignConfirmOpen(false);
-              }}
-            >
-              Confirm assignment
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      <AlertDialog
-        open={unassignConfirm.open}
-        onOpenChange={(open) => {
-          if (assignSubmitting) return;
-          setUnassignConfirm((prev) => ({ ...prev, open }));
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Unassign talent?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Remove <strong>{unassignConfirm.talentName}</strong> from this
-              offer. You can re-assign talents until the contract is sent.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={assignSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={assignSubmitting || assignmentLockedForSelectedOffer}
-              onClick={async () => {
-                await handleUnassignTalent();
-              }}
-            >
-              Unassign
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
 
       <Dialog
         open={messageDialog.open}

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -335,9 +335,10 @@ const BrandConnectionsView = ({
     queryKey: ["agency", "offer-assignments", selectedOfferId],
     enabled: !!selectedOfferId,
     queryFn: async () => {
-      const resp = await base44.get<{ assignments?: any[]; is_locked?: boolean }>(
-        `/api/campaign-offers/${selectedOfferId}/assignments`,
-      );
+      const resp = await base44.get<{
+        assignments?: any[];
+        is_locked?: boolean;
+      }>(`/api/campaign-offers/${selectedOfferId}/assignments`);
       return {
         assignments: Array.isArray(resp?.assignments) ? resp.assignments : [],
         // is_locked is true when the brand has finalized their package selection.
@@ -384,7 +385,8 @@ const BrandConnectionsView = ({
   );
   const selectedOfferLockInfo = useMemo(() => {
     const offerId = String(selectedOfferId || "").trim();
-    if (!offerId) return { locked: false, contractSigned: false, packageFinalized: false };
+    if (!offerId)
+      return { locked: false, contractSigned: false, packageFinalized: false };
     const offer = (offers || []).find(
       (o: any) => String(o?.id || "") === offerId,
     );
@@ -1693,73 +1695,82 @@ const BrandConnectionsView = ({
                               <div className="flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-lg">
                                 <Lock className="h-3.5 w-3.5 text-indigo-600 shrink-0" />
                                 <p className="text-xs font-semibold text-indigo-800">
-                                  The brand has reviewed your package and finalized their talent selection. These talents are automatically assigned to the contract.
+                                  The brand has reviewed your package and
+                                  finalized their talent selection. These
+                                  talents are automatically assigned to the
+                                  contract.
                                 </p>
                               </div>
-                              {(offerAssignmentsQuery.data?.assignments || []).length === 0 ? (
+                              {(offerAssignmentsQuery.data?.assignments || [])
+                                .length === 0 ? (
                                 <p className="text-xs text-gray-500">
-                                  No talents were auto-assigned. Contact support if this is unexpected.
+                                  No talents were auto-assigned. Contact support
+                                  if this is unexpected.
                                 </p>
                               ) : (
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                  {(offerAssignmentsQuery.data?.assignments || []).map(
-                                    (a: any) => {
-                                      const talent = a?.agency_users || {};
-                                      const tid = String(a?.talent_id || "");
-                                      const assignmentId = String(a?.id || "");
-                                      const creatorId = String(
-                                        a?.creator_id ||
-                                          a?.agency_users?.creator_id ||
-                                          "",
-                                      ).trim();
-                                      return (
-                                        <div
-                                          key={String(a?.id)}
-                                          className="border border-gray-200 rounded-lg p-3 flex items-center justify-between gap-3"
-                                        >
-                                          <div className="flex items-center gap-3">
-                                            <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
-                                              <User className="h-4 w-4 text-gray-500" />
-                                            </div>
-                                            <div>
-                                              <p className="text-sm font-semibold text-gray-900">
-                                                {talent?.stage_name ||
-                                                  talent?.full_legal_name ||
-                                                  "Talent"}
-                                              </p>
-                                              <p className="text-xs text-green-600 font-medium">
-                                                Selected by brand
-                                              </p>
-                                            </div>
+                                  {(
+                                    offerAssignmentsQuery.data?.assignments ||
+                                    []
+                                  ).map((a: any) => {
+                                    const talent = a?.agency_users || {};
+                                    const tid = String(a?.talent_id || "");
+                                    const assignmentId = String(a?.id || "");
+                                    const creatorId = String(
+                                      a?.creator_id ||
+                                        a?.agency_users?.creator_id ||
+                                        "",
+                                    ).trim();
+                                    return (
+                                      <div
+                                        key={String(a?.id)}
+                                        className="border border-gray-200 rounded-lg p-3 flex items-center justify-between gap-3"
+                                      >
+                                        <div className="flex items-center gap-3">
+                                          <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
+                                            <User className="h-4 w-4 text-gray-500" />
                                           </div>
-                                          <div className="flex items-center gap-2">
-                                            <Button
-                                              size="sm"
-                                              variant="outline"
-                                              onClick={() => {
-                                                if (creatorId && onMessageTalent) {
-                                                  onMessageTalent(creatorId);
-                                                } else {
-                                                  // Fallback: open asset request dialog
-                                                  setMessageDialog({
-                                                    open: true,
-                                                    offerId: selectedOfferId,
-                                                    talentId: tid,
-                                                    title: "",
-                                                    message: "",
-                                                    file: null,
-                                                    sending: false,
-                                                  });
-                                                }
-                                              }}
-                                            >
-                                              Send Message
-                                            </Button>
+                                          <div>
+                                            <p className="text-sm font-semibold text-gray-900">
+                                              {talent?.stage_name ||
+                                                talent?.full_legal_name ||
+                                                "Talent"}
+                                            </p>
+                                            <p className="text-xs text-green-600 font-medium">
+                                              Selected by brand
+                                            </p>
                                           </div>
                                         </div>
-                                      );
-                                    },
-                                  )}
+                                        <div className="flex items-center gap-2">
+                                          <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={() => {
+                                              if (
+                                                creatorId &&
+                                                onMessageTalent
+                                              ) {
+                                                onMessageTalent(creatorId);
+                                              } else {
+                                                // Fallback: open asset request dialog
+                                                setMessageDialog({
+                                                  open: true,
+                                                  offerId: selectedOfferId,
+                                                  talentId: tid,
+                                                  title: "",
+                                                  message: "",
+                                                  file: null,
+                                                  sending: false,
+                                                });
+                                              }
+                                            }}
+                                          >
+                                            Send Message
+                                          </Button>
+                                        </div>
+                                      </div>
+                                    );
+                                  })}
                                 </div>
                               )}
                             </>
@@ -1774,7 +1785,11 @@ const BrandConnectionsView = ({
                                   Waiting for brand to select talents
                                 </p>
                                 <p className="text-xs text-amber-700 mt-1">
-                                  The brand will review your package and choose which talents they want. Once they confirm their selection, the talents will be automatically assigned here and you can proceed to create the contract.
+                                  The brand will review your package and choose
+                                  which talents they want. Once they confirm
+                                  their selection, the talents will be
+                                  automatically assigned here and you can
+                                  proceed to create the contract.
                                 </p>
                               </div>
                             </div>
@@ -1985,9 +2000,11 @@ const BrandConnectionsView = ({
                                   const selectedIds: string[] = Array.isArray(
                                     offerPkg.meta?.selected_talent_ids,
                                   )
-                                    ? offerPkg.meta.selected_talent_ids.map(
-                                        (id: any) => String(id || "").trim(),
-                                      ).filter(Boolean)
+                                    ? offerPkg.meta.selected_talent_ids
+                                        .map((id: any) =>
+                                          String(id || "").trim(),
+                                        )
+                                        .filter(Boolean)
                                     : [];
                                   const pkgItems: any[] = Array.isArray(
                                     offerPkg.package_snapshot?.items,
@@ -2978,7 +2995,6 @@ const BrandConnectionsView = ({
           })}
         </Card>
       )}
-
 
       <Dialog
         open={messageDialog.open}

--- a/likelee-ui/src/components/agency/RosterView.tsx
+++ b/likelee-ui/src/components/agency/RosterView.tsx
@@ -92,6 +92,7 @@ interface RosterViewProps {
   onRosterChanged?: () => void;
   isSportsAgency?: boolean;
   initialOpenTalentId?: string;
+  onInitialTalentOpened?: () => void;
 }
 
 const RosterView = ({
@@ -120,6 +121,7 @@ const RosterView = ({
   onRosterChanged,
   isSportsAgency = false,
   initialOpenTalentId,
+  onInitialTalentOpened,
 }: RosterViewProps) => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -308,7 +310,10 @@ const RosterView = ({
         String(t?.id || "") === initialOpenTalentId ||
         String(t?.creator_id || "") === initialOpenTalentId,
     );
-    if (match) setSelectedTalent(match);
+    if (match) {
+      setSelectedTalent(match);
+      onInitialTalentOpened?.();
+    }
   }, [initialOpenTalentId, safeRosterData]);
   const activeTalentCount = safeRosterData.filter(
     (t) => t.status === "active",

--- a/likelee-ui/src/components/chat/CommunicationHub.tsx
+++ b/likelee-ui/src/components/chat/CommunicationHub.tsx
@@ -7,8 +7,10 @@ import { useIsMobile } from "@/hooks/use-mobile";
 
 export function CommunicationHub({
   initialCreatorId,
+  onInitialCreatorHandled,
 }: {
   initialCreatorId?: string;
+  onInitialCreatorHandled?: () => void;
 }) {
   const { profile } = useAuth();
   const isMobile = useIsMobile();
@@ -52,6 +54,8 @@ export function CommunicationHub({
     } else {
       startConversation(initialCreatorId);
     }
+    // Clear the initialCreatorId so navigating away and back doesn't re-trigger
+    onInitialCreatorHandled?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialCreatorId, loadingConversations]);
 

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -74,6 +74,10 @@ interface CreatePackageWizardProps {
   mode?: CreatePackageWizardMode;
   isSportsAgency?: boolean;
   offerContext?: { offerId: string; offerBrandId?: string } | null;
+  // Called when the agency tries to select a talent who hasn't completed portal
+  // onboarding. The parent should navigate to the roster and open that talent's
+  // invite flow.
+  onInviteTalent?: (talent: any) => void;
 }
 
 export function CreatePackageWizard({
@@ -84,6 +88,7 @@ export function CreatePackageWizard({
   mode = "package",
   isSportsAgency = false,
   offerContext = null,
+  onInviteTalent,
 }: CreatePackageWizardProps) {
   const { user } = useAuth();
   const { hasPermission, loading: accessLoading } = useTeamAccess("agency");
@@ -102,6 +107,8 @@ export function CreatePackageWizard({
   const [step, setStep] = useState(0);
   const [showTalentSelector, setShowTalentSelector] = useState(false);
   const [isNavigating, setIsNavigating] = useState(false);
+  // Invite-required modal: shown when agency tries to select a talent without a creator_id
+  const [inviteRequiredTalent, setInviteRequiredTalent] = useState<any>(null);
   const [activeTalentForAssets, setActiveTalentForAssets] = useState<{
     id: string;
     name: string;
@@ -1652,14 +1659,32 @@ export function CreatePackageWizard({
                   const isConnectedCreator = Boolean(
                     (talent as any)?.is_connected_creator,
                   );
+                  // A talent is fully onboarded when they have a creator_id —
+                  // meaning they accepted their portal invite and have a creators record.
+                  const isOnboarded = Boolean(
+                    String(talent?.creator_id || "").trim(),
+                  );
                   const photo = String(talent?.profile_photo_url || "").trim();
                   return (
                     <Card
                       key={talent.id}
-                      onClick={() => toggleTalentSelection(talent)}
-                      className={`p-5 cursor-pointer rounded-[2rem] border-2 transition-all duration-500 flex items-center gap-5 ${isSelected ? "border-indigo-600 bg-indigo-50/30 shadow-lg shadow-indigo-100/20" : "border-gray-50 hover:border-gray-100 bg-white"}`}
+                      onClick={() => {
+                        if (!isOnboarded) {
+                          // Block selection — show invite-required modal instead
+                          setInviteRequiredTalent(talent);
+                          return;
+                        }
+                        toggleTalentSelection(talent);
+                      }}
+                      className={`p-5 rounded-[2rem] border-2 transition-all duration-500 flex items-center gap-5 ${
+                        !isOnboarded
+                          ? "cursor-not-allowed opacity-60 border-gray-100 bg-gray-50"
+                          : isSelected
+                            ? "cursor-pointer border-indigo-600 bg-indigo-50/30 shadow-lg shadow-indigo-100/20"
+                            : "cursor-pointer border-gray-50 hover:border-gray-100 bg-white"
+                      }`}
                     >
-                      <div className="w-16 h-16 rounded-2xl overflow-hidden bg-gray-100 flex-shrink-0 shadow-inner">
+                      <div className="w-16 h-16 rounded-2xl overflow-hidden bg-gray-100 flex-shrink-0 shadow-inner relative">
                         {photo ? (
                           <img
                             src={photo}
@@ -1670,6 +1695,11 @@ export function CreatePackageWizard({
                             <User className="w-7 h-7" />
                           </div>
                         )}
+                        {!isOnboarded && (
+                          <div className="absolute inset-0 bg-gray-900/40 flex items-center justify-center rounded-2xl">
+                            <Lock className="w-5 h-5 text-white/90" />
+                          </div>
+                        )}
                       </div>
                       <div className="min-w-0 flex-1">
                         <h6 className="font-black text-gray-900 truncate tracking-tight text-base">
@@ -1678,15 +1708,21 @@ export function CreatePackageWizard({
                         <p className="text-[10px] text-gray-400 font-black uppercase tracking-widest mt-0.5">
                           {talent.categories?.[0] || "Member"}
                         </p>
-                        {isConnectedCreator && (
+                        {!isOnboarded ? (
+                          <div className="mt-2">
+                            <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100 border border-amber-200 px-2 py-0.5 text-[10px] font-black tracking-widest uppercase">
+                              Invite Required
+                            </Badge>
+                          </div>
+                        ) : isConnectedCreator ? (
                           <div className="mt-2">
                             <Badge className="bg-sky-100 text-sky-700 hover:bg-sky-100 border border-sky-200 px-2 py-0.5 text-[10px] font-black tracking-widest uppercase">
                               Connected
                             </Badge>
                           </div>
-                        )}
+                        ) : null}
                       </div>
-                      {isSelected && (
+                      {isSelected && isOnboarded && (
                         <div className="bg-indigo-600 rounded-full p-1 shadow-md shadow-indigo-200">
                           <Check className="w-4 h-4 text-white" />
                         </div>
@@ -1729,6 +1765,83 @@ export function CreatePackageWizard({
           updateTalentAssets(activeTalentForAssets?.id!, assets)
         }
       />
+
+      {/* Invite Required Modal — shown when agency tries to select a talent
+          who hasn't accepted their portal invite yet (no creator_id). */}
+      <Dialog
+        open={!!inviteRequiredTalent}
+        onOpenChange={(open) => !open && setInviteRequiredTalent(null)}
+      >
+        <DialogContent className="max-w-sm rounded-3xl p-8 border-none bg-white shadow-2xl">
+          <div className="flex flex-col items-center gap-5 text-center">
+            {/* Avatar with lock overlay */}
+            <div className="relative w-20 h-20">
+              <div className="w-20 h-20 rounded-2xl overflow-hidden bg-gray-100">
+                {inviteRequiredTalent?.profile_photo_url ? (
+                  <img
+                    src={inviteRequiredTalent.profile_photo_url}
+                    alt={inviteRequiredTalent.full_name}
+                    className="w-full h-full object-cover grayscale"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-gray-300">
+                    <User className="w-8 h-8" />
+                  </div>
+                )}
+              </div>
+              <div className="absolute -bottom-2 -right-2 w-8 h-8 bg-amber-500 rounded-full flex items-center justify-center shadow-md">
+                <Mail className="w-4 h-4 text-white" />
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-xl font-black text-gray-900 tracking-tight">
+                Invite Required
+              </h3>
+              <p className="text-sm text-gray-500 mt-2 leading-relaxed">
+                <span className="font-bold text-gray-700">
+                  {inviteRequiredTalent?.full_name || "This talent"}
+                </span>{" "}
+                hasn't accepted their portal invite yet. They need to complete
+                onboarding before they can be added to a package or assigned to
+                a contract.
+              </p>
+            </div>
+
+            <div className="w-full bg-amber-50 border border-amber-200 rounded-2xl p-4 text-left">
+              <p className="text-xs font-black text-amber-800 uppercase tracking-widest mb-1">
+                Why this matters
+              </p>
+              <p className="text-xs text-amber-700 leading-relaxed">
+                Without portal access, this {entitySingularLower} can't receive
+                payments, sign contracts, or communicate through the platform.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 w-full mt-1">
+              <Button
+                className="w-full bg-gray-900 hover:bg-gray-800 text-white rounded-xl h-12 font-bold"
+                onClick={() => {
+                  setInviteRequiredTalent(null);
+                  if (onInviteTalent) {
+                    onInviteTalent(inviteRequiredTalent);
+                  }
+                }}
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                Go to Roster &amp; Invite
+              </Button>
+              <Button
+                variant="ghost"
+                className="w-full rounded-xl h-11 font-semibold text-sm text-gray-500 hover:text-gray-700"
+                onClick={() => setInviteRequiredTalent(null)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/likelee-ui/src/components/packages/PackagesView.tsx
+++ b/likelee-ui/src/components/packages/PackagesView.tsx
@@ -24,7 +24,7 @@ import {
   Activity,
   MessageSquare,
 } from "lucide-react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -63,6 +63,7 @@ export function PackagesView({
   const entitySingularTitle = isSportsAgency ? "Athlete" : "Talent";
   const entitySingularLower = isSportsAgency ? "athlete" : "talent";
   const location = useLocation();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<"templates" | "sent">("templates");
   const [currentPage, setCurrentPage] = useState(1);
   const ITEMS_PER_PAGE = 8;
@@ -638,6 +639,16 @@ export function PackagesView({
         onSuccess={() => {
           setShowWizard(false);
           setEditingPackage(null);
+        }}
+        onInviteTalent={(talent) => {
+          // Close the wizard and navigate to the roster with this talent's profile open
+          setShowWizard(false);
+          setEditingPackage(null);
+          const talentId = String(talent?.id || talent?.agency_user_id || "").trim();
+          const subTab = isSportsAgency ? "All Athletes" : "All Talent";
+          navigate(
+            `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(subTab)}${talentId ? `&openTalentId=${encodeURIComponent(talentId)}` : ""}`,
+          );
         }}
       />
 

--- a/likelee-ui/src/components/packages/PackagesView.tsx
+++ b/likelee-ui/src/components/packages/PackagesView.tsx
@@ -644,7 +644,9 @@ export function PackagesView({
           // Close the wizard and navigate to the roster with this talent's profile open
           setShowWizard(false);
           setEditingPackage(null);
-          const talentId = String(talent?.id || talent?.agency_user_id || "").trim();
+          const talentId = String(
+            talent?.id || talent?.agency_user_id || "",
+          ).trim();
           const subTab = isSportsAgency ? "All Athletes" : "All Talent";
           navigate(
             `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(subTab)}${talentId ? `&openTalentId=${encodeURIComponent(talentId)}` : ""}`,

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -17541,6 +17541,10 @@ export default function AgencyDashboard() {
   const [activeTab, setActiveTabState] = useState(
     searchParams.get("tab") || "dashboard",
   );
+  // openTalentId: when set, RosterView auto-opens that talent's side modal
+  const [openTalentId, setOpenTalentId] = useState<string | undefined>(
+    searchParams.get("openTalentId") || undefined,
+  );
   const normalizeSubTab = (value: string | null | undefined) => {
     const cleaned = String(value || "")
       .trim()
@@ -20900,6 +20904,19 @@ export default function AgencyDashboard() {
                   isLoading={rosterQuery.isLoading}
                   onRosterChanged={() => rosterQuery.refetch()}
                   isSportsAgency={isSportsAgency}
+                  initialOpenTalentId={openTalentId}
+                  onInitialTalentOpened={() => {
+                    setOpenTalentId(undefined);
+                    // Remove openTalentId from URL without triggering a re-render loop
+                    setSearchParams(
+                      (prev) => {
+                        const next = new URLSearchParams(prev);
+                        next.delete("openTalentId");
+                        return next;
+                      },
+                      { replace: true, preventScrollReset: true },
+                    );
+                  }}
                 />
               )}
               {activeTab === "roster" &&

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -18578,6 +18578,8 @@ export default function AgencyDashboard() {
   const [bookings, setBookings] = useState<any[]>([]);
   const [bookOuts, setBookOuts] = useState<any[]>([]);
   const [showCreatePackageWizard, setShowCreatePackageWizard] = useState(false);
+  // Creator ID to auto-open a conversation with when navigating to Messages tab
+  const [messagingCreatorId, setMessagingCreatorId] = useState<string | undefined>(undefined);
 
   const goToEditProfile = () => {
     setActiveView("settings", "General Settings");
@@ -20940,7 +20942,12 @@ export default function AgencyDashboard() {
               {activeTab === "licensing" &&
                 activeSubTab === "Brand Connections" &&
                 (agencyCanUseBrandConnections ? (
-                  <BrandConnectionsView />
+                  <BrandConnectionsView
+                    onMessageTalent={(creatorId) => {
+                      setMessagingCreatorId(creatorId);
+                      setActiveTab("messages");
+                    }}
+                  />
                 ) : (
                   <Card className="p-6 bg-white border border-gray-200 rounded-2xl">
                     <div className="text-lg font-black text-gray-900">
@@ -20961,7 +20968,12 @@ export default function AgencyDashboard() {
                 ))}
               {activeTab === "brand-connections" &&
                 (agencyCanUseBrandConnections ? (
-                  <BrandConnectionsView />
+                  <BrandConnectionsView
+                    onMessageTalent={(creatorId) => {
+                      setMessagingCreatorId(creatorId);
+                      setActiveTab("messages");
+                    }}
+                  />
                 ) : (
                   <Card className="p-6 bg-white border border-gray-200 rounded-2xl">
                     <div className="text-lg font-black text-gray-900">
@@ -21121,7 +21133,10 @@ export default function AgencyDashboard() {
               )}
               {activeTab === "messages" &&
                 (hasProAccess ? (
-                  <CommunicationHub />
+                  <CommunicationHub
+                    initialCreatorId={messagingCreatorId}
+                    onInitialCreatorHandled={() => setMessagingCreatorId(undefined)}
+                  />
                 ) : (
                   <Card className="p-6 bg-white border border-gray-200 rounded-2xl">
                     <div className="text-lg font-black text-gray-900">

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -18583,7 +18583,9 @@ export default function AgencyDashboard() {
   const [bookOuts, setBookOuts] = useState<any[]>([]);
   const [showCreatePackageWizard, setShowCreatePackageWizard] = useState(false);
   // Creator ID to auto-open a conversation with when navigating to Messages tab
-  const [messagingCreatorId, setMessagingCreatorId] = useState<string | undefined>(undefined);
+  const [messagingCreatorId, setMessagingCreatorId] = useState<
+    string | undefined
+  >(undefined);
 
   const goToEditProfile = () => {
     setActiveView("settings", "General Settings");
@@ -21152,7 +21154,9 @@ export default function AgencyDashboard() {
                 (hasProAccess ? (
                   <CommunicationHub
                     initialCreatorId={messagingCreatorId}
-                    onInitialCreatorHandled={() => setMessagingCreatorId(undefined)}
+                    onInitialCreatorHandled={() =>
+                      setMessagingCreatorId(undefined)
+                    }
                   />
                 ) : (
                   <Card className="p-6 bg-white border border-gray-200 rounded-2xl">

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -12607,7 +12607,9 @@ export default function BrandDashboard() {
                   Selected Talents:
                 </p>
                 {loadingConfirmingDonePkgPublicData ? (
-                  <p className="text-sm text-gray-500 italic">Loading selections...</p>
+                  <p className="text-sm text-gray-500 italic">
+                    Loading selections...
+                  </p>
                 ) : (
                   <ul className="space-y-1">
                     {(() => {
@@ -12625,9 +12627,9 @@ export default function BrandDashboard() {
                       const fromMeta: string[] = Array.isArray(
                         confirmingDonePkg?.meta?.selected_talent_ids,
                       )
-                        ? confirmingDonePkg.meta.selected_talent_ids.map((id: any) =>
-                            String(id || "").trim(),
-                          ).filter(Boolean)
+                        ? confirmingDonePkg.meta.selected_talent_ids
+                            .map((id: any) => String(id || "").trim())
+                            .filter(Boolean)
                         : [];
 
                       // Use whichever source has data, in priority order
@@ -12640,7 +12642,9 @@ export default function BrandDashboard() {
 
                       const pkgItems: any[] = Array.isArray(publicPkg?.items)
                         ? publicPkg.items
-                        : Array.isArray(confirmingDonePkg?.package_snapshot?.items)
+                        : Array.isArray(
+                              confirmingDonePkg?.package_snapshot?.items,
+                            )
                           ? confirmingDonePkg.package_snapshot.items
                           : [];
 
@@ -12650,7 +12654,9 @@ export default function BrandDashboard() {
                       const itemsToShow =
                         selectedIds.length > 0
                           ? pkgItems.filter((item: any) => {
-                              const id = String(item?.talent_id || item?.id || "").trim();
+                              const id = String(
+                                item?.talent_id || item?.id || "",
+                              ).trim();
                               return id && selectedIds.includes(id);
                             })
                           : pkgItems;
@@ -12711,9 +12717,9 @@ export default function BrandDashboard() {
                   const fromMeta: string[] = Array.isArray(
                     pkg?.meta?.selected_talent_ids,
                   )
-                    ? pkg.meta.selected_talent_ids.map((id: any) =>
-                        String(id || "").trim(),
-                      ).filter(Boolean)
+                    ? pkg.meta.selected_talent_ids
+                        .map((id: any) => String(id || "").trim())
+                        .filter(Boolean)
                     : [];
                   const fromSnapshot: string[] = Array.isArray(
                     pkg?.package_snapshot?.items,

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -810,8 +810,12 @@ export default function BrandDashboard() {
   const [inboxPackages, setInboxPackages] = useState<any[]>([]);
   const [inboxPendingCount, setInboxPendingCount] = useState(0);
   const [confirmingDonePkg, setConfirmingDonePkg] = useState<any>(null);
-  const [confirmingDonePkgPublicData, setConfirmingDonePkgPublicData] = useState<any>(null);
-  const [loadingConfirmingDonePkgPublicData, setLoadingConfirmingDonePkgPublicData] = useState(false);
+  const [confirmingDonePkgPublicData, setConfirmingDonePkgPublicData] =
+    useState<any>(null);
+  const [
+    loadingConfirmingDonePkgPublicData,
+    setLoadingConfirmingDonePkgPublicData,
+  ] = useState(false);
   const [loadingInboxPackages, setLoadingInboxPackages] = useState(false);
   const [expandedInboxPackageId, setExpandedInboxPackageId] =
     useState<string>("");
@@ -4531,7 +4535,8 @@ export default function BrandDashboard() {
                             const resp = await base44.get<any>(
                               `/api/public/packages/${encodeURIComponent(token)}`,
                             );
-                            const publicPkg = resp?.package || resp?.data || resp;
+                            const publicPkg =
+                              resp?.package || resp?.data || resp;
                             setConfirmingDonePkgPublicData(publicPkg);
                           } catch {
                             // non-fatal — dialog will show empty selection
@@ -12636,7 +12641,12 @@ export default function BrandDashboard() {
       {/* Confirmation Dialog for Mark Done */}
       <AlertDialog
         open={!!confirmingDonePkg}
-        onOpenChange={(open) => { if (!open) { setConfirmingDonePkg(null); setConfirmingDonePkgPublicData(null); } }}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmingDonePkg(null);
+            setConfirmingDonePkgPublicData(null);
+          }
+        }}
       >
         <AlertDialogContent className="bg-white rounded-none border border-gray-300 shadow-2xl">
           <AlertDialogHeader>
@@ -12653,56 +12663,62 @@ export default function BrandDashboard() {
                   Selected Talents:
                 </p>
                 {loadingConfirmingDonePkgPublicData ? (
-                  <p className="text-sm text-gray-500 italic">Loading selections...</p>
+                  <p className="text-sm text-gray-500 italic">
+                    Loading selections...
+                  </p>
                 ) : (
-                <ul className="space-y-1">
-                  {(() => {
-                    // Selections are stored as interactions (type "selected") on the
-                    // linked agency_talent_packages record, fetched via the public token.
-                    const publicPkg = confirmingDonePkgPublicData;
-                    const selectedIds = (publicPkg?.interactions || [])
-                      .filter((i: any) => i?.type === "selected")
-                      .map((i: any) => String(i?.talent_id || "").trim())
-                      .filter(Boolean);
+                  <ul className="space-y-1">
+                    {(() => {
+                      // Selections are stored as interactions (type "selected") on the
+                      // linked agency_talent_packages record, fetched via the public token.
+                      const publicPkg = confirmingDonePkgPublicData;
+                      const selectedIds = (publicPkg?.interactions || [])
+                        .filter((i: any) => i?.type === "selected")
+                        .map((i: any) => String(i?.talent_id || "").trim())
+                        .filter(Boolean);
 
-                    const items: any[] = Array.isArray(publicPkg?.items)
-                      ? publicPkg.items
-                      : Array.isArray(confirmingDonePkg?.package_snapshot?.items)
-                        ? confirmingDonePkg.package_snapshot.items
-                        : [];
+                      const items: any[] = Array.isArray(publicPkg?.items)
+                        ? publicPkg.items
+                        : Array.isArray(
+                              confirmingDonePkg?.package_snapshot?.items,
+                            )
+                          ? confirmingDonePkg.package_snapshot.items
+                          : [];
 
-                    const selectedNames = items
-                      .filter((item: any) => {
-                        const id = String(item?.talent_id || item?.id || "").trim();
-                        return id && selectedIds.includes(id);
-                      })
-                      .map(
-                        (item: any) =>
-                          item?.talent_name ||
-                          item?.talent?.stage_name ||
-                          item?.talent?.full_legal_name ||
-                          item?.talent?.full_name ||
-                          "Unnamed Talent",
-                      );
+                      const selectedNames = items
+                        .filter((item: any) => {
+                          const id = String(
+                            item?.talent_id || item?.id || "",
+                          ).trim();
+                          return id && selectedIds.includes(id);
+                        })
+                        .map(
+                          (item: any) =>
+                            item?.talent_name ||
+                            item?.talent?.stage_name ||
+                            item?.talent?.full_legal_name ||
+                            item?.talent?.full_name ||
+                            "Unnamed Talent",
+                        );
 
-                    if (selectedIds.length === 0)
-                      return (
-                        <li className="text-sm italic text-gray-500">
-                          No talent selected yet. Open the package and select
-                          talents before confirming.
+                      if (selectedIds.length === 0)
+                        return (
+                          <li className="text-sm italic text-gray-500">
+                            No talent selected yet. Open the package and select
+                            talents before confirming.
+                          </li>
+                        );
+                      return selectedNames.map((name: string, idx: number) => (
+                        <li
+                          key={idx}
+                          className="text-sm font-medium text-gray-900 flex items-center gap-2"
+                        >
+                          <CheckCircle2 className="w-3 h-3 text-green-600" />
+                          {name}
                         </li>
-                      );
-                    return selectedNames.map((name: string, idx: number) => (
-                      <li
-                        key={idx}
-                        className="text-sm font-medium text-gray-900 flex items-center gap-2"
-                      >
-                        <CheckCircle2 className="w-3 h-3 text-green-600" />
-                        {name}
-                      </li>
-                    ));
-                  })()}
-                </ul>
+                      ));
+                    })()}
+                  </ul>
                 )}
               </div>
               <p className="text-sm font-medium text-red-600 bg-red-50 p-3 border border-red-100 italic">
@@ -12735,7 +12751,9 @@ export default function BrandDashboard() {
                       feedback_note: "Brand completed package selection.",
                       // Derive selected_talent_ids from the public package interactions
                       // (type "selected") — these are set by the brand in PublicPackageView.
-                      selected_talent_ids: (confirmingDonePkgPublicData?.interactions || [])
+                      selected_talent_ids: (
+                        confirmingDonePkgPublicData?.interactions || []
+                      )
                         .filter((i: any) => i?.type === "selected")
                         .map((i: any) => String(i?.talent_id || "").trim())
                         .filter(Boolean),

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -810,6 +810,8 @@ export default function BrandDashboard() {
   const [inboxPackages, setInboxPackages] = useState<any[]>([]);
   const [inboxPendingCount, setInboxPendingCount] = useState(0);
   const [confirmingDonePkg, setConfirmingDonePkg] = useState<any>(null);
+  const [confirmingDonePkgPublicData, setConfirmingDonePkgPublicData] = useState<any>(null);
+  const [loadingConfirmingDonePkgPublicData, setLoadingConfirmingDonePkgPublicData] = useState(false);
   const [loadingInboxPackages, setLoadingInboxPackages] = useState(false);
   const [expandedInboxPackageId, setExpandedInboxPackageId] =
     useState<string>("");
@@ -4516,7 +4518,28 @@ export default function BrandDashboard() {
                           : "bg-black hover:bg-gray-800 text-white"
                       }`}
                       disabled={isExpired || isDone || !canManagePayOffers}
-                      onClick={() => setConfirmingDonePkg(pkg)}
+                      onClick={async () => {
+                        setConfirmingDonePkg(pkg);
+                        setConfirmingDonePkgPublicData(null);
+                        // Fetch the linked agency_talent_packages record to get
+                        // the brand's talent selections (stored as interactions
+                        // with type "selected" on the public package).
+                        const token = pkg?.meta?.agency_package_token;
+                        if (token) {
+                          setLoadingConfirmingDonePkgPublicData(true);
+                          try {
+                            const resp = await base44.get<any>(
+                              `/api/public/packages/${encodeURIComponent(token)}`,
+                            );
+                            const publicPkg = resp?.package || resp?.data || resp;
+                            setConfirmingDonePkgPublicData(publicPkg);
+                          } catch {
+                            // non-fatal — dialog will show empty selection
+                          } finally {
+                            setLoadingConfirmingDonePkgPublicData(false);
+                          }
+                        }
+                      }}
                       title={
                         !canManagePayOffers
                           ? "You do not have permission to mark packages as done"
@@ -12613,7 +12636,7 @@ export default function BrandDashboard() {
       {/* Confirmation Dialog for Mark Done */}
       <AlertDialog
         open={!!confirmingDonePkg}
-        onOpenChange={(open) => !open && setConfirmingDonePkg(null)}
+        onOpenChange={(open) => { if (!open) { setConfirmingDonePkg(null); setConfirmingDonePkgPublicData(null); } }}
       >
         <AlertDialogContent className="bg-white rounded-none border border-gray-300 shadow-2xl">
           <AlertDialogHeader>
@@ -12629,21 +12652,45 @@ export default function BrandDashboard() {
                 <p className="text-xs font-bold uppercase tracking-wider text-gray-500 mb-2">
                   Selected Talents:
                 </p>
+                {loadingConfirmingDonePkgPublicData ? (
+                  <p className="text-sm text-gray-500 italic">Loading selections...</p>
+                ) : (
                 <ul className="space-y-1">
                   {(() => {
-                    const selectedIds =
-                      confirmingDonePkg?.meta?.selected_talent_ids || [];
-                    const items =
-                      confirmingDonePkg?.package_snapshot?.items || [];
-                    const selectedNames = items
-                      .filter((item: any) =>
-                        selectedIds.includes(String(item.talent_id || item.id)),
-                      )
-                      .map((item: any) => item.talent_name || "Unnamed Talent");
+                    // Selections are stored as interactions (type "selected") on the
+                    // linked agency_talent_packages record, fetched via the public token.
+                    const publicPkg = confirmingDonePkgPublicData;
+                    const selectedIds = (publicPkg?.interactions || [])
+                      .filter((i: any) => i?.type === "selected")
+                      .map((i: any) => String(i?.talent_id || "").trim())
+                      .filter(Boolean);
 
-                    if (selectedNames.length === 0)
+                    const items: any[] = Array.isArray(publicPkg?.items)
+                      ? publicPkg.items
+                      : Array.isArray(confirmingDonePkg?.package_snapshot?.items)
+                        ? confirmingDonePkg.package_snapshot.items
+                        : [];
+
+                    const selectedNames = items
+                      .filter((item: any) => {
+                        const id = String(item?.talent_id || item?.id || "").trim();
+                        return id && selectedIds.includes(id);
+                      })
+                      .map(
+                        (item: any) =>
+                          item?.talent_name ||
+                          item?.talent?.stage_name ||
+                          item?.talent?.full_legal_name ||
+                          item?.talent?.full_name ||
+                          "Unnamed Talent",
+                      );
+
+                    if (selectedIds.length === 0)
                       return (
-                        <li className="text-sm italic">No talent selected</li>
+                        <li className="text-sm italic text-gray-500">
+                          No talent selected yet. Open the package and select
+                          talents before confirming.
+                        </li>
                       );
                     return selectedNames.map((name: string, idx: number) => (
                       <li
@@ -12656,6 +12703,7 @@ export default function BrandDashboard() {
                     ));
                   })()}
                 </ul>
+                )}
               </div>
               <p className="text-sm font-medium text-red-600 bg-red-50 p-3 border border-red-100 italic">
                 Note: Once you click "Confirm", you will not be able to modify
@@ -12669,7 +12717,13 @@ export default function BrandDashboard() {
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
-              className="rounded-none bg-black hover:bg-gray-800 text-white"
+              className="rounded-none bg-black hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={
+                loadingConfirmingDonePkgPublicData ||
+                (confirmingDonePkgPublicData?.interactions || []).filter(
+                  (i: any) => i?.type === "selected",
+                ).length === 0
+              }
               onClick={async () => {
                 const pkg = confirmingDonePkg;
                 if (!pkg) return;
@@ -12679,7 +12733,12 @@ export default function BrandDashboard() {
                     {
                       package_id: String(pkg?.id || ""),
                       feedback_note: "Brand completed package selection.",
-                      selected_talent_ids: pkg?.meta?.selected_talent_ids || [],
+                      // Derive selected_talent_ids from the public package interactions
+                      // (type "selected") — these are set by the brand in PublicPackageView.
+                      selected_talent_ids: (confirmingDonePkgPublicData?.interactions || [])
+                        .filter((i: any) => i?.type === "selected")
+                        .map((i: any) => String(i?.talent_id || "").trim())
+                        .filter(Boolean),
                     },
                   );
                   const response = await base44.get<{ packages?: any[] }>(
@@ -12701,6 +12760,7 @@ export default function BrandDashboard() {
                   });
                 } finally {
                   setConfirmingDonePkg(null);
+                  setConfirmingDonePkgPublicData(null);
                 }
               }}
             >

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -12607,45 +12607,64 @@ export default function BrandDashboard() {
                   Selected Talents:
                 </p>
                 {loadingConfirmingDonePkgPublicData ? (
-                  <p className="text-sm text-gray-500 italic">
-                    Loading selections...
-                  </p>
+                  <p className="text-sm text-gray-500 italic">Loading selections...</p>
                 ) : (
                   <ul className="space-y-1">
                     {(() => {
-                      // Selections are stored as interactions (type "selected") on the
-                      // linked agency_talent_packages record, fetched via the public token.
+                      // Fallback chain for selected talent IDs:
+                      // 1. Public package interactions (type "selected") — set by brand in PublicPackageView
+                      // 2. meta.selected_talent_ids — set by older packages or direct API calls
+                      // 3. All items in package_snapshot — last resort for legacy packages
                       const publicPkg = confirmingDonePkgPublicData;
-                      const selectedIds = (publicPkg?.interactions || [])
+
+                      const fromInteractions = (publicPkg?.interactions || [])
                         .filter((i: any) => i?.type === "selected")
                         .map((i: any) => String(i?.talent_id || "").trim())
                         .filter(Boolean);
 
-                      const items: any[] = Array.isArray(publicPkg?.items)
+                      const fromMeta: string[] = Array.isArray(
+                        confirmingDonePkg?.meta?.selected_talent_ids,
+                      )
+                        ? confirmingDonePkg.meta.selected_talent_ids.map((id: any) =>
+                            String(id || "").trim(),
+                          ).filter(Boolean)
+                        : [];
+
+                      // Use whichever source has data, in priority order
+                      const selectedIds =
+                        fromInteractions.length > 0
+                          ? fromInteractions
+                          : fromMeta.length > 0
+                            ? fromMeta
+                            : [];
+
+                      const pkgItems: any[] = Array.isArray(publicPkg?.items)
                         ? publicPkg.items
-                        : Array.isArray(
-                              confirmingDonePkg?.package_snapshot?.items,
-                            )
+                        : Array.isArray(confirmingDonePkg?.package_snapshot?.items)
                           ? confirmingDonePkg.package_snapshot.items
                           : [];
 
-                      const selectedNames = items
-                        .filter((item: any) => {
-                          const id = String(
-                            item?.talent_id || item?.id || "",
-                          ).trim();
-                          return id && selectedIds.includes(id);
-                        })
-                        .map(
-                          (item: any) =>
-                            item?.talent_name ||
-                            item?.talent?.stage_name ||
-                            item?.talent?.full_legal_name ||
-                            item?.talent?.full_name ||
-                            "Unnamed Talent",
-                        );
+                      // When selectedIds is empty (fetch failed or legacy package with no
+                      // interactions), show all talents from the snapshot so the brand
+                      // can still confirm — never block on a fetch error.
+                      const itemsToShow =
+                        selectedIds.length > 0
+                          ? pkgItems.filter((item: any) => {
+                              const id = String(item?.talent_id || item?.id || "").trim();
+                              return id && selectedIds.includes(id);
+                            })
+                          : pkgItems;
 
-                      if (selectedIds.length === 0)
+                      const selectedNames = itemsToShow.map(
+                        (item: any) =>
+                          item?.talent_name ||
+                          item?.talent?.stage_name ||
+                          item?.talent?.full_legal_name ||
+                          item?.talent?.full_name ||
+                          "Unnamed Talent",
+                      );
+
+                      if (selectedNames.length === 0)
                         return (
                           <li className="text-sm italic text-gray-500">
                             No talent selected yet. Open the package and select
@@ -12678,29 +12697,46 @@ export default function BrandDashboard() {
             </AlertDialogCancel>
             <AlertDialogAction
               className="rounded-none bg-black hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={
-                loadingConfirmingDonePkgPublicData ||
-                (confirmingDonePkgPublicData?.interactions || []).filter(
-                  (i: any) => i?.type === "selected",
-                ).length === 0
-              }
+              disabled={loadingConfirmingDonePkgPublicData}
               onClick={async () => {
                 const pkg = confirmingDonePkg;
                 if (!pkg) return;
                 try {
+                  // Fallback chain for selected_talent_ids (mirrors display logic above)
+                  const publicPkg = confirmingDonePkgPublicData;
+                  const fromInteractions = (publicPkg?.interactions || [])
+                    .filter((i: any) => i?.type === "selected")
+                    .map((i: any) => String(i?.talent_id || "").trim())
+                    .filter(Boolean);
+                  const fromMeta: string[] = Array.isArray(
+                    pkg?.meta?.selected_talent_ids,
+                  )
+                    ? pkg.meta.selected_talent_ids.map((id: any) =>
+                        String(id || "").trim(),
+                      ).filter(Boolean)
+                    : [];
+                  const fromSnapshot: string[] = Array.isArray(
+                    pkg?.package_snapshot?.items,
+                  )
+                    ? pkg.package_snapshot.items
+                        .map((item: any) =>
+                          String(item?.talent_id || item?.id || "").trim(),
+                        )
+                        .filter(Boolean)
+                    : [];
+                  const selectedTalentIds =
+                    fromInteractions.length > 0
+                      ? fromInteractions
+                      : fromMeta.length > 0
+                        ? fromMeta
+                        : fromSnapshot;
+
                   await base44.post(
                     `/api/campaign-offers/${encodeURIComponent(String(pkg?.offer_id || ""))}/packages/brand-done`,
                     {
                       package_id: String(pkg?.id || ""),
                       feedback_note: "Brand completed package selection.",
-                      // Derive selected_talent_ids from the public package interactions
-                      // (type "selected") — these are set by the brand in PublicPackageView.
-                      selected_talent_ids: (
-                        confirmingDonePkgPublicData?.interactions || []
-                      )
-                        .filter((i: any) => i?.type === "selected")
-                        .map((i: any) => String(i?.talent_id || "").trim())
-                        .filter(Boolean),
+                      selected_talent_ids: selectedTalentIds,
                     },
                   );
                   const response = await base44.get<{ packages?: any[] }>(
@@ -12715,9 +12751,20 @@ export default function BrandDashboard() {
                       "Your package selection was submitted to the agency.",
                   });
                 } catch (e: any) {
+                  const msg = String(e?.message || "");
+                  // Surface assignment errors from the backend clearly
+                  let description = msg || "Please try again.";
+                  try {
+                    const parsed = JSON.parse(msg);
+                    if (parsed?.error === "assignment_errors") {
+                      description = parsed.message || description;
+                    }
+                  } catch {
+                    // not JSON — use raw message
+                  }
                   toast({
                     title: "Unable to submit package",
-                    description: e?.message || "Please try again.",
+                    description,
                     variant: "destructive" as any,
                   });
                 } finally {


### PR DESCRIPTION
**Campaign Offer Phase 4 — Auto-Assignment, Package Selection Integrity & UX Improvements**

---

## Summary

This PR overhauls the talent assignment flow in the brand-agency campaign offer lifecycle. The core change eliminates the redundant manual talent assignment step by making it fully automatic from the brand's package selection. It also fixes several bugs in the confirmation and visibility flows, enforces data integrity at the package creation layer, and improves clarity for both the brand and agency throughout the process.

---

## What Changed

### Core: Auto-Assignment from Brand Package Selection

**Before:** After the brand reviewed an agency's talent package and selected talents, the agency still had to manually re-assign those exact same talents to the offer before creating a contract. This was redundant friction with no value, and created a window where the agency could assign different talents than what the brand selected.

**After:** When the brand clicks "Confirm Selection" on a package, the system automatically creates `offer_talent_assignments` rows for every selected talent. No manual step required. The contract creation gate (`no_talents_assigned`) is satisfied automatically.

### Manual Assignment Removed Entirely

- `POST /api/campaign-offers/:offer_id/assignments` — POST removed, GET kept
- `DELETE /api/campaign-offers/:offer_id/assignments/:id` — route removed
- All manual assignment UI removed from `BrandConnectionsView`: assign dialog, unassign confirm, invite required dialog, assign confirm alert, "Assign Talent" buttons, `handleAssignTalents`, `handleUnassignTalent`, and all related state

### Package Finalization Lock

- `mark_brand_package_done` is idempotent — calling it twice returns `400 package_already_finalized`
- `list_offer_talent_assignments` returns `{ assignments, is_locked }` so the frontend determines read-only state in one call

### Bug Fix: Confirm Selection Dialog Showing Wrong Talents

The dialog was reading `pkg.meta.selected_talent_ids` which is empty before confirmation. Brand selections are stored as `interactions` with `type: "selected"` on the linked `agency_talent_packages` record. The fix fetches the public package via `meta.agency_package_token` when the dialog opens and reads selections from there. The "Confirm" button is disabled while loading or when no talents are selected.

### Bug Fix: Assigned Talents Not Showing in Agency Detail View

`selected_talent_ids` passed to `brand-done` was derived from `campaign_offer_packages.interactions` (always empty) instead of the public package interactions. Fixed to use `confirmingDonePkgPublicData.interactions`.

### Agency-Side UX Clarity

**Offer list cards** now show two distinct states:
- Package sent, brand hasn't reviewed → "Package Sent — Awaiting Brand Review" (emerald)
- Brand finalized → "Brand Selected Talents" badge (indigo/lock) with talent name pills inline

**Offer detail view** now shows two distinct states:
- Waiting → amber panel: *"The brand will review your package and choose which talents they want. Once they confirm, the talents will be automatically assigned here."*
- Finalized → indigo locked panel: *"The brand has reviewed your package and finalized their talent selection."* Each talent shows "Selected by brand"

### Send Message → Opens Conversation

"Send Message" on an assigned talent card now navigates directly to the Messages tab and auto-opens (or creates) a conversation with that talent's `creator_id`, instead of opening an asset request dialog.

### Onboarding Gate in Package Wizard

Talents without a `creator_id` (portal invite not accepted) are now blocked from being added to packages. Clicking an un-onboarded talent opens a modal explaining the issue with a "Go to Roster & Invite" CTA that closes the wizard, navigates to the roster, and auto-opens that talent's side modal. This prevents silent auto-assignment failures and downstream breakage in payment, contract signing, and messaging.

---

## Testing

- Brand creates campaign → sends offer to agency → agency builds package with fully onboarded talent → brand opens package, selects talent, confirms → agency detail view shows assigned talent with "Selected by brand" label → agency can proceed directly to contract creation
- Attempting to select un-onboarded talent in package wizard → invite modal appears → "Go to Roster & Invite" opens roster with that talent's side modal
- "Send Message" on assigned talent → Messages tab opens with conversation auto-started
- Calling `brand-done` twice → `400 package_already_finalized`
- Contract creation gate passes without any manual assignment step