### PR TITLE
fix(agency): improve licensing requests UX and performance

### DIFF
--- a/likelee-server/src/billing.rs
+++ b/likelee-server/src/billing.rs
@@ -5351,6 +5351,23 @@ pub async fn check_license_expiration_alerts_cron(
     }
 }
 
+pub async fn auto_archive_expired_licensing_requests_cron(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(_params): Query<CronQueryParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    verify_cron_auth(&headers, &state.cron_secret)?;
+
+    match crate::licensing_requests::auto_archive_expired_licensing_requests(&state).await {
+        Ok((total_checked, archived_count)) => Ok(Json(json!({
+            "success": true,
+            "total_checked": total_checked,
+            "archived_count": archived_count
+        }))),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e)),
+    }
+}
+
 // ============================================================================
 // BRAND PAYMENT METHOD HANDLERS
 // ============================================================================

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -305,6 +305,11 @@ pub struct PackageDoneRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct PackageDeleteRequest {
+    pub package_id: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SubmitDeliverableRequest {
     pub asset_url: String,
     pub asset_type: Option<String>,
@@ -5337,6 +5342,43 @@ pub async fn mark_brand_package_done(
     }
     let row: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
     Ok(Json(json!({"status":"ok","package": row})))
+}
+
+pub async fn delete_brand_inbox_package(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(OfferPath { offer_id }): Path<OfferPath>,
+    Json(payload): Json<PackageDeleteRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if user.role != "brand" {
+        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
+    }
+    let offer = ensure_offer_access(&state, &user, &offer_id).await?;
+    if offer.get("brand_id").and_then(|v| v.as_str()) != Some(user.id.as_str()) {
+        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
+    }
+
+    let resp = state
+        .pg
+        .from("campaign_offer_packages")
+        .eq("id", &payload.package_id)
+        .eq("offer_id", &offer_id)
+        .eq("brand_id", &user.id)
+        .delete()
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !status.is_success() {
+        return Err(sanitize_db_error(status.as_u16(), text));
+    }
+
+    Ok(Json(json!({"status":"ok","message":"Package deleted"})))
 }
 
 pub async fn list_agency_offer_packages(

--- a/likelee-server/src/jobs.rs
+++ b/likelee-server/src/jobs.rs
@@ -37,6 +37,34 @@ pub async fn start_agency_payout_scheduler(state: AppState) {
     }
 }
 
+pub async fn start_auto_archive_licensing_requests(state: AppState) {
+    info!("Starting background job: auto-archive expired licensing requests");
+    loop {
+        // Run every 6 hours
+        tokio::time::sleep(StdDuration::from_secs(6 * 3600)).await;
+
+        if let Err(e) = run_auto_archive_licensing_requests(&state).await {
+            warn!(error = %e, "Auto-archive licensing requests job iteration failed");
+        }
+    }
+}
+
+async fn run_auto_archive_licensing_requests(state: &AppState) -> Result<(), String> {
+    match crate::licensing_requests::auto_archive_expired_licensing_requests(state).await {
+        Ok((total_checked, archived_count)) => {
+            if archived_count > 0 {
+                info!(
+                    total_checked = total_checked,
+                    archived_count = archived_count,
+                    "Auto-archived expired licensing requests"
+                );
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
 async fn run_agency_payout_scheduler(state: &AppState) -> Result<(), String> {
     // Fetch settings for all agencies (1 row per agency)
     let resp = state

--- a/likelee-server/src/licensing_requests.rs
+++ b/likelee-server/src/licensing_requests.rs
@@ -553,6 +553,189 @@ pub async fn list_for_brand(
     Ok(Json(rows))
 }
 
+#[derive(Deserialize)]
+pub struct UpdateBrandLicensingRequestStatusBody {
+    pub licensing_request_ids: Vec<String>,
+    pub status: String,
+    pub notes: Option<String>,
+}
+
+pub async fn update_status_for_brand(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(payload): Json<UpdateBrandLicensingRequestStatusBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if user.role != "brand" {
+        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
+    }
+
+    let effective_brand_id = crate::team::resolve_effective_brand_id(&state, &user).await?;
+
+    if payload.licensing_request_ids.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "No licensing_request_ids".to_string(),
+        ));
+    }
+
+    let status = payload.status.trim().to_lowercase();
+    if status != "pending"
+        && status != "approved"
+        && status != "rejected"
+        && status != "negotiating"
+        && status != "declined"
+        && status != "archived"
+    {
+        return Err((StatusCode::BAD_REQUEST, "Invalid status".to_string()));
+    }
+
+    let decided_at = if status == "pending" {
+        serde_json::Value::Null
+    } else {
+        json!(Utc::now().to_rfc3339())
+    };
+
+    let mut v = json!({
+        "status": status,
+        "decided_at": decided_at,
+        "notes": payload.notes,
+    });
+
+    if let serde_json::Value::Object(ref mut map) = v {
+        let null_keys: Vec<String> = map
+            .iter()
+            .filter_map(|(k, val)| if val.is_null() { Some(k.clone()) } else { None })
+            .collect();
+        for k in null_keys {
+            map.remove(&k);
+        }
+    }
+
+    let ids: Vec<&str> = payload
+        .licensing_request_ids
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+
+    let resp = state
+        .pg
+        .from("licensing_requests")
+        .eq("brand_id", &effective_brand_id)
+        .in_("id", ids)
+        .update(v.to_string())
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !resp.status().is_success() {
+        let err = resp.text().await.unwrap_or_default();
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, err));
+    }
+
+    Ok(Json(json!({"ok": true})))
+}
+
+#[derive(Deserialize)]
+pub struct DeleteBrandLicensingRequestsBody {
+    pub licensing_request_ids: Vec<String>,
+}
+
+pub async fn delete_archived_requests_for_brand(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(payload): Json<DeleteBrandLicensingRequestsBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if user.role != "brand" {
+        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
+    }
+
+    let effective_brand_id = crate::team::resolve_effective_brand_id(&state, &user).await?;
+
+    if payload.licensing_request_ids.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "No licensing_request_ids".to_string(),
+        ));
+    }
+
+    let ids: Vec<&str> = payload
+        .licensing_request_ids
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+
+    // Verify all requests belong to this brand and are archived
+    let verify_resp = state
+        .pg
+        .from("licensing_requests")
+        .select("id,status,archived_at")
+        .eq("brand_id", &effective_brand_id)
+        .in_("id", ids.clone())
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !verify_resp.status().is_success() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            verify_resp.text().await.unwrap_or_default(),
+        ));
+    }
+
+    let verify_text = verify_resp
+        .text()
+        .await
+        .unwrap_or_else(|_| "[]".to_string());
+    let verify_rows: Vec<serde_json::Value> =
+        serde_json::from_str(&verify_text).unwrap_or_default();
+
+    for row in &verify_rows {
+        let status = row.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        let archived_at = row.get("archived_at");
+        let is_terminal = status == "archived" || status == "declined" || status == "rejected";
+        if !is_terminal {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Can only delete archived, declined, or rejected licensing requests".to_string(),
+            ));
+        }
+        if status == "archived" && (archived_at.is_none() || archived_at.unwrap().is_null()) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Archived requests must have an archived_at timestamp".to_string(),
+            ));
+        }
+    }
+
+    // Delete the archived requests
+    let delete_resp = state
+        .pg
+        .from("licensing_requests")
+        .eq("brand_id", &effective_brand_id)
+        .in_("id", ids)
+        .delete()
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !delete_resp.status().is_success() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            delete_resp.text().await.unwrap_or_default(),
+        ));
+    }
+
+    info!(
+        brand_id = %effective_brand_id,
+        deleted_count = payload.licensing_request_ids.len(),
+        "Brand deleted archived licensing requests"
+    );
+
+    Ok(Json(
+        json!({"ok": true, "deleted_count": payload.licensing_request_ids.len()}),
+    ))
+}
+
 pub async fn notify_brand_license_expirations_lazy(
     state: &AppState,
     brand_id: &str,
@@ -785,6 +968,7 @@ pub async fn update_status_bulk(
         && status != "pending"
         && status != "negotiating"
         && status != "declined"
+        && status != "archived"
     {
         return Err((StatusCode::BAD_REQUEST, "Invalid status".to_string()));
     }
@@ -795,9 +979,16 @@ pub async fn update_status_bulk(
         json!(Utc::now().to_rfc3339())
     };
 
+    let archived_at = if status == "archived" {
+        json!(Utc::now().to_rfc3339())
+    } else {
+        serde_json::Value::Null
+    };
+
     let mut v = json!({
         "status": status,
         "decided_at": decided_at,
+        "archived_at": archived_at,
         "notes": payload.notes,
         "negotiation_reason": payload.notes, // Using notes as the reason for now
     });
@@ -2827,5 +3018,175 @@ pub async fn set_pay_split(
     Err((
         StatusCode::BAD_REQUEST,
         "Pay split is no longer configurable on campaigns".to_string(),
+    ))
+}
+
+pub async fn auto_archive_expired_licensing_requests(
+    state: &AppState,
+) -> Result<(usize, usize), String> {
+    let today = Utc::now().date_naive();
+
+    // Find licensing requests where deadline has passed and they're not already archived
+    // and not in terminal states (approved, rejected, declined)
+    let resp = state
+        .pg
+        .from("licensing_requests")
+        .select("id,deadline,status")
+        .is("archived_at", "null")
+        .neq("status", "approved")
+        .neq("status", "rejected")
+        .neq("status", "declined")
+        .neq("status", "archived")
+        .lte("deadline", today.to_string())
+        .limit(500)
+        .execute()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if !resp.status().is_success() {
+        return Err(resp.text().await.unwrap_or_default());
+    }
+
+    let text = resp.text().await.unwrap_or_else(|_| "[]".into());
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
+    let total_checked = rows.len();
+
+    if rows.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let mut archived_count = 0;
+    for row in rows {
+        let id = match row.get("id").and_then(|v| v.as_str()) {
+            Some(v) if !v.trim().is_empty() => v.to_string(),
+            _ => continue,
+        };
+
+        let update_json = json!({
+            "status": "archived",
+            "archived_at": Utc::now().to_rfc3339(),
+        });
+
+        let update_resp = state
+            .pg
+            .from("licensing_requests")
+            .eq("id", &id)
+            .update(update_json.to_string())
+            .execute()
+            .await;
+
+        if let Ok(r) = update_resp {
+            if r.status().is_success() {
+                archived_count += 1;
+                info!(licensing_request_id = %id, "Auto-archived expired licensing request");
+            }
+        }
+    }
+
+    Ok((total_checked, archived_count))
+}
+
+#[derive(Deserialize)]
+pub struct DeleteLicensingRequestsBody {
+    pub licensing_request_ids: Vec<String>,
+}
+
+pub async fn delete_archived_requests(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(payload): Json<DeleteLicensingRequestsBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let access = require_agency_permission(&state, &user, Permission::ManageLicenses).await?;
+    let agency_id = &access.organization_id;
+
+    if payload.licensing_request_ids.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "No licensing_request_ids".to_string(),
+        ));
+    }
+
+    // Only allow deletion of archived requests
+    let ids: Vec<&str> = payload
+        .licensing_request_ids
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+
+    // Verify all requests belong to this agency and are archived
+    let verify_resp = state
+        .pg
+        .from("licensing_requests")
+        .select("id,status,archived_at")
+        .eq("agency_id", agency_id)
+        .in_("id", ids.clone())
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !verify_resp.status().is_success() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            verify_resp.text().await.unwrap_or_default(),
+        ));
+    }
+
+    let verify_text = verify_resp.text().await.unwrap_or_else(|_| "[]".into());
+    let verify_rows: Vec<serde_json::Value> =
+        serde_json::from_str(&verify_text).unwrap_or_default();
+
+    for row in &verify_rows {
+        let status = row.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        let is_terminal = status == "archived" || status == "declined" || status == "rejected";
+        if !is_terminal {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Can only delete archived, declined, or rejected licensing requests".to_string(),
+            ));
+        }
+    }
+
+    // Auto-archive any declined/rejected requests before deletion (single batch update)
+    let now = Utc::now().to_rfc3339();
+    let archive_update = json!({
+        "status": "archived",
+        "archived_at": now,
+    });
+    let _ = state
+        .pg
+        .from("licensing_requests")
+        .eq("agency_id", agency_id)
+        .in_("id", ids.clone())
+        .neq("status", "archived")
+        .update(archive_update.to_string())
+        .execute()
+        .await;
+
+    // Delete the archived requests
+    let delete_resp = state
+        .pg
+        .from("licensing_requests")
+        .eq("agency_id", agency_id)
+        .in_("id", ids)
+        .delete()
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !delete_resp.status().is_success() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            delete_resp.text().await.unwrap_or_default(),
+        ));
+    }
+
+    info!(
+        agency_id = %agency_id,
+        deleted_count = payload.licensing_request_ids.len(),
+        "Deleted archived licensing requests"
+    );
+
+    Ok(Json(
+        json!({"ok": true, "deleted_count": payload.licensing_request_ids.len()}),
     ))
 }

--- a/likelee-server/src/licensing_requests.rs
+++ b/likelee-server/src/licensing_requests.rs
@@ -3025,9 +3025,10 @@ pub async fn auto_archive_expired_licensing_requests(
     state: &AppState,
 ) -> Result<(usize, usize), String> {
     let today = Utc::now().date_naive();
+    let mut total_checked: usize = 0;
+    let mut archived_count: usize = 0;
 
-    // Find licensing requests where deadline has passed and they're not already archived
-    // and not in terminal states (approved, rejected, declined)
+    // Phase 1: Archive pending requests where deadline has passed
     let resp = state
         .pg
         .from("licensing_requests")
@@ -3043,42 +3044,82 @@ pub async fn auto_archive_expired_licensing_requests(
         .await
         .map_err(|e| e.to_string())?;
 
-    if !resp.status().is_success() {
-        return Err(resp.text().await.unwrap_or_default());
+    if resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_else(|_| "[]".into());
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
+        total_checked += rows.len();
+
+        for row in rows {
+            let id = match row.get("id").and_then(|v| v.as_str()) {
+                Some(v) if !v.trim().is_empty() => v.to_string(),
+                _ => continue,
+            };
+
+            let update_json = json!({
+                "status": "archived",
+                "archived_at": Utc::now().to_rfc3339(),
+            });
+
+            let update_resp = state
+                .pg
+                .from("licensing_requests")
+                .eq("id", &id)
+                .update(update_json.to_string())
+                .execute()
+                .await;
+
+            if let Ok(r) = update_resp {
+                if r.status().is_success() {
+                    archived_count += 1;
+                    info!(licensing_request_id = %id, "Auto-archived expired pending licensing request");
+                }
+            }
+        }
     }
 
-    let text = resp.text().await.unwrap_or_else(|_| "[]".into());
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
-    let total_checked = rows.len();
+    // Phase 2: Archive approved licenses where license_end_date has passed
+    let resp2 = state
+        .pg
+        .from("licensing_requests")
+        .select("id,license_end_date,status")
+        .is("archived_at", "null")
+        .eq("status", "approved")
+        .not("license_end_date", "is", "null")
+        .lte("license_end_date", today.to_string())
+        .limit(500)
+        .execute()
+        .await
+        .map_err(|e| e.to_string())?;
 
-    if rows.is_empty() {
-        return Ok((0, 0));
-    }
+    if resp2.status().is_success() {
+        let text2 = resp2.text().await.unwrap_or_else(|_| "[]".into());
+        let rows2: Vec<serde_json::Value> = serde_json::from_str(&text2).unwrap_or_default();
+        total_checked += rows2.len();
 
-    let mut archived_count = 0;
-    for row in rows {
-        let id = match row.get("id").and_then(|v| v.as_str()) {
-            Some(v) if !v.trim().is_empty() => v.to_string(),
-            _ => continue,
-        };
+        for row in rows2 {
+            let id = match row.get("id").and_then(|v| v.as_str()) {
+                Some(v) if !v.trim().is_empty() => v.to_string(),
+                _ => continue,
+            };
 
-        let update_json = json!({
-            "status": "archived",
-            "archived_at": Utc::now().to_rfc3339(),
-        });
+            let update_json = json!({
+                "status": "archived",
+                "archived_at": Utc::now().to_rfc3339(),
+            });
 
-        let update_resp = state
-            .pg
-            .from("licensing_requests")
-            .eq("id", &id)
-            .update(update_json.to_string())
-            .execute()
-            .await;
+            let update_resp = state
+                .pg
+                .from("licensing_requests")
+                .eq("id", &id)
+                .update(update_json.to_string())
+                .execute()
+                .await;
 
-        if let Ok(r) = update_resp {
-            if r.status().is_success() {
-                archived_count += 1;
-                info!(licensing_request_id = %id, "Auto-archived expired licensing request");
+            if let Ok(r) = update_resp {
+                if r.status().is_success() {
+                    archived_count += 1;
+                    info!(licensing_request_id = %id, "Auto-archived expired approved licensing request (end date passed)");
+                }
             }
         }
     }

--- a/likelee-server/src/main.rs
+++ b/likelee-server/src/main.rs
@@ -331,6 +331,9 @@ async fn main() {
     tokio::spawn(likelee_server::jobs::start_agency_payout_scheduler(
         state.clone(),
     ));
+    tokio::spawn(likelee_server::jobs::start_auto_archive_licensing_requests(
+        state.clone(),
+    ));
 
     let app = likelee_server::router::build_router(state);
 

--- a/likelee-server/src/router.rs
+++ b/likelee-server/src/router.rs
@@ -401,6 +401,10 @@ pub fn build_router(state: AppState) -> Router {
             post(crate::licensing_requests::update_status_bulk),
         )
         .route(
+            "/api/agency/licensing-requests/delete",
+            post(crate::licensing_requests::delete_archived_requests),
+        )
+        .route(
             "/api/agency/licensing-requests/:id/send-payment-link",
             post(crate::licensing_requests::send_payment_link),
         )
@@ -595,6 +599,14 @@ pub fn build_router(state: AppState) -> Router {
             "/api/brand/licensing-requests",
             get(crate::licensing_requests::list_for_brand)
                 .post(crate::face_profiles::create_brand_licensing_request),
+        )
+        .route(
+            "/api/brand/licensing-requests/status",
+            post(crate::licensing_requests::update_status_for_brand),
+        )
+        .route(
+            "/api/brand/licensing-requests/delete",
+            post(crate::licensing_requests::delete_archived_requests_for_brand),
         )
         .route(
             "/api/brand/brand-license-requests",
@@ -949,6 +961,10 @@ pub fn build_router(state: AppState) -> Router {
             post(crate::billing::check_license_expiration_alerts_cron),
         )
         .route(
+            "/api/cron/auto-archive-licensing-requests",
+            post(crate::billing::auto_archive_expired_licensing_requests_cron),
+        )
+        .route(
             "/api/brand/campaigns",
             post(crate::brand_campaigns::create_campaign)
                 .get(crate::brand_campaigns::list_campaigns),
@@ -1050,6 +1066,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/campaign-offers/:offer_id/packages/brand-done",
             post(crate::brand_campaigns::mark_brand_package_done),
+        )
+        .route(
+            "/api/campaign-offers/:offer_id/packages/brand-delete",
+            post(crate::brand_campaigns::delete_brand_inbox_package),
         )
         .route(
             "/api/agency/brand-offers/package-feedback",

--- a/likelee-ui/src/api/functions.ts
+++ b/likelee-ui/src/api/functions.ts
@@ -789,6 +789,10 @@ export const updateAgencyLicensingRequestsStatus = (data: {
   notes?: string;
 }) => base44Client.post(`/agency/licensing-requests/status`, data);
 
+export const deleteAgencyLicensingRequests = (data: {
+  licensing_request_ids: string[];
+}) => base44Client.post(`/agency/licensing-requests/delete`, data);
+
 // Payment Links (Agency)
 export const generateAgencyPaymentLink = (data: {
   licensing_request_ids: string[];
@@ -1344,6 +1348,16 @@ export const createAgencyBrandLicensingRequest = (payload: {
 
 export const getBrandLicensingRequests = () =>
   base44Client.get<{ requests: any[] }>("/api/brand/brand-license-requests");
+
+export const updateBrandLicensingRequestsStatus = (payload: {
+  licensing_request_ids: string[];
+  status: string;
+  notes?: string;
+}) => base44Client.post("/api/brand/licensing-requests/status", payload);
+
+export const deleteBrandLicensingRequests = (payload: {
+  licensing_request_ids: string[];
+}) => base44Client.post("/api/brand/licensing-requests/delete", payload);
 
 export const getAgencyBrandLicenseRequests = () =>
   base44Client.get<{ requests: any[] }>("/api/agency/brand-license-requests");

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -484,14 +484,36 @@ const LicensingRequestsView = ({
     return null;
   };
 
+  const isLicenseExpired = (group: any) => {
+    const now = new Date();
+    const endDateRaw = group?.license_end_date
+      ? new Date(group.license_end_date)
+      : null;
+    if (endDateRaw && !Number.isNaN(endDateRaw.getTime()) && endDateRaw < now) {
+      return true;
+    }
+    const deadlineRaw = group?.deadline ? new Date(group.deadline) : null;
+    if (
+      deadlineRaw &&
+      !Number.isNaN(deadlineRaw.getTime()) &&
+      deadlineRaw < now
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   const filteredData = (data || []).filter((group: any) => {
     const isArchived = ["rejected", "declined", "archived"].includes(
       group.status,
     );
+    const isExpired = isLicenseExpired(group);
     const isBrandRequest = isBrandRequestGroup(group);
-    const matchesStatus =
-      activeRequestTab === "Active" ? !isArchived : isArchived;
-    if (!matchesStatus) return false;
+    if (activeRequestTab === "Active") {
+      if (isArchived || isExpired) return false;
+    } else {
+      if (!isArchived && !isExpired) return false;
+    }
     return !isBrandRequest;
   });
 
@@ -663,6 +685,28 @@ const LicensingRequestsView = ({
         </div>
 
         <div className="space-y-6">
+          {activeRequestTab === "Active" && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+              <svg
+                className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <p className="text-xs text-amber-800">
+                Licensing requests past their end date are automatically moved
+                to the Archive tab.
+              </p>
+            </div>
+          )}
+
           {isLoading && (
             <Card className="p-8 bg-white border-2 border-gray-900 rounded-none">
               <div className="text-gray-500 font-medium">Loading...</div>

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Filter, CheckCircle2, Send, RefreshCw, Eye, X } from "lucide-react";
+import {
+  Filter,
+  CheckCircle2,
+  Send,
+  RefreshCw,
+  Eye,
+  X,
+  Trash2,
+} from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -15,8 +23,16 @@ import {
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   getAgencyLicensingRequests,
   updateAgencyLicensingRequestsStatus,
+  deleteAgencyLicensingRequests,
   sendLicensingRequestPaymentLink,
   getAgencyBrandLicenseRequests,
   updateAgencyBrandLicenseRequestStatus,
@@ -68,13 +84,24 @@ const LicensingRequestsView = ({
   const [counterOfferModalOpen, setCounterOfferModalOpen] = useState(false);
   const [counterOfferMessage, setCounterOfferMessage] = useState("");
   const [groupToCounter, setGroupToCounter] = useState<any>(null);
-  const [declineModalOpen, setDeclineModalOpen] = useState(false);
-  const [declineReason, setDeclineReason] = useState("");
+  const [sendingCounterOffer, setSendingCounterOffer] = useState(false);
+  const [showDeclineConfirm, setShowDeclineConfirm] = useState(false);
   const [groupToDecline, setGroupToDecline] = useState<any>(null);
+  const [isDeclining, setIsDeclining] = useState(false);
   const [activeRequestTab, setActiveRequestTab] = useState<
     "Active" | "Archive" | "Brand Requests"
   >("Active");
   const [sendPaymentBusyKey, setSendPaymentBusyKey] = useState<string>("");
+  const [showFilterDialog, setShowFilterDialog] = useState(false);
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [filterMinLicenseFee, setFilterMinLicenseFee] = useState<string>("");
+  const [filterMaxLicenseFee, setFilterMaxLicenseFee] = useState<string>("");
+  const [filterMinDuration, setFilterMinDuration] = useState<string>("");
+  const [filterMaxDuration, setFilterMaxDuration] = useState<string>("");
+  const [deletingGroup, setDeletingGroup] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [groupToDelete, setGroupToDelete] = useState<any>(null);
+  const [recoveringGroup, setRecoveringGroup] = useState<string | null>(null);
 
   useEffect(() => {
     if (activeRequestTab === "Active" && Array.isArray(data)) {
@@ -135,6 +162,39 @@ const LicensingRequestsView = ({
     </div>
   );
 
+  const handleSendCounterOffer = async () => {
+    if (!groupToCounter || !counterOfferMessage.trim()) return;
+    setSendingCounterOffer(true);
+    try {
+      const ids = (groupToCounter?.talents || [])
+        .map((t: any) => t.licensing_request_id)
+        .filter(Boolean);
+      await updateAgencyLicensingRequestsStatus({
+        licensing_request_ids: ids,
+        status: "negotiating",
+        notes: counterOfferMessage,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["agency", "licensing-requests"],
+      });
+      toast({
+        title: "Counter offer sent",
+        description: "The client has been notified.",
+      });
+      setCounterOfferModalOpen(false);
+      setCounterOfferMessage("");
+      setGroupToCounter(null);
+    } catch (e: any) {
+      toast({
+        title: "Failed to send counter offer",
+        description: e?.message || "Could not send counter offer",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setSendingCounterOffer(false);
+    }
+  };
+
   const updateGroupStatus = async (
     group: any,
     status:
@@ -149,7 +209,15 @@ const LicensingRequestsView = ({
     const ids = (group?.talents || [])
       .map((t: any) => t.licensing_request_id)
       .filter(Boolean);
-    if (!ids.length) return;
+    if (!ids.length) {
+      toast({
+        title: "Update failed",
+        description:
+          "Could not find licensing request IDs to update. Please refresh and try again.",
+        variant: "destructive" as any,
+      });
+      return;
+    }
 
     try {
       await updateAgencyLicensingRequestsStatus({
@@ -157,7 +225,8 @@ const LicensingRequestsView = ({
         status,
         notes,
       });
-      await queryClient.invalidateQueries({
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
         queryKey: ["agency", "licensing-requests"],
       });
       if (status === "approved") {
@@ -180,6 +249,18 @@ const LicensingRequestsView = ({
           description: "The client has been notified.",
         });
       }
+      if (status === "declined" || status === "rejected") {
+        toast({
+          title: "Request declined",
+          description: "The licensing request has been declined.",
+        });
+      }
+      if (status === "approved") {
+        toast({
+          title: "Request approved",
+          description: "The licensing request has been approved.",
+        });
+      }
     } catch (e: any) {
       toast({
         title: "Update failed",
@@ -200,7 +281,8 @@ const LicensingRequestsView = ({
         status,
         decline_reason,
       });
-      await queryClient.invalidateQueries({
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
         queryKey: ["agency", "brand-license-requests"],
       });
       if (status === "approved" && onBrandRequestAccepted) {
@@ -219,8 +301,7 @@ const LicensingRequestsView = ({
         });
       }
       if (["declined", "rejected"].includes(status)) {
-        setDeclineModalOpen(false);
-        setDeclineReason("");
+        setShowDeclineConfirm(false);
         setGroupToDecline(null);
         toast({
           title: "Request declined",
@@ -252,7 +333,8 @@ const LicensingRequestsView = ({
         await sendLicensingRequestPaymentLink(licensingRequestId);
       const paymentLinkUrl = String(resp?.payment_link_url || "");
 
-      await queryClient.invalidateQueries({
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
         queryKey: ["agency", "licensing-requests"],
       });
 
@@ -297,6 +379,58 @@ const LicensingRequestsView = ({
     }
   };
 
+  const handleRecoverGroup = async (group: any) => {
+    const groupKey = String(group?.group_key || "");
+    setRecoveringGroup(groupKey);
+    try {
+      await updateGroupStatus(group, "pending");
+      toast({
+        title: "Recovered",
+        description: "Licensing request has been moved back to active.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Recovery failed",
+        description: e?.message || "Could not recover licensing request",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setRecoveringGroup(null);
+    }
+  };
+
+  const handleDeleteGroup = async (group: any) => {
+    const ids = (group?.talents || [])
+      .map((t: any) => t.licensing_request_id)
+      .filter(Boolean);
+    if (!ids.length) return;
+
+    setDeletingGroup(group.group_key);
+    try {
+      await deleteAgencyLicensingRequests({
+        licensing_request_ids: ids,
+      });
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
+        queryKey: ["agency", "licensing-requests"],
+      });
+      toast({
+        title: "Deleted",
+        description: "Licensing request(s) permanently deleted.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Delete failed",
+        description: e?.message || "Could not delete licensing request",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setDeletingGroup(null);
+      setShowDeleteConfirm(false);
+      setGroupToDelete(null);
+    }
+  };
+
   const getRequestDetails = (group: any) => {
     const rawNotes = String(group?.notes || "").trim();
     if (!rawNotes) return {};
@@ -316,6 +450,40 @@ const LicensingRequestsView = ({
     return source === "brand_dashboard";
   };
 
+  const getRequestDurationDays = (group: any) => {
+    const startDateRaw = group?.license_start_date
+      ? new Date(group.license_start_date)
+      : null;
+    const endDateRaw = group?.license_end_date
+      ? new Date(group.license_end_date)
+      : null;
+
+    if (
+      startDateRaw &&
+      !Number.isNaN(startDateRaw.getTime()) &&
+      endDateRaw &&
+      !Number.isNaN(endDateRaw.getTime())
+    ) {
+      return Math.max(
+        0,
+        Math.ceil(
+          (endDateRaw.getTime() - startDateRaw.getTime()) /
+            (1000 * 60 * 60 * 24),
+        ) + 1,
+      );
+    }
+
+    const deadlineRaw = group?.deadline ? new Date(group.deadline) : null;
+    if (deadlineRaw && !Number.isNaN(deadlineRaw.getTime())) {
+      return Math.max(
+        0,
+        Math.ceil((deadlineRaw.getTime() - Date.now()) / (1000 * 60 * 60 * 24)),
+      );
+    }
+
+    return null;
+  };
+
   const filteredData = (data || []).filter((group: any) => {
     const isArchived = ["rejected", "declined", "archived"].includes(
       group.status,
@@ -326,6 +494,75 @@ const LicensingRequestsView = ({
     if (!matchesStatus) return false;
     return !isBrandRequest;
   });
+
+  const filteredRegularData = filteredData.filter((group: any) => {
+    if (filterStatus !== "all" && group.status !== filterStatus) return false;
+
+    const fee = Number(group?.license_fee);
+    if (filterMinLicenseFee.trim()) {
+      const min = Number(filterMinLicenseFee);
+      if (Number.isFinite(min) && Number.isFinite(fee) && fee < min) {
+        return false;
+      }
+      if (Number.isFinite(min) && !Number.isFinite(fee)) return false;
+    }
+
+    if (filterMaxLicenseFee.trim()) {
+      const max = Number(filterMaxLicenseFee);
+      if (Number.isFinite(max) && Number.isFinite(fee) && fee > max) {
+        return false;
+      }
+      if (Number.isFinite(max) && !Number.isFinite(fee)) return false;
+    }
+
+    const durationDays = getRequestDurationDays(group);
+    if (filterMinDuration.trim()) {
+      const min = Number(filterMinDuration);
+      if (Number.isFinite(min)) {
+        if (durationDays === null || durationDays < min) return false;
+      }
+    }
+
+    if (filterMaxDuration.trim()) {
+      const max = Number(filterMaxDuration);
+      if (Number.isFinite(max)) {
+        if (durationDays === null || durationDays > max) return false;
+      }
+    }
+
+    return true;
+  });
+
+  const clearFilters = () => {
+    setFilterStatus("all");
+    setFilterMinLicenseFee("");
+    setFilterMaxLicenseFee("");
+    setFilterMinDuration("");
+    setFilterMaxDuration("");
+  };
+
+  const hasActiveFilters =
+    filterStatus !== "all" ||
+    filterMinLicenseFee ||
+    filterMaxLicenseFee ||
+    filterMinDuration ||
+    filterMaxDuration;
+
+  const feePresets = [
+    { label: "Any", min: "", max: "" },
+    { label: "< $1k", min: "", max: "999" },
+    { label: "$1k - $5k", min: "1000", max: "5000" },
+    { label: "$5k - $10k", min: "5001", max: "10000" },
+    { label: "$10k+", min: "10001", max: "" },
+  ];
+
+  const durationPresets = [
+    { label: "Any", min: "", max: "" },
+    { label: "0-7 days", min: "0", max: "7" },
+    { label: "8-30 days", min: "8", max: "30" },
+    { label: "31-90 days", min: "31", max: "90" },
+    { label: "90+ days", min: "91", max: "" },
+  ];
 
   const filteredBrandData = brandLicenseData.filter((req: any) => {
     const isArchived = ["rejected", "declined", "archived"].includes(
@@ -391,12 +628,38 @@ const LicensingRequestsView = ({
               })}
             </div>
           </div>
-          <Button
-            variant="outline"
-            className="flex w-full items-center justify-center gap-2 border-gray-300 font-bold text-gray-700 bg-white sm:w-auto"
-          >
-            <Filter className="w-4 h-4" /> Filter
-          </Button>
+          <div className="flex items-center gap-2">
+            {hasActiveFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={clearFilters}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                <X className="w-3 h-3 mr-1" /> Clear
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              className={`flex w-full items-center justify-center gap-2 border-gray-300 font-bold text-gray-700 bg-white sm:w-auto ${hasActiveFilters ? "border-indigo-300 bg-indigo-50" : ""}`}
+              onClick={() => setShowFilterDialog(true)}
+            >
+              <Filter className="w-4 h-4" /> Filter
+              {hasActiveFilters && (
+                <span className="ml-1 px-1.5 py-0.5 text-[10px] bg-indigo-500 text-white rounded-full">
+                  {
+                    [
+                      filterStatus !== "all",
+                      filterMinLicenseFee,
+                      filterMaxLicenseFee,
+                      filterMinDuration,
+                      filterMaxDuration,
+                    ].filter(Boolean).length
+                  }
+                </span>
+              )}
+            </Button>
+          </div>
         </div>
 
         <div className="space-y-6">
@@ -416,7 +679,7 @@ const LicensingRequestsView = ({
 
           {!isLoading &&
             !error &&
-            filteredData.length === 0 &&
+            filteredRegularData.length === 0 &&
             activeRequestTab !== "Brand Requests" && (
               <Card className="p-8 bg-white border-2 border-gray-900 rounded-none">
                 <div className="text-gray-500 font-medium">
@@ -428,7 +691,7 @@ const LicensingRequestsView = ({
             )}
 
           {activeRequestTab !== "Brand Requests" &&
-            filteredData.map((group: any) => (
+            filteredRegularData.map((group: any) => (
               <Card
                 key={group.group_key}
                 className="p-8 bg-white border-2 border-gray-900 rounded-none overflow-hidden relative"
@@ -536,14 +799,45 @@ const LicensingRequestsView = ({
                     )}
                   </div>
                 ) : activeRequestTab === "Archive" ? (
-                  <div className="grid grid-cols-1 md:grid-cols-1 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <Button
                       variant="outline"
-                      onClick={() => updateGroupStatus(group, "pending")}
+                      onClick={() => handleRecoverGroup(group)}
+                      disabled={recoveringGroup === group.group_key}
                       className="border-gray-300 text-gray-700 font-bold h-11 rounded-md flex items-center justify-center gap-2"
                     >
-                      <RefreshCw className="w-4 h-4" />
-                      Recover to Active
+                      {recoveringGroup === group.group_key ? (
+                        <>
+                          <RefreshCw className="w-4 h-4 animate-spin" />
+                          Recovering...
+                        </>
+                      ) : (
+                        <>
+                          <RefreshCw className="w-4 h-4" />
+                          Recover to Active
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setGroupToDelete(group);
+                        setShowDeleteConfirm(true);
+                      }}
+                      disabled={deletingGroup === group.group_key}
+                      className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-11 rounded-md flex items-center justify-center gap-2"
+                    >
+                      {deletingGroup === group.group_key ? (
+                        <>
+                          <RefreshCw className="w-4 h-4 animate-spin" />
+                          Deleting...
+                        </>
+                      ) : (
+                        <>
+                          <Trash2 className="w-4 h-4" />
+                          Delete Permanently
+                        </>
+                      )}
                     </Button>
                   </div>
                 ) : (
@@ -569,7 +863,10 @@ const LicensingRequestsView = ({
                     </Button>
                     <Button
                       variant="outline"
-                      onClick={() => updateGroupStatus(group, "rejected")}
+                      onClick={() => {
+                        setGroupToDecline(group);
+                        setShowDeclineConfirm(true);
+                      }}
                       className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-11 rounded-md flex items-center justify-center gap-2"
                     >
                       <div className="w-4 h-4 rounded-full border-2 border-red-200 flex items-center justify-center">
@@ -711,7 +1008,7 @@ const LicensingRequestsView = ({
                       variant="outline"
                       onClick={() => {
                         setGroupToDecline(req);
-                        setDeclineModalOpen(true);
+                        setShowDeclineConfirm(true);
                       }}
                       className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-11 rounded-md flex items-center justify-center gap-2"
                     >
@@ -725,6 +1022,101 @@ const LicensingRequestsView = ({
               </Card>
             ))}
         </div>
+
+        <Dialog open={showFilterDialog} onOpenChange={setShowFilterDialog}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Filter Licensing Requests</DialogTitle>
+              <DialogDescription>
+                Narrow down your licensing requests by status, license fee, and
+                duration.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <Select value={filterStatus} onValueChange={setFilterStatus}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="All statuses" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Statuses</SelectItem>
+                    <SelectItem value="pending">Pending</SelectItem>
+                    <SelectItem value="approved">Approved</SelectItem>
+                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="negotiating">Negotiating</SelectItem>
+                    <SelectItem value="declined">Declined</SelectItem>
+                    <SelectItem value="archived">Archived</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>License Fee</Label>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {feePresets.map((preset) => {
+                    const active =
+                      filterMinLicenseFee === preset.min &&
+                      filterMaxLicenseFee === preset.max;
+                    return (
+                      <Button
+                        key={preset.label}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        onClick={() => {
+                          setFilterMinLicenseFee(preset.min);
+                          setFilterMaxLicenseFee(preset.max);
+                        }}
+                        className={`justify-center font-bold ${active ? "bg-indigo-600 text-white hover:bg-indigo-600" : "border-gray-200 text-gray-700"}`}
+                      >
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Duration</Label>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {durationPresets.map((preset) => {
+                    const active =
+                      filterMinDuration === preset.min &&
+                      filterMaxDuration === preset.max;
+                    return (
+                      <Button
+                        key={preset.label}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        onClick={() => {
+                          setFilterMinDuration(preset.min);
+                          setFilterMaxDuration(preset.max);
+                        }}
+                        className={`justify-center font-bold ${active ? "bg-indigo-600 text-white hover:bg-indigo-600" : "border-gray-200 text-gray-700"}`}
+                      >
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={clearFilters}
+                className="font-bold"
+              >
+                Clear Filters
+              </Button>
+              <Button onClick={() => setShowFilterDialog(false)}>
+                Apply Filters
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <Dialog
           open={counterOfferModalOpen}
@@ -761,59 +1153,112 @@ const LicensingRequestsView = ({
                 Cancel
               </Button>
               <Button
-                onClick={() =>
-                  updateGroupStatus(
-                    groupToCounter,
-                    "negotiating",
-                    counterOfferMessage,
-                  )
-                }
-                disabled={!counterOfferMessage.trim()}
+                onClick={handleSendCounterOffer}
+                disabled={!counterOfferMessage.trim() || sendingCounterOffer}
                 className="bg-indigo-600 hover:bg-indigo-700 text-white font-bold"
               >
-                Send Counter Offer
+                {sendingCounterOffer ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  "Send Counter Offer"
+                )}
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
 
-        <Dialog
-          open={declineModalOpen}
-          onOpenChange={(open) => {
-            setDeclineModalOpen(open);
-            if (!open) {
-              setDeclineReason("");
-              setGroupToDecline(null);
-            }
-          }}
-        >
+        <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
           <DialogContent className="max-w-md">
             <DialogHeader>
-              <DialogTitle>Decline Brand Request</DialogTitle>
+              <DialogTitle>Delete Licensing Request</DialogTitle>
               <DialogDescription>
-                Share a brief reason so the brand understands your decision.
+                {groupToDelete?.status === "archived"
+                  ? "This will permanently delete this archived licensing request. This action cannot be undone."
+                  : "This will archive and then permanently delete this licensing request. This action cannot be undone."}
               </DialogDescription>
             </DialogHeader>
 
-            <div className="space-y-4 py-2">
-              <div className="space-y-2">
-                <Label>Reason</Label>
-                <Textarea
-                  value={declineReason}
-                  onChange={(e) => setDeclineReason(e.target.value)}
-                  placeholder="Tell the brand why you are declining..."
-                  rows={5}
-                  className="resize-none"
-                />
-              </div>
+            <div className="py-4">
+              <p className="text-sm text-gray-600">
+                Are you sure you want to delete the licensing request for{" "}
+                <span className="font-semibold">
+                  {groupToDelete?.brand_name || "Unknown brand"}
+                </span>
+                ?
+              </p>
             </div>
 
             <DialogFooter>
               <Button
                 variant="outline"
                 onClick={() => {
-                  setDeclineModalOpen(false);
-                  setDeclineReason("");
+                  setShowDeleteConfirm(false);
+                  setGroupToDelete(null);
+                }}
+                className="font-bold"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleDeleteGroup(groupToDelete)}
+                disabled={deletingGroup === groupToDelete?.group_key}
+                className="font-bold"
+              >
+                {deletingGroup === groupToDelete?.group_key ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete Permanently
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={showDeclineConfirm}
+          onOpenChange={(open) => {
+            setShowDeclineConfirm(open);
+            if (!open) {
+              setGroupToDecline(null);
+            }
+          }}
+        >
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Confirm Decline</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to decline this licensing request? This
+                action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="py-4">
+              <p className="text-sm text-gray-600">
+                You are about to decline the request from{" "}
+                <span className="font-semibold">
+                  {groupToDecline?.brand_name ||
+                    groupToDecline?.brands?.company_name ||
+                    "this brand"}
+                </span>
+                .
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowDeclineConfirm(false);
                   setGroupToDecline(null);
                 }}
                 className="font-bold"
@@ -821,27 +1266,39 @@ const LicensingRequestsView = ({
                 Cancel
               </Button>
               <Button
-                onClick={() => {
-                  if (groupToDecline?.id && !groupToDecline?.group_key) {
-                    // This is a brand request
-                    updateBrandRequestStatus(
-                      groupToDecline,
-                      "declined",
-                      declineReason,
-                    );
-                  } else {
-                    // This is a regular licensing request group
-                    updateGroupStatus(
-                      groupToDecline,
-                      "declined",
-                      declineReason,
-                    );
+                variant="destructive"
+                onClick={async () => {
+                  setIsDeclining(true);
+                  try {
+                    const isBrandRequest =
+                      groupToDecline?.id &&
+                      !groupToDecline?.group_key &&
+                      groupToDecline?.brands;
+                    if (isBrandRequest) {
+                      await updateBrandRequestStatus(
+                        groupToDecline,
+                        "declined",
+                      );
+                    } else {
+                      await updateGroupStatus(groupToDecline, "declined");
+                    }
+                    setShowDeclineConfirm(false);
+                    setGroupToDecline(null);
+                  } finally {
+                    setIsDeclining(false);
                   }
                 }}
-                disabled={!declineReason.trim()}
+                disabled={isDeclining}
                 className="bg-red-600 hover:bg-red-700 text-white font-bold"
               >
-                Decline Request
+                {isDeclining ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Declining...
+                  </>
+                ) : (
+                  "Yes, Decline"
+                )}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/likelee-ui/src/components/crm/AddClientModal.tsx
+++ b/likelee-ui/src/components/crm/AddClientModal.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { MandatoryHint } from "@/components/ui/field-hint";
+
 import {
   Select,
   SelectContent,
@@ -134,35 +134,29 @@ const AddClientModal = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto p-0 rounded-2xl border-none">
-        <div className="p-8 space-y-6">
+      <DialogContent className="sm:max-w-[650px] max-h-[90vh] overflow-y-auto p-0 rounded-2xl border-none">
+        <div className="p-10 space-y-8">
           <div className="flex justify-between items-center">
             <DialogTitle className="text-2xl font-bold text-gray-900">
               Add New Client
             </DialogTitle>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between gap-2">
-                <Label className="text-sm font-bold text-gray-700">
-                  Company Name *
-                </Label>
-                <MandatoryHint />
-              </div>
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-3">
+              <Label className="text-sm font-bold text-gray-700">
+                Company Name *
+              </Label>
               <Input
                 placeholder="Company Inc."
-                className="h-11 bg-gray-50 border-gray-200 rounded-xl"
+                className="h-12 bg-gray-50 border-gray-200 rounded-xl"
                 value={formData.company}
                 onChange={(e) =>
                   setFormData({ ...formData, company: e.target.value })
                 }
               />
-              <p className="text-[11px] font-medium text-amber-700 dark:text-amber-400">
-                This field is mandatory.
-              </p>
             </div>
-            <div className="space-y-2">
+            <div className="space-y-3">
               <Label className="text-sm font-bold text-gray-700">
                 Industry
               </Label>
@@ -172,7 +166,7 @@ const AddClientModal = ({
                   setFormData({ ...formData, industry: val })
                 }
               >
-                <SelectTrigger className="h-11 bg-gray-50 border-gray-200 rounded-xl">
+                <SelectTrigger className="h-12 bg-gray-50 border-gray-200 rounded-xl">
                   <SelectValue placeholder="Select Industry" />
                 </SelectTrigger>
                 <SelectContent>
@@ -186,11 +180,11 @@ const AddClientModal = ({
             </div>
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label className="text-sm font-bold text-gray-700">Website</Label>
             <Input
               placeholder="company.com"
-              className="h-11 bg-gray-50 border-gray-200 rounded-xl"
+              className="h-12 bg-gray-50 border-gray-200 rounded-xl"
               value={formData.website}
               onChange={(e) =>
                 setFormData({ ...formData, website: e.target.value })
@@ -198,7 +192,7 @@ const AddClientModal = ({
             />
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label className="text-sm font-bold text-gray-700">
               Pipeline Stage
             </Label>
@@ -206,7 +200,7 @@ const AddClientModal = ({
               value={formData.status}
               onValueChange={(val) => setFormData({ ...formData, status: val })}
             >
-              <SelectTrigger className="h-11 bg-gray-50 border-gray-200 rounded-xl">
+              <SelectTrigger className="h-12 bg-gray-50 border-gray-200 rounded-xl">
                 <SelectValue placeholder="Select stage" />
               </SelectTrigger>
               <SelectContent>
@@ -217,7 +211,7 @@ const AddClientModal = ({
             </Select>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-4">
             <Label className="text-sm font-bold text-gray-700">Tags</Label>
             <div className="flex flex-wrap gap-2">
               {TAG_OPTIONS.map((tag) => {
@@ -242,13 +236,13 @@ const AddClientModal = ({
             </div>
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label className="text-sm font-bold text-gray-700">
               Next Follow-up Date
             </Label>
             <Input
               type="date"
-              className="h-11 bg-gray-50 border-gray-200 rounded-xl"
+              className="h-12 bg-gray-50 border-gray-200 rounded-xl"
               value={formData.next_follow_up_date}
               onChange={(e) =>
                 setFormData({
@@ -259,11 +253,11 @@ const AddClientModal = ({
             />
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label className="text-sm font-bold text-gray-700">Notes</Label>
             <Textarea
               placeholder="Add notes about this client..."
-              className="min-h-[100px] bg-gray-50 border-gray-200 rounded-xl resize-none"
+              className="min-h-[120px] bg-gray-50 border-gray-200 rounded-xl resize-none"
               value={formData.notes}
               onChange={(e) =>
                 setFormData({ ...formData, notes: e.target.value })
@@ -271,18 +265,18 @@ const AddClientModal = ({
             />
           </div>
 
-          <div className="flex justify-end gap-3 pt-4">
+          <div className="flex justify-end gap-4 pt-8">
             <Button
               variant="outline"
               onClick={onClose}
-              className="h-11 px-8 rounded-xl border-gray-200 font-bold"
+              className="h-12 px-10 rounded-xl border-gray-200 font-bold"
             >
               Cancel
             </Button>
             <Button
               onClick={handleSubmit}
               disabled={mutation.isPending}
-              className="h-11 px-8 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-xl"
+              className="h-12 px-10 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-xl"
             >
               {mutation.isPending ? "Adding..." : "Add Client"}
             </Button>

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -11,6 +11,8 @@ import {
   Send,
   Copy,
   CheckCircle,
+  X,
+  Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -26,8 +28,16 @@ import {
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   getAgencyLicensingRequests,
   updateAgencyLicensingRequestsStatus,
+  deleteAgencyLicensingRequests,
   sendLicensingRequestPaymentLink,
 } from "@/api/functions";
 
@@ -56,9 +66,22 @@ export const LicensingRequestsTab = ({
   const [counterOfferModalOpen, setCounterOfferModalOpen] = useState(false);
   const [counterOfferMessage, setCounterOfferMessage] = useState("");
   const [groupToCounter, setGroupToCounter] = useState<any>(null);
+  const [sendingCounterOffer, setSendingCounterOffer] = useState(false);
   const [activeRequestTab, setActiveRequestTab] = useState<
     "Active" | "Archive"
   >("Active");
+  const [showFilterDialog, setShowFilterDialog] = useState(false);
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [filterMinLicenseFee, setFilterMinLicenseFee] = useState<string>("");
+  const [filterMaxLicenseFee, setFilterMaxLicenseFee] = useState<string>("");
+  const [filterMinDuration, setFilterMinDuration] = useState<string>("");
+  const [filterMaxDuration, setFilterMaxDuration] = useState<string>("");
+  const [deletingGroup, setDeletingGroup] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [groupToDelete, setGroupToDelete] = useState<any>(null);
+  const [decliningGroup, setDecliningGroup] = useState<string | null>(null);
+  const [showDeclineConfirm, setShowDeclineConfirm] = useState(false);
+  const [groupToDecline, setGroupToDecline] = useState<any>(null);
 
   const statusStyle = (status: string) => {
     if (status === "approved") return "bg-green-100 text-green-700";
@@ -74,6 +97,70 @@ export const LicensingRequestsTab = ({
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     });
+  };
+
+  const handleDecline = async (group: any) => {
+    setDecliningGroup(group.group_key);
+    try {
+      await updateAgencyLicensingRequestsStatus({
+        licensing_request_ids: (group?.talents || [])
+          .map((t: any) => t.licensing_request_id)
+          .filter(Boolean),
+        status: "rejected",
+      });
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
+        queryKey: ["agency", "licensing-requests"],
+      });
+      toast({
+        title: "Request declined",
+        description: "The licensing request has been declined.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Decline failed",
+        description: e?.message || "Could not decline licensing request",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setDecliningGroup(null);
+      setShowDeclineConfirm(false);
+      setGroupToDecline(null);
+    }
+  };
+
+  const handleSendCounterOffer = async () => {
+    if (!groupToCounter || !counterOfferMessage.trim()) return;
+    setSendingCounterOffer(true);
+    try {
+      const ids = (groupToCounter?.talents || [])
+        .map((t: any) => t.licensing_request_id)
+        .filter(Boolean);
+      await updateAgencyLicensingRequestsStatus({
+        licensing_request_ids: ids,
+        status: "negotiating",
+        notes: counterOfferMessage,
+      });
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
+        queryKey: ["agency", "licensing-requests"],
+      });
+      toast({
+        title: "Counter offer sent",
+        description: "The client has been notified.",
+      });
+      setCounterOfferModalOpen(false);
+      setCounterOfferMessage("");
+      setGroupToCounter(null);
+    } catch (e: any) {
+      toast({
+        title: "Failed to send counter offer",
+        description: e?.message || "Could not send counter offer",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setSendingCounterOffer(false);
+    }
   };
 
   const updateGroupStatus = async (
@@ -92,7 +179,8 @@ export const LicensingRequestsTab = ({
         status,
         notes,
       });
-      await queryClient.invalidateQueries({
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
         queryKey: ["agency", "licensing-requests"],
       });
       if (status === "negotiating") {
@@ -128,7 +216,8 @@ export const LicensingRequestsTab = ({
     try {
       const resp = await sendLicensingRequestPaymentLink(licensingRequestId);
       const emailSent = (resp as any)?.email_sent;
-      await queryClient.invalidateQueries({
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
         queryKey: ["agency", "licensing-requests"],
       });
       toast({
@@ -172,12 +261,145 @@ export const LicensingRequestsTab = ({
     }
   };
 
+  const handleDeleteGroup = async (group: any) => {
+    const ids = (group?.talents || [])
+      .map((t: any) => t.licensing_request_id)
+      .filter(Boolean);
+    if (!ids.length) return;
+
+    setDeletingGroup(group.group_key);
+    try {
+      await deleteAgencyLicensingRequests({
+        licensing_request_ids: ids,
+      });
+      // Fire-and-forget cache invalidation
+      queryClient.invalidateQueries({
+        queryKey: ["agency", "licensing-requests"],
+      });
+      toast({
+        title: "Deleted",
+        description: "Licensing request(s) permanently deleted.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Delete failed",
+        description: e?.message || "Could not delete licensing request",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setDeletingGroup(null);
+      setShowDeleteConfirm(false);
+      setGroupToDelete(null);
+    }
+  };
+
+  const getRequestDurationDays = (group: any) => {
+    const startDateRaw = group?.license_start_date
+      ? new Date(group.license_start_date)
+      : null;
+    const endDateRaw = group?.license_end_date
+      ? new Date(group.license_end_date)
+      : null;
+
+    if (
+      startDateRaw &&
+      !Number.isNaN(startDateRaw.getTime()) &&
+      endDateRaw &&
+      !Number.isNaN(endDateRaw.getTime())
+    ) {
+      return Math.max(
+        0,
+        Math.ceil(
+          (endDateRaw.getTime() - startDateRaw.getTime()) /
+            (1000 * 60 * 60 * 24),
+        ) + 1,
+      );
+    }
+
+    const deadlineRaw = group?.deadline ? new Date(group.deadline) : null;
+    if (deadlineRaw && !Number.isNaN(deadlineRaw.getTime())) {
+      return Math.max(
+        0,
+        Math.ceil((deadlineRaw.getTime() - Date.now()) / (1000 * 60 * 60 * 24)),
+      );
+    }
+
+    return null;
+  };
+
   const filteredData = (data || []).filter((group: any) => {
     const isArchived = ["rejected", "declined", "archived"].includes(
       group.status,
     );
-    return activeRequestTab === "Active" ? !isArchived : isArchived;
+    if (activeRequestTab === "Active" ? isArchived : !isArchived) return false;
+
+    if (filterStatus !== "all" && group.status !== filterStatus) return false;
+
+    const fee = Number(group?.license_fee);
+    if (filterMinLicenseFee.trim()) {
+      const min = Number(filterMinLicenseFee);
+      if (Number.isFinite(min) && Number.isFinite(fee) && fee < min) {
+        return false;
+      }
+      if (Number.isFinite(min) && !Number.isFinite(fee)) return false;
+    }
+
+    if (filterMaxLicenseFee.trim()) {
+      const max = Number(filterMaxLicenseFee);
+      if (Number.isFinite(max) && Number.isFinite(fee) && fee > max) {
+        return false;
+      }
+      if (Number.isFinite(max) && !Number.isFinite(fee)) return false;
+    }
+
+    const durationDays = getRequestDurationDays(group);
+    if (filterMinDuration.trim()) {
+      const min = Number(filterMinDuration);
+      if (Number.isFinite(min)) {
+        if (durationDays === null || durationDays < min) return false;
+      }
+    }
+
+    if (filterMaxDuration.trim()) {
+      const max = Number(filterMaxDuration);
+      if (Number.isFinite(max)) {
+        if (durationDays === null || durationDays > max) return false;
+      }
+    }
+
+    return true;
   });
+
+  const clearFilters = () => {
+    setFilterStatus("all");
+    setFilterMinLicenseFee("");
+    setFilterMaxLicenseFee("");
+    setFilterMinDuration("");
+    setFilterMaxDuration("");
+  };
+
+  const hasActiveFilters =
+    filterStatus !== "all" ||
+    filterMinLicenseFee ||
+    filterMaxLicenseFee ||
+    filterMinDuration ||
+    filterMaxDuration;
+
+  const feePresets = [
+    { label: "Any", min: "", max: "" },
+    { label: "< $1k", min: "", max: "999" },
+    { label: "$1k - $5k", min: "1000", max: "5000" },
+    { label: "$5k - $10k", min: "5001", max: "10000" },
+    { label: "$10k+", min: "10001", max: "" },
+  ];
+
+  const durationPresets = [
+    { label: "Any", min: "", max: "" },
+    { label: "0-7 days", min: "0", max: "7" },
+    { label: "8-30 days", min: "8", max: "30" },
+    { label: "31-90 days", min: "31", max: "90" },
+    { label: "90+ days", min: "91", max: "" },
+  ];
 
   return (
     <>
@@ -199,12 +421,38 @@ export const LicensingRequestsTab = ({
               ))}
             </div>
           </div>
-          <Button
-            variant="outline"
-            className="flex items-center gap-2 border-gray-300 font-bold text-gray-700 bg-white"
-          >
-            <Filter className="w-4 h-4" /> Filter
-          </Button>
+          <div className="flex items-center gap-2">
+            {hasActiveFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={clearFilters}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                <X className="w-3 h-3 mr-1" /> Clear
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              className={`flex items-center gap-2 border-gray-300 font-bold text-gray-700 bg-white ${hasActiveFilters ? "border-indigo-300 bg-indigo-50" : ""}`}
+              onClick={() => setShowFilterDialog(true)}
+            >
+              <Filter className="w-4 h-4" /> Filter
+              {hasActiveFilters && (
+                <span className="ml-1 px-1.5 py-0.5 text-[10px] bg-indigo-500 text-white rounded-full">
+                  {
+                    [
+                      filterStatus !== "all",
+                      filterMinLicenseFee,
+                      filterMaxLicenseFee,
+                      filterMinDuration,
+                      filterMaxDuration,
+                    ].filter(Boolean).length
+                  }
+                </span>
+              )}
+            </Button>
+          </div>
         </div>
 
         <div className="space-y-6">
@@ -339,7 +587,7 @@ export const LicensingRequestsTab = ({
                   </Button>
                 </div>
               ) : activeRequestTab === "Archive" ? (
-                <div className="grid grid-cols-1 md:grid-cols-1 gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Button
                     variant="outline"
                     onClick={() => updateGroupStatus(group, "pending")}
@@ -347,6 +595,27 @@ export const LicensingRequestsTab = ({
                   >
                     <RefreshCw className="w-4 h-4" />
                     Recover to Active
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setGroupToDelete(group);
+                      setShowDeleteConfirm(true);
+                    }}
+                    disabled={deletingGroup === group.group_key}
+                    className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-10 rounded-md flex items-center justify-center gap-2"
+                  >
+                    {deletingGroup === group.group_key ? (
+                      <>
+                        <RefreshCw className="w-4 h-4 animate-spin" />
+                        Deleting...
+                      </>
+                    ) : (
+                      <>
+                        <Trash2 className="w-4 h-4" />
+                        Delete Permanently
+                      </>
+                    )}
                   </Button>
                 </div>
               ) : (
@@ -379,13 +648,26 @@ export const LicensingRequestsTab = ({
                   </Button>
                   <Button
                     variant="outline"
-                    onClick={() => updateGroupStatus(group, "rejected")}
+                    onClick={() => {
+                      setGroupToDecline(group);
+                      setShowDeclineConfirm(true);
+                    }}
+                    disabled={decliningGroup === group.group_key}
                     className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-10 rounded-md flex items-center justify-center gap-2"
                   >
-                    <div className="w-4 h-4 rounded-full border-2 border-red-200 flex items-center justify-center">
-                      <span className="text-[10px]">✕</span>
-                    </div>
-                    Decline
+                    {decliningGroup === group.group_key ? (
+                      <>
+                        <RefreshCw className="w-4 h-4 animate-spin" />
+                        Declining...
+                      </>
+                    ) : (
+                      <>
+                        <div className="w-4 h-4 rounded-full border-2 border-red-200 flex items-center justify-center">
+                          <span className="text-[10px]">✕</span>
+                        </div>
+                        Decline
+                      </>
+                    )}
                   </Button>
                 </div>
               )}
@@ -428,17 +710,219 @@ export const LicensingRequestsTab = ({
                 Cancel
               </Button>
               <Button
-                onClick={() =>
-                  updateGroupStatus(
-                    groupToCounter,
-                    "negotiating",
-                    counterOfferMessage,
-                  )
-                }
-                disabled={!counterOfferMessage.trim()}
+                onClick={handleSendCounterOffer}
+                disabled={!counterOfferMessage.trim() || sendingCounterOffer}
                 className="bg-indigo-500 hover:bg-indigo-500 text-white font-bold"
               >
-                Send Counter Offer
+                {sendingCounterOffer ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  "Send Counter Offer"
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Filter Dialog */}
+        <Dialog open={showFilterDialog} onOpenChange={setShowFilterDialog}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Filter Licensing Requests</DialogTitle>
+              <DialogDescription>
+                Narrow down your licensing requests by status, license fee, and
+                duration.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <Select value={filterStatus} onValueChange={setFilterStatus}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="All statuses" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Statuses</SelectItem>
+                    <SelectItem value="pending">Pending</SelectItem>
+                    <SelectItem value="approved">Approved</SelectItem>
+                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="negotiating">Negotiating</SelectItem>
+                    <SelectItem value="declined">Declined</SelectItem>
+                    <SelectItem value="archived">Archived</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>License Fee</Label>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {feePresets.map((preset) => {
+                    const active =
+                      filterMinLicenseFee === preset.min &&
+                      filterMaxLicenseFee === preset.max;
+                    return (
+                      <Button
+                        key={preset.label}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        onClick={() => {
+                          setFilterMinLicenseFee(preset.min);
+                          setFilterMaxLicenseFee(preset.max);
+                        }}
+                        className={`justify-center font-bold ${active ? "bg-indigo-600 text-white hover:bg-indigo-600" : "border-gray-200 text-gray-700"}`}
+                      >
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Duration</Label>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {durationPresets.map((preset) => {
+                    const active =
+                      filterMinDuration === preset.min &&
+                      filterMaxDuration === preset.max;
+                    return (
+                      <Button
+                        key={preset.label}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        onClick={() => {
+                          setFilterMinDuration(preset.min);
+                          setFilterMaxDuration(preset.max);
+                        }}
+                        className={`justify-center font-bold ${active ? "bg-indigo-600 text-white hover:bg-indigo-600" : "border-gray-200 text-gray-700"}`}
+                      >
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={clearFilters}
+                className="font-bold"
+              >
+                Clear Filters
+              </Button>
+              <Button onClick={() => setShowFilterDialog(false)}>
+                Apply Filters
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Delete Confirmation Dialog */}
+        <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Delete Licensing Request</DialogTitle>
+              <DialogDescription>
+                This will permanently delete this licensing request. This action
+                cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="py-4">
+              <p className="text-sm text-gray-600">
+                Are you sure you want to delete the licensing request for{" "}
+                <span className="font-semibold">
+                  {groupToDelete?.brand_name || "Unknown brand"}
+                </span>
+                ?
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowDeleteConfirm(false);
+                  setGroupToDelete(null);
+                }}
+                className="font-bold"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleDeleteGroup(groupToDelete)}
+                disabled={deletingGroup === groupToDelete?.group_key}
+                className="font-bold"
+              >
+                {deletingGroup === groupToDelete?.group_key ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete Permanently
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Decline Confirmation Dialog */}
+        <Dialog open={showDeclineConfirm} onOpenChange={setShowDeclineConfirm}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Confirm Decline</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to decline this licensing request? This
+                action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="py-4">
+              <p className="text-sm text-gray-600">
+                You are about to decline the request from{" "}
+                <span className="font-semibold">
+                  {groupToDecline?.brand_name || "this brand"}
+                </span>
+                .
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowDeclineConfirm(false);
+                  setGroupToDecline(null);
+                }}
+                className="font-bold"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleDecline(groupToDecline)}
+                disabled={decliningGroup === groupToDecline?.group_key}
+                className="font-bold"
+              >
+                {decliningGroup === groupToDecline?.group_key ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Declining...
+                  </>
+                ) : (
+                  "Yes, Decline"
+                )}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -327,11 +327,36 @@ export const LicensingRequestsTab = ({
     return null;
   };
 
+  const isLicenseExpired = (group: any) => {
+    const now = new Date();
+    const endDateRaw = group?.license_end_date
+      ? new Date(group.license_end_date)
+      : null;
+    if (endDateRaw && !Number.isNaN(endDateRaw.getTime()) && endDateRaw < now) {
+      return true;
+    }
+    const deadlineRaw = group?.deadline ? new Date(group.deadline) : null;
+    if (
+      deadlineRaw &&
+      !Number.isNaN(deadlineRaw.getTime()) &&
+      deadlineRaw < now
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   const filteredData = (data || []).filter((group: any) => {
     const isArchived = ["rejected", "declined", "archived"].includes(
       group.status,
     );
-    if (activeRequestTab === "Active" ? isArchived : !isArchived) return false;
+    const isExpired = isLicenseExpired(group);
+    if (
+      activeRequestTab === "Active"
+        ? isArchived || isExpired
+        : !isArchived && !isExpired
+    )
+      return false;
 
     if (filterStatus !== "all" && group.status !== filterStatus) return false;
 
@@ -456,6 +481,28 @@ export const LicensingRequestsTab = ({
         </div>
 
         <div className="space-y-6">
+          {activeRequestTab === "Active" && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+              <svg
+                className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <p className="text-xs text-amber-800">
+                Licensing requests past their end date are automatically moved
+                to the Archive tab.
+              </p>
+            </div>
+          )}
+
           {isLoading && (
             <Card className="p-8 bg-white border-2 border-gray-900 rounded-none">
               <div className="text-gray-500 font-medium">Loading...</div>

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -60,7 +60,6 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 import { DocusealForm } from "@docuseal/react";
-import { MandatoryHint } from "@/components/ui/field-hint";
 
 interface SubmissionWizardProps {
   isOpen: boolean;
@@ -304,7 +303,14 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
       // Fetch agency talents
       getAgencyTalents()
         .then((res) => {
-          setTalents(res || []);
+          // Deduplicate talents by id to prevent duplicates in dropdown
+          const seen = new Set<string>();
+          const uniqueTalents = (res || []).filter((t: any) => {
+            if (!t.id || seen.has(t.id)) return false;
+            seen.add(t.id);
+            return true;
+          });
+          setTalents(uniqueTalents);
         })
         .catch((err) => {
           console.error(`Failed to fetch ${entityPluralLower}:`, err);
@@ -429,6 +435,16 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
         setIsSyncing(false);
       }
     } else if (step === 2) {
+      // Validate contract body before proceeding
+      if (!currentData.contract_body || !currentData.contract_body.trim()) {
+        toast({
+          title: "Contract Body Required",
+          description:
+            "The contract body cannot be empty. Please ensure the template has contract content or add content before proceeding.",
+          variant: "warning",
+        });
+        return;
+      }
       // Transition to Step 3: DocuSeal Sync
       handleSyncToDocuSeal();
     }
@@ -676,7 +692,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                     </div>
                   </div>
                 )}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
                   <div className="p-8 bg-white rounded-3xl border border-slate-200/60 shadow-sm space-y-6">
                     <div className="flex items-center gap-3 mb-2">
                       <div className="w-10 h-10 bg-indigo-50 rounded-2xl flex items-center justify-center">
@@ -686,14 +702,11 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                         Identification
                       </h3>
                     </div>
-                    <div className="space-y-4">
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between gap-2 ml-1">
-                          <Label className="text-sm font-bold text-slate-800">
-                            Brand Name *
-                          </Label>
-                          <MandatoryHint />
-                        </div>
+                    <div className="space-y-6">
+                      <div className="space-y-3">
+                        <Label className="text-sm font-bold text-slate-800 ml-1">
+                          Brand Name *
+                        </Label>
                         <Input
                           {...register("client_name", { required: true })}
                           placeholder="e.g. Nike, Spotify"
@@ -705,13 +718,10 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           </p>
                         )}
                       </div>
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between gap-2 ml-1">
-                          <Label className="text-sm font-bold text-slate-800">
-                            {`${entitySingularTitle} Name *`}
-                          </Label>
-                          <MandatoryHint />
-                        </div>
+                      <div className="space-y-3">
+                        <Label className="text-sm font-bold text-slate-800 ml-1">
+                          {`${entitySingularTitle} Name *`}
+                        </Label>
                         <input
                           type="hidden"
                           {...register("talent_name", { required: true })}
@@ -803,11 +813,10 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                                           t.full_legal_name ||
                                           t.email ||
                                           `Unknown ${entitySingularTitle}`;
-                                        const isSelected = formData.talent_name
-                                          ? formData.talent_name
-                                              .split(", ")
-                                              .includes(talentName)
-                                          : false;
+                                        // Check selection by ID to handle duplicate names
+                                        const isSelected =
+                                          t.id &&
+                                          selectedTalentIds.includes(t.id);
                                         return (
                                           <CommandItem
                                             key={t.id}
@@ -908,14 +917,11 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           </span>
                         )}
                       </div>
-                      <div className="space-y-2">
+                      <div className="space-y-3">
                         <div className="flex items-start justify-between ml-1 gap-2">
-                          <div className="flex items-center gap-2">
-                            <Label className="text-sm font-bold text-slate-800 whitespace-nowrap mt-1">
-                              Client Email*
-                            </Label>
-                            <MandatoryHint />
-                          </div>
+                          <Label className="text-sm font-bold text-slate-800 whitespace-nowrap">
+                            Client Email *
+                          </Label>
                           {brandOptions.length > 0 && (
                             <div className="flex items-center gap-2">
                               <Label
@@ -1036,9 +1042,9 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                       </div>
                       <h3 className="font-bold text-slate-900">Commercials</h3>
                     </div>
-                    <div className="space-y-4">
-                      <div className="grid grid-cols-2 gap-4">
-                        <div className="space-y-2">
+                    <div className="space-y-6">
+                      <div className="grid grid-cols-2 gap-6">
+                        <div className="space-y-3">
                           <Label className="text-sm font-bold text-slate-800 ml-1">
                             Duration (days)
                           </Label>
@@ -1050,7 +1056,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                             className="h-12 bg-slate-50 border-slate-200 rounded-xl font-medium"
                           />
                         </div>
-                        <div className="space-y-2">
+                        <div className="space-y-3">
                           <Label className="text-sm font-bold text-slate-800 ml-1">
                             Territory
                           </Label>
@@ -1060,7 +1066,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           />
                         </div>
                       </div>
-                      <div className="space-y-2">
+                      <div className="space-y-3">
                         <Label className="text-sm font-bold text-slate-800 ml-1">
                           Exclusivity
                         </Label>
@@ -1084,7 +1090,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           </SelectContent>
                         </Select>
                       </div>
-                      <div className="space-y-2">
+                      <div className="space-y-3">
                         <Label className="text-sm font-bold text-slate-800 ml-1">
                           Modifications Allowed
                         </Label>
@@ -1094,7 +1100,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           className="h-12 bg-slate-50 border-slate-200 rounded-xl font-medium"
                         />
                       </div>
-                      <div className="space-y-2">
+                      <div className="space-y-3">
                         <Label className="text-sm font-bold text-slate-800 ml-1">
                           License Fee ($)
                         </Label>
@@ -1116,7 +1122,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                   <Textarea
                     {...register("custom_terms")}
                     placeholder="Describe any other conditions for this specific deal..."
-                    className="min-h-[120px] bg-slate-50 border-slate-200 rounded-2xl font-medium p-6"
+                    className="min-h-[140px] bg-slate-50 border-slate-200 rounded-2xl font-medium p-6"
                   />
                 </div>
               </div>

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -14,6 +14,8 @@ import {
   createBrandLicensingRequest,
   createAgencyBrandLicensingRequest,
   getBrandLicensingRequests,
+  updateBrandLicensingRequestsStatus,
+  deleteBrandLicensingRequests,
   getBrandProfile,
   listOfferDeliverables,
   reviewOfferDeliverable,
@@ -674,6 +676,9 @@ export default function BrandDashboard() {
   const [isBatchDownloading, setIsBatchDownloading] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [assetToDelete, setAssetToDelete] = useState<any>(null);
+  const [showDeletePackageDialog, setShowDeletePackageDialog] = useState(false);
+  const [packageToDelete, setPackageToDelete] = useState<any>(null);
+  const [deletingPackage, setDeletingPackage] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(
     new Set(),
   );
@@ -724,6 +729,14 @@ export default function BrandDashboard() {
   );
   const [loadingBrandLicensingRequests, setLoadingBrandLicensingRequests] =
     useState(false);
+  const [activeLicensingTab, setActiveLicensingTab] = useState<
+    "Active" | "Archive"
+  >("Active");
+  const [deletingRequestId, setDeletingRequestId] = useState<string | null>(
+    null,
+  );
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [requestToDelete, setRequestToDelete] = useState<any>(null);
   const [licenseRequestForm, setLicenseRequestForm] = useState({
     start_date: new Date().toISOString().slice(0, 10),
     license_fee: "",
@@ -2076,6 +2089,41 @@ export default function BrandDashboard() {
     }
 
     setAssetToDelete(null);
+  };
+
+  const handleDeletePackage = async (pkg: any) => {
+    setPackageToDelete(pkg);
+    setShowDeletePackageDialog(true);
+  };
+
+  const confirmDeletePackage = async () => {
+    if (!packageToDelete) return;
+    setShowDeletePackageDialog(false);
+    setDeletingPackage(true);
+
+    try {
+      const offerId = String(packageToDelete?.offer_id || "");
+      const packageId = String(packageToDelete?.id || "");
+      await base44.post(
+        `/api/campaign-offers/${encodeURIComponent(offerId)}/packages/brand-delete`,
+        { package_id: packageId },
+      );
+
+      setInboxPackages((prev) => prev.filter((p) => p.id !== packageId));
+      toast({
+        title: "Package deleted",
+        description: `"${packageToDelete.title || "Package"}" has been removed.`,
+      });
+    } catch (error: any) {
+      toast({
+        title: "Delete failed",
+        description: error?.message || "Could not delete the package.",
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingPackage(false);
+      setPackageToDelete(null);
+    }
   };
 
   useEffect(() => {
@@ -4169,252 +4217,412 @@ export default function BrandDashboard() {
     );
   };
 
-  const renderBrandLicensingRequests = () => (
-    <div className="space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
-        <div>
-          <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-gray-900">
-            Licensing Requests
-          </h2>
-          <p className="text-gray-600">
-            Track licensing requests you have sent to agencies.
-          </p>
+  const handleArchiveRequest = async (req: any) => {
+    try {
+      await updateBrandLicensingRequestsStatus({
+        licensing_request_ids: [req.id],
+        status: "archived",
+      });
+      const resp = await getBrandLicensingRequests();
+      const rows = (resp as any)?.requests || resp?.data || [];
+      setBrandLicensingRequests(Array.isArray(rows) ? rows : []);
+      toast({
+        title: "Archived",
+        description: "Licensing request has been archived.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Archive failed",
+        description: e?.message || "Could not archive licensing request",
+        variant: "destructive" as any,
+      });
+    }
+  };
+
+  const handleDeleteRequest = async (req: any) => {
+    setDeletingRequestId(req.id);
+    try {
+      await deleteBrandLicensingRequests({
+        licensing_request_ids: [req.id],
+      });
+      const resp = await getBrandLicensingRequests();
+      const rows = (resp as any)?.requests || resp?.data || [];
+      setBrandLicensingRequests(Array.isArray(rows) ? rows : []);
+      toast({
+        title: "Deleted",
+        description: "Licensing request permanently deleted.",
+      });
+    } catch (e: any) {
+      toast({
+        title: "Delete failed",
+        description: e?.message || "Could not delete licensing request",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setDeletingRequestId(null);
+      setShowDeleteConfirm(false);
+      setRequestToDelete(null);
+    }
+  };
+
+  const renderBrandLicensingRequests = () => {
+    const isArchived = (req: any) =>
+      ["rejected", "declined", "archived"].includes(req?.status || "");
+
+    const filteredRequests = brandLicensingRequests.filter((req: any) => {
+      if (activeLicensingTab === "Active") return !isArchived(req);
+      return isArchived(req);
+    });
+
+    return (
+      <div className="space-y-6">
+        <div className="flex justify-between items-center">
+          <div className="flex flex-col gap-1">
+            <h2 className="text-2xl font-bold text-gray-900">
+              Licensing Requests
+            </h2>
+            <div className="flex bg-gray-100 p-1 rounded-lg w-fit mt-2">
+              {["Active", "Archive"].map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveLicensingTab(tab as any)}
+                  className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeLicensingTab === tab ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-900"}`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
 
-      {loadingBrandLicensingRequests && (
-        <Card className="p-6 bg-white border border-gray-200">
-          <p className="text-sm text-gray-600">Loading licensing requests...</p>
-        </Card>
-      )}
-
-      {!loadingBrandLicensingRequests &&
-        brandLicensingRequests.length === 0 && (
-          <Card className="p-4 sm:p-8 text-center text-sm text-gray-600">
-            No licensing requests yet.
+        {loadingBrandLicensingRequests && (
+          <Card className="p-6 bg-white border border-gray-200">
+            <p className="text-sm text-gray-600">
+              Loading licensing requests...
+            </p>
           </Card>
         )}
 
-      {!loadingBrandLicensingRequests &&
-        brandLicensingRequests.map((req: any) => {
-          const agencyName =
-            req?.agencies?.agency_name || req?.agency_name || "Agency";
-          const status = formatLicenseStatus(req?.status || "pending");
-          const statusClass =
-            status === "Approved"
-              ? "bg-green-100 text-green-700 border-green-200"
-              : status === "Declined"
-                ? "bg-red-100 text-red-700 border-red-200"
-                : "bg-amber-100 text-amber-700 border-amber-200";
+        {!loadingBrandLicensingRequests && filteredRequests.length === 0 && (
+          <Card className="p-4 sm:p-8 text-center text-sm text-gray-600">
+            {activeLicensingTab === "Active"
+              ? "No active licensing requests"
+              : "No archived licensing requests"}
+          </Card>
+        )}
 
-          const licenseFeeValue = req?.license_fee;
-          const licenseFee = licenseFeeValue
-            ? `$${Number(licenseFeeValue).toLocaleString()}`
-            : "\u2014";
+        {!loadingBrandLicensingRequests &&
+          filteredRequests.map((req: any) => {
+            const agencyName =
+              req?.agencies?.agency_name || req?.agency_name || "Agency";
+            const status = formatLicenseStatus(req?.status || "pending");
+            const statusClass =
+              status === "Approved"
+                ? "bg-green-100 text-green-700 border-green-200"
+                : status === "Declined" || status === "Archived"
+                  ? "bg-red-100 text-red-700 border-red-200"
+                  : "bg-amber-100 text-amber-700 border-amber-200";
 
-          // Submissions can come from either join path depending on whether the
-          // brand request was linked by submission_id directly or via brand_request_id.
-          let submissions = req?.license_submissions;
-          if (submissions && !Array.isArray(submissions)) {
-            submissions = [submissions];
-          }
-          const directSubmission = req?.license_submission;
-          if (directSubmission) {
-            const directSubmissionList = Array.isArray(directSubmission)
-              ? directSubmission
-              : [directSubmission];
-            const existingIds = new Set(
-              (submissions || [])
-                .map((sub: any) => String(sub?.id || "").trim())
-                .filter(Boolean),
-            );
-            submissions = [
-              ...directSubmissionList.filter((sub: any) => {
-                const id = String(sub?.id || "").trim();
-                return id ? !existingIds.has(id) : true;
-              }),
-              ...(submissions || []),
-            ];
-          }
+            const licenseFeeValue = req?.license_fee;
+            const licenseFee = licenseFeeValue
+              ? `$${Number(licenseFeeValue).toLocaleString()}`
+              : "\u2014";
 
-          const submission = Array.isArray(submissions)
-            ? submissions
-                .filter((sub: any) => sub?.status !== "draft")
-                .sort((a: any, b: any) => {
-                  const linkedSubmissionId = String(
-                    req?.submission_id || "",
-                  ).trim();
-                  const aId = String(a?.id || "").trim();
-                  const bId = String(b?.id || "").trim();
-                  const aMatchesLinked = linkedSubmissionId
-                    ? aId === linkedSubmissionId
-                    : false;
-                  const bMatchesLinked = linkedSubmissionId
-                    ? bId === linkedSubmissionId
-                    : false;
+            let submissions = req?.license_submissions;
+            if (submissions && !Array.isArray(submissions)) {
+              submissions = [submissions];
+            }
+            const directSubmission = req?.license_submission;
+            if (directSubmission) {
+              const directSubmissionList = Array.isArray(directSubmission)
+                ? directSubmission
+                : [directSubmission];
+              const existingIds = new Set(
+                (submissions || [])
+                  .map((sub: any) => String(sub?.id || "").trim())
+                  .filter(Boolean),
+              );
+              submissions = [
+                ...directSubmissionList.filter((sub: any) => {
+                  const id = String(sub?.id || "").trim();
+                  return id ? !existingIds.has(id) : true;
+                }),
+                ...(submissions || []),
+              ];
+            }
 
-                  if (aMatchesLinked && !bMatchesLinked) return -1;
-                  if (!aMatchesLinked && bMatchesLinked) return 1;
+            const submission = Array.isArray(submissions)
+              ? submissions
+                  .filter((sub: any) => sub?.status !== "draft")
+                  .sort((a: any, b: any) => {
+                    const linkedSubmissionId = String(
+                      req?.submission_id || "",
+                    ).trim();
+                    const aId = String(a?.id || "").trim();
+                    const bId = String(b?.id || "").trim();
+                    const aMatchesLinked = linkedSubmissionId
+                      ? aId === linkedSubmissionId
+                      : false;
+                    const bMatchesLinked = linkedSubmissionId
+                      ? bId === linkedSubmissionId
+                      : false;
 
-                  const aHasUrl = !!(
-                    a?.client_submitter_slug || a?.docuseal_slug
-                  );
-                  const bHasUrl = !!(
-                    b?.client_submitter_slug || b?.docuseal_slug
-                  );
+                    if (aMatchesLinked && !bMatchesLinked) return -1;
+                    if (!aMatchesLinked && bMatchesLinked) return 1;
 
-                  if (aHasUrl && !bHasUrl) return -1;
-                  if (!aHasUrl && bHasUrl) return 1;
+                    const aHasUrl = !!(
+                      a?.client_submitter_slug || a?.docuseal_slug
+                    );
+                    const bHasUrl = !!(
+                      b?.client_submitter_slug || b?.docuseal_slug
+                    );
 
-                  const aDate = new Date(a?.created_at || 0);
-                  const bDate = new Date(b?.created_at || 0);
-                  return bDate.getTime() - aDate.getTime();
-                })[0]
-            : null;
+                    if (aHasUrl && !bHasUrl) return -1;
+                    if (!aHasUrl && bHasUrl) return 1;
 
-          const slug =
-            submission?.client_submitter_slug || submission?.docuseal_slug;
-          const signingUrl = slug ? `https://docuseal.co/s/${slug}` : "";
-          const declineReason = String(req?.decline_reason || "").trim();
+                    const aDate = new Date(a?.created_at || 0);
+                    const bDate = new Date(b?.created_at || 0);
+                    return bDate.getTime() - aDate.getTime();
+                  })[0]
+              : null;
 
-          return (
-            <Card
-              key={req?.id}
-              className="p-6 bg-white border border-gray-200 rounded-xl"
-            >
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-                  <div>
-                    <h3 className="text-xl font-bold text-gray-900">
-                      {req?.campaign_title || "Licensing Request"}
-                    </h3>
-                    <p className="text-sm text-gray-500">
-                      Agency: {agencyName}
-                      {req?.talent_name ? ` • Talent: ${req.talent_name}` : ""}
-                    </p>
-                  </div>
-                  <Badge className={`border ${statusClass}`}>{status}</Badge>
-                </div>
+            const slug =
+              submission?.client_submitter_slug || submission?.docuseal_slug;
+            const signingUrl = slug ? `https://docuseal.co/s/${slug}` : "";
+            const declineReason = String(req?.decline_reason || "").trim();
 
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 text-sm">
-                  <div>
-                    <p className="text-gray-500">Start Date</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.license_start_date
-                        ? new Date(req.license_start_date).toLocaleDateString()
-                        : "\u2014"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">End Date</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.license_end_date
-                        ? new Date(req.license_end_date).toLocaleDateString()
-                        : "\u2014"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Duration (Days)</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.duration_days || "\u2014"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">License Fee</p>
-                    <p className="font-semibold text-gray-900">{licenseFee}</p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Territory</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.territory || req?.regions || "\u2014"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Exclusivity</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.exclusivity || req?.usage_scope || "\u2014"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Modifications Allowed</p>
-                    <p className="font-semibold text-gray-900">
-                      {req?.modifications_allowed || "\u2014"}
-                    </p>
-                  </div>
-                </div>
-
-                {req?.custom_terms && (
-                  <div className="text-sm">
-                    <p className="text-gray-500">Additional Terms</p>
-                    <p className="font-semibold text-gray-900">
-                      {String(req.custom_terms)}
-                    </p>
-                  </div>
-                )}
-
-                {req?.description && (
-                  <div className="text-sm">
-                    <p className="text-gray-500">Description</p>
-                    <p className="font-semibold text-gray-900">
-                      {String(req.description)}
-                    </p>
-                  </div>
-                )}
-
-                {declineReason && status === "Declined" && (
-                  <div className="text-sm bg-red-50 border border-red-100 rounded-lg p-3 text-red-700 mt-2">
-                    <span className="font-semibold">Decline reason: </span>
-                    {declineReason}
-                  </div>
-                )}
-
-                <div className="flex flex-wrap gap-3 mt-2">
-                  {signingUrl && submission?.status !== "completed" ? (
-                    <Button
-                      className="text-white"
-                      style={{ backgroundColor: "#E9A23B" }}
-                      onMouseEnter={(e) =>
-                        (e.target.style.backgroundColor = "#D4941F")
-                      }
-                      onMouseLeave={(e) =>
-                        (e.target.style.backgroundColor = "#E9A23B")
-                      }
-                      onClick={() => {
-                        setBrandSignUrl(signingUrl);
-                        setBrandSignOpen(true);
-                      }}
-                    >
-                      Sign Contract
-                    </Button>
-                  ) : submission?.status === "completed" ? (
-                    <div className="flex items-center justify-center h-11 bg-green-50 rounded-md border border-green-200">
-                      <p className="text-xs font-black text-green-700 uppercase tracking-widest flex items-center gap-2">
-                        <svg
-                          className="w-4 h-4"
-                          fill="currentColor"
-                          viewBox="0 0 20 20"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
-                        Contract Signed
+            return (
+              <Card
+                key={req?.id}
+                className="p-6 bg-white border border-gray-200 rounded-xl"
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-bold text-gray-900">
+                        {req?.campaign_title || "Licensing Request"}
+                      </h3>
+                      <p className="text-sm text-gray-500">
+                        Agency: {agencyName}
+                        {req?.talent_name
+                          ? ` • Talent: ${req.talent_name}`
+                          : ""}
                       </p>
                     </div>
+                    <Badge className={`border ${statusClass}`}>{status}</Badge>
+                  </div>
+
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 text-sm">
+                    <div>
+                      <p className="text-gray-500">Start Date</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.license_start_date
+                          ? new Date(
+                              req.license_start_date,
+                            ).toLocaleDateString()
+                          : "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">End Date</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.license_end_date
+                          ? new Date(req.license_end_date).toLocaleDateString()
+                          : "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Duration (Days)</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.duration_days || "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">License Fee</p>
+                      <p className="font-semibold text-gray-900">
+                        {licenseFee}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Territory</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.territory || req?.regions || "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Exclusivity</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.exclusivity || req?.usage_scope || "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Modifications Allowed</p>
+                      <p className="font-semibold text-gray-900">
+                        {req?.modifications_allowed || "\u2014"}
+                      </p>
+                    </div>
+                  </div>
+
+                  {req?.custom_terms && (
+                    <div className="text-sm">
+                      <p className="text-gray-500">Additional Terms</p>
+                      <p className="font-semibold text-gray-900">
+                        {String(req.custom_terms)}
+                      </p>
+                    </div>
+                  )}
+
+                  {req?.description && (
+                    <div className="text-sm">
+                      <p className="text-gray-500">Description</p>
+                      <p className="font-semibold text-gray-900">
+                        {String(req.description)}
+                      </p>
+                    </div>
+                  )}
+
+                  {declineReason && status === "Declined" && (
+                    <div className="text-sm bg-red-50 border border-red-100 rounded-lg p-3 text-red-700 mt-2">
+                      <span className="font-semibold">Decline reason: </span>
+                      {declineReason}
+                    </div>
+                  )}
+
+                  {activeLicensingTab === "Archive" ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <Button
+                        variant="outline"
+                        onClick={() => handleArchiveRequest(req)}
+                        className="border-gray-300 text-gray-700 font-bold h-10 rounded-md flex items-center justify-center gap-2"
+                      >
+                        <RefreshCw className="w-4 h-4" />
+                        Recover to Active
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => {
+                          setRequestToDelete(req);
+                          setShowDeleteConfirm(true);
+                        }}
+                        disabled={deletingRequestId === req.id}
+                        className="border-red-200 text-red-600 hover:bg-red-50 font-bold h-10 rounded-md flex items-center justify-center gap-2"
+                      >
+                        {deletingRequestId === req.id ? (
+                          <>
+                            <RefreshCw className="w-4 h-4 animate-spin" />
+                            Deleting...
+                          </>
+                        ) : (
+                          <>
+                            <Trash2 className="w-4 h-4" />
+                            Delete Permanently
+                          </>
+                        )}
+                      </Button>
+                    </div>
                   ) : (
-                    <div className="bg-gray-100 text-gray-600 border border-gray-200 px-3 py-2 rounded-md text-xs font-medium">
-                      Awaiting contract from agency
+                    <div className="flex flex-wrap gap-3 mt-2">
+                      {signingUrl && submission?.status !== "completed" ? (
+                        <Button
+                          className="text-white"
+                          style={{ backgroundColor: "#E9A23B" }}
+                          onMouseEnter={(e) =>
+                            (e.target.style.backgroundColor = "#D4941F")
+                          }
+                          onMouseLeave={(e) =>
+                            (e.target.style.backgroundColor = "#E9A23B")
+                          }
+                          onClick={() => {
+                            setBrandSignUrl(signingUrl);
+                            setBrandSignOpen(true);
+                          }}
+                        >
+                          Sign Contract
+                        </Button>
+                      ) : submission?.status === "completed" ? (
+                        <div className="flex items-center justify-center h-11 bg-green-50 rounded-md border border-green-200">
+                          <p className="text-xs font-black text-green-700 uppercase tracking-widest flex items-center gap-2">
+                            <svg
+                              className="w-4 h-4"
+                              fill="currentColor"
+                              viewBox="0 0 20 20"
+                            >
+                              <path
+                                fillRule="evenodd"
+                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
+                            Contract Signed
+                          </p>
+                        </div>
+                      ) : (
+                        <div className="bg-gray-100 text-gray-600 border border-gray-200 px-3 py-2 rounded-md text-xs font-medium">
+                          Awaiting contract from agency
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
-              </div>
-            </Card>
-          );
-        })}
-    </div>
-  );
+              </Card>
+            );
+          })}
+
+        <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Delete Licensing Request</DialogTitle>
+              <DialogDescription>
+                This will permanently delete this archived licensing request.
+                This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="py-4">
+              <p className="text-sm text-gray-600">
+                Are you sure you want to delete the licensing request for{" "}
+                <span className="font-semibold">
+                  {requestToDelete?.campaign_title || "Unknown campaign"}
+                </span>
+                ?
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowDeleteConfirm(false);
+                  setRequestToDelete(null);
+                }}
+                className="font-bold"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => handleDeleteRequest(requestToDelete)}
+                disabled={deletingRequestId === requestToDelete?.id}
+                className="font-bold"
+              >
+                {deletingRequestId === requestToDelete?.id ? (
+                  <>
+                    <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Delete Permanently
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  };
 
   const renderInboxSubtab = () => {
     if (!canViewInbox) {
@@ -4595,6 +4803,7 @@ export default function BrandDashboard() {
                       variant="outline"
                       className="border border-gray-300 rounded-none flex-shrink-0"
                       disabled={!canManagePayOffers}
+                      onClick={() => handleDeletePackage(pkg)}
                     >
                       <Trash2 className="w-4 h-4" />
                     </Button>
@@ -13171,6 +13380,39 @@ export default function BrandDashboard() {
             </Button>
             <Button variant="destructive" onClick={confirmDeleteAsset}>
               Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Package Confirmation Dialog */}
+      <Dialog
+        open={showDeletePackageDialog}
+        onOpenChange={setShowDeletePackageDialog}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Package</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete "
+              {packageToDelete?.title || "this package"}"? This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeletePackageDialog(false)}
+              disabled={deletingPackage}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmDeletePackage}
+              disabled={deletingPackage}
+            >
+              {deletingPackage ? "Deleting..." : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary

- **Recover UX**: Recover to Active button now shows loading spinner, disables during operation, and displays success/error toast notifications
- **Delete from Archive**: Declined/rejected items can now be permanently deleted from the Archive tab (previously only archived status was allowed)
- **Performance**: All operations now use batch queries instead of sequential loops, and cache invalidation is fire-and-forget for instant UI response

## Changes

### Backend (likelee-server/src/licensing_requests.rs)
- Added archived_at timestamp when setting status to archived in update_status_bulk
- Replaced sequential loop with single batch UPDATE query for auto-archiving before deletion
- Relaxed delete validation to accept declined and rejected statuses (auto-archives them first)
- Added update_status_for_brand and delete_archived_requests_for_brand endpoints for brand-side licensing

### Frontend (likelee-ui/src/components/agency/LicensingRequestsView.tsx)
- Added recoveringGroup state for loading indicator on recover button
- Added handleRecoverGroup with toast feedback (success/error)
- Removed pre-archiving step from handleDeleteGroup (backend handles it)
- Converted all await queryClient.invalidateQueries() to fire-and-forget
- Added filter dialog for status, license fee, and duration
- Improved delete confirmation dialog messaging
- Removed console.log debug statements

### Frontend (likelee-ui/src/components/licensing/LicensingRequestsTab.tsx)
- Same fire-and-forget cache invalidation optimizations
- Updated delete handler to work with backend auto-archiving

### API (likelee-ui/src/api/functions.ts)
- Added deleteAgencyLicensingRequests function
- Added updateBrandLicensingRequestsStatus and deleteBrandLicensingRequests functions