### PR TITLE
fix(brand-analytics): replace mock data with real values and implement CSV export

### DIFF
--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -1718,6 +1718,7 @@ pub async fn get_brand_analytics(
         turnaround_sum: f64,
         turnaround_count: i64,
         success_count: i64,
+        total_cost_cents: i64,
     }
 
     let mut ytd_projects: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -1805,8 +1806,25 @@ pub async fn get_brand_analytics(
             turnaround_sum: 0.0,
             turnaround_count: 0,
             success_count: 0,
+            total_cost_cents: 0,
         });
         entry.projects.insert(campaign_key.clone());
+
+        let payment_status = offer
+            .get("payment_status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_lowercase();
+
+        if payment_status == "paid" {
+            if let Some(budget_snapshot) = offer.get("budget_snapshot") {
+                let budget_cents = parse_budget_cents(budget_snapshot);
+                if budget_cents > 0 {
+                    entry.total_cost_cents += budget_cents;
+                }
+            }
+        }
 
         if let (Some(completed_at), true) = (completed_at.as_deref(), !start_date.is_empty()) {
             if let (Ok(start), Ok(done)) = (
@@ -1970,7 +1988,7 @@ pub async fn get_brand_analytics(
                 "projects_count": projects_count,
                 "avg_turnaround_hours": avg_turnaround_hours,
                 "success_rate_pct": success_rate_pct,
-                "total_cost_cents": serde_json::Value::Null,
+                "total_cost_cents": entry.total_cost_cents,
                 "avg_rating": serde_json::Value::Null
             })
         })

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -8141,9 +8141,7 @@ export default function BrandDashboard() {
                 "Metric,Value\nTotal Projects (YTD),{projects}\nTotal Spend (YTD),{spend}\nAvg Cost/Project,{avgCost}\n\nTalent,Projects,Success Rate (%),Total Cost ($)\n";
               const talentRows = brandAnalytics.talent_performance
                 .map((t: any) => {
-                  const name = sanitizeCsvField(
-                    String(t?.name || "Talent"),
-                  );
+                  const name = sanitizeCsvField(String(t?.name || "Talent"));
                   const projects = Number(t?.projects_count || 0);
                   const successRate = Number(t?.success_rate_pct || 0);
                   const totalCostCents = Number(t?.total_cost_cents || 0);

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -8089,7 +8089,7 @@ export default function BrandDashboard() {
       </div>
 
       {/* Top KPI Section */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
         <Card className="p-4 sm:p-6 bg-white border border-gray-200">
           <p className="text-sm text-gray-600 mb-1">Total Projects (YTD)</p>
           <p className="text-2xl sm:text-3xl font-bold text-gray-900">
@@ -8097,20 +8097,22 @@ export default function BrandDashboard() {
           </p>
         </Card>
         <Card className="p-4 sm:p-6 bg-white border border-gray-200">
-          <p className="text-sm text-gray-600 mb-1">Avg Turnaround</p>
+          <p className="text-sm text-gray-600 mb-1">Total Spend (YTD)</p>
           <p className="text-2xl sm:text-3xl font-bold text-gray-900">
-            {campaignMetrics.avg_turnaround_hours > 0
-              ? `${campaignMetrics.avg_turnaround_hours}h`
-              : "—"}
+            {billingYtdSpend > 0
+              ? currencyFormatter.format(billingYtdSpend / 100)
+              : "$0"}
           </p>
         </Card>
         <Card className="p-4 sm:p-6 bg-white border border-gray-200">
-          <p className="text-sm text-gray-600 mb-1">Total Spend (YTD)</p>
-          <p className="text-2xl sm:text-3xl font-bold text-gray-900">$45.2K</p>
-        </Card>
-        <Card className="p-4 sm:p-6 bg-white border border-gray-200">
           <p className="text-sm text-gray-600 mb-1">Avg Cost/Project</p>
-          <p className="text-2xl sm:text-3xl font-bold text-gray-900">$3.8K</p>
+          <p className="text-2xl sm:text-3xl font-bold text-gray-900">
+            {billingYtdSpend > 0 && brandAnalytics.total_projects_ytd > 0
+              ? currencyFormatter.format(
+                  billingYtdSpend / 100 / brandAnalytics.total_projects_ytd,
+                )
+              : "$0"}
+          </p>
         </Card>
       </div>
 
@@ -8120,7 +8122,57 @@ export default function BrandDashboard() {
           <h3 className="text-xl font-bold text-gray-900">
             Talent Performance
           </h3>
-          <Button variant="outline" className="border-2 border-gray-300">
+          <Button
+            variant="outline"
+            className="border-2 border-gray-300"
+            onClick={() => {
+              const header =
+                "Metric,Value\nTotal Projects (YTD),{projects}\nTotal Spend (YTD),{spend}\nAvg Cost/Project,{avgCost}\n\nTalent,Projects,Success Rate (%),Total Cost ($)\n";
+              const talentRows = brandAnalytics.talent_performance
+                .map((t: any) => {
+                  const name = String(t?.name || "Talent").replace(/,/g, ";");
+                  const projects = Number(t?.projects_count || 0);
+                  const successRate = Number(t?.success_rate_pct || 0);
+                  const totalCostCents = Number(t?.total_cost_cents || 0);
+                  const totalCostDollars = (totalCostCents / 100).toFixed(2);
+                  return `${name},${projects},${successRate},${totalCostDollars}`;
+                })
+                .join("\n");
+              const monthlyRows =
+                brandSpendData?.monthly_spend &&
+                brandSpendData.monthly_spend.length > 0
+                  ? "\n\nMonth,Spend ($)\n" +
+                    brandSpendData.monthly_spend
+                      .map(
+                        (d: any) => `${d.month},${(d.spend / 100).toFixed(2)}`,
+                      )
+                      .join("\n")
+                  : "";
+              const totalProjects = brandAnalytics.total_projects_ytd;
+              const totalSpend =
+                billingYtdSpend > 0
+                  ? (billingYtdSpend / 100).toFixed(2)
+                  : "0.00";
+              const avgCost =
+                billingYtdSpend > 0 && totalProjects > 0
+                  ? (billingYtdSpend / 100 / totalProjects).toFixed(2)
+                  : "0.00";
+              const csv =
+                header
+                  .replace("{projects}", String(totalProjects))
+                  .replace("{spend}", totalSpend)
+                  .replace("{avgCost}", avgCost) +
+                talentRows +
+                monthlyRows;
+              const blob = new Blob([csv], { type: "text/csv" });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `brand-analytics-report-${new Date().toISOString().slice(0, 10)}.csv`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+          >
             <Download className="w-4 h-4 mr-2" />
             Export Report
           </Button>
@@ -8136,9 +8188,6 @@ export default function BrandDashboard() {
                   Projects
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                  Avg Turnaround
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
                   Success Rate
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
@@ -8149,7 +8198,7 @@ export default function BrandDashboard() {
             <tbody className="divide-y divide-gray-200">
               {brandAnalytics.loading && (
                 <tr>
-                  <td className="px-4 py-4 text-sm text-gray-600" colSpan={5}>
+                  <td className="px-4 py-4 text-sm text-gray-600" colSpan={4}>
                     Loading talent performance...
                   </td>
                 </tr>
@@ -8157,7 +8206,7 @@ export default function BrandDashboard() {
               {!brandAnalytics.loading &&
                 brandAnalytics.talent_performance.length === 0 && (
                   <tr>
-                    <td className="px-4 py-4 text-sm text-gray-600" colSpan={5}>
+                    <td className="px-4 py-4 text-sm text-gray-600" colSpan={4}>
                       No talent performance data yet.
                     </td>
                   </tr>
@@ -8168,9 +8217,6 @@ export default function BrandDashboard() {
                     const name = String(talent?.name || "Talent");
                     const imageUrl = String(talent?.image_url || "").trim();
                     const projectsCount = Number(talent?.projects_count || 0);
-                    const avgTurnaround = Number(
-                      talent?.avg_turnaround_hours || 0,
-                    );
                     const successRate = Number(talent?.success_rate_pct || 0);
                     return (
                       <tr
@@ -8205,13 +8251,17 @@ export default function BrandDashboard() {
                         <td className="px-4 py-4 text-gray-900">
                           {projectsCount}
                         </td>
-                        <td className="px-4 py-4 text-gray-900">
-                          {avgTurnaround > 0 ? `${avgTurnaround}h` : "—"}
-                        </td>
                         <td className="px-4 py-4 text-green-600 font-semibold">
                           {projectsCount > 0 ? `${successRate}%` : "—"}
                         </td>
-                        <td className="px-4 py-4 font-bold text-gray-900">—</td>
+                        <td className="px-4 py-4 font-bold text-gray-900">
+                          {talent.total_cost_cents != null &&
+                          Number(talent.total_cost_cents) > 0
+                            ? currencyFormatter.format(
+                                Number(talent.total_cost_cents) / 100,
+                              )
+                            : "—"}
+                        </td>
                       </tr>
                     );
                   },
@@ -8259,32 +8309,38 @@ export default function BrandDashboard() {
         <h3 className="text-lg font-bold text-gray-900 mb-4">
           Budget Forecast
         </h3>
-        <div className="grid md:grid-cols-3 gap-6">
-          <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-            <p className="text-sm text-gray-600 mb-1">YTD Spend</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {billingYtdSpend > 0
-                ? `$${(billingYtdSpend / 100).toLocaleString()}`
-                : "$0"}
-            </p>
+        {loadingBillingData ? (
+          <div className="p-4 text-center text-gray-500">
+            Loading budget forecast...
           </div>
-          <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-            <p className="text-sm text-gray-600 mb-1">Monthly Avg</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {billingMonthlyAvg > 0
-                ? `$${(billingMonthlyAvg / 100).toLocaleString()}`
-                : "$0"}
-            </p>
+        ) : (
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">YTD Spend</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {billingYtdSpend > 0
+                  ? currencyFormatter.format(billingYtdSpend / 100)
+                  : "$0"}
+              </p>
+            </div>
+            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">Monthly Avg</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {billingMonthlyAvg > 0
+                  ? currencyFormatter.format(billingMonthlyAvg / 100)
+                  : "$0"}
+              </p>
+            </div>
+            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">Projected EOY</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {billingProjectedEoy > 0
+                  ? currencyFormatter.format(billingProjectedEoy / 100)
+                  : "$0"}
+              </p>
+            </div>
           </div>
-          <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-            <p className="text-sm text-gray-600 mb-1">Projected EOY</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {billingProjectedEoy > 0
-                ? `$${(billingProjectedEoy / 100000).toFixed(1)}K`
-                : "$0"}
-            </p>
-          </div>
-        </div>
+        )}
       </Card>
     </div>
   );

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -8126,11 +8126,24 @@ export default function BrandDashboard() {
             variant="outline"
             className="border-2 border-gray-300"
             onClick={() => {
+              const sanitizeCsvField = (value: string): string => {
+                const needsQuoting =
+                  /[,"\n\r]/.test(value) || /^[=+\-@]/.test(value.trim());
+                if (needsQuoting) {
+                  const safeValue = /^[=+\-@]/.test(value.trim())
+                    ? `'${value}`
+                    : value;
+                  return `"${safeValue.replace(/"/g, '""')}"`;
+                }
+                return value;
+              };
               const header =
                 "Metric,Value\nTotal Projects (YTD),{projects}\nTotal Spend (YTD),{spend}\nAvg Cost/Project,{avgCost}\n\nTalent,Projects,Success Rate (%),Total Cost ($)\n";
               const talentRows = brandAnalytics.talent_performance
                 .map((t: any) => {
-                  const name = String(t?.name || "Talent").replace(/,/g, ";");
+                  const name = sanitizeCsvField(
+                    String(t?.name || "Talent"),
+                  );
                   const projects = Number(t?.projects_count || 0);
                   const successRate = Number(t?.success_rate_pct || 0);
                   const totalCostCents = Number(t?.total_cost_cents || 0);
@@ -8144,7 +8157,8 @@ export default function BrandDashboard() {
                   ? "\n\nMonth,Spend ($)\n" +
                     brandSpendData.monthly_spend
                       .map(
-                        (d: any) => `${d.month},${(d.spend / 100).toFixed(2)}`,
+                        (d: any) =>
+                          `${sanitizeCsvField(d.month)},${(d.spend / 100).toFixed(2)}`,
                       )
                       .join("\n")
                   : "";
@@ -9887,13 +9901,24 @@ export default function BrandDashboard() {
             className="border-2 border-gray-300"
             disabled={brandInvoices.length === 0}
             onClick={() => {
+              const sanitizeCsvField = (value: string): string => {
+                const needsQuoting =
+                  /[,"\n\r]/.test(value) || /^[=+\-@]/.test(value.trim());
+                if (needsQuoting) {
+                  const safeValue = /^[=+\-@]/.test(value.trim())
+                    ? `'${value}`
+                    : value;
+                  return `"${safeValue.replace(/"/g, '""')}"`;
+                }
+                return value;
+              };
               const header = "ID,Number,Amount,Currency,Status,Date\n";
               const rows = brandInvoices.map((inv) => {
                 const amountDollars = ((inv.amount || 0) / 100).toFixed(2);
                 const date = inv.created_at
                   ? new Date(inv.created_at).toLocaleDateString()
                   : "";
-                return `${inv.id},${inv.number || ""},${amountDollars},${inv.currency},${inv.status},${date}`;
+                return `${inv.id},${sanitizeCsvField(inv.number || "")},${amountDollars},${inv.currency},${inv.status},${date}`;
               });
               const csv = header + rows.join("\n");
               const blob = new Blob([csv], { type: "text/csv" });


### PR DESCRIPTION
## Summary

This PR fixes the Analytics & Reporting page in BrandDashboard which was showing hardcoded mock values and had non-functional buttons.

### Changes Made

**Frontend (`BrandDashboard.tsx`):**
- Replaced hardcoded `$45.2K` Total Spend (YTD) with real data from `billingYtdSpend`
- Replaced hardcoded `$3.8K` Avg Cost/Project with calculated value from `billingYtdSpend / total_projects_ytd`
- Implemented functional **Export Report** button that generates CSV download with KPIs, talent performance, and monthly spend data
- Removed unreliable **Avg Turnaround** KPI card and table column (data not reliably populated)
- Added **Total Cost** display in Talent Performance table using `total_cost_cents` from backend
- Added loading state indicator for Budget Forecast section
- Standardized currency formatting using `currencyFormatter`

**Backend (`brand_campaigns.rs`):**
- Added `total_cost_cents` field to `TargetAccumulator` struct
- Populated `total_cost_cents` by aggregating `budget_snapshot` from `campaign_offers` where `payment_status = 'paid'`
- Returns actual cost data per talent in the analytics response

### Data Flow

```
GET /api/brand/analytics → total_projects_ytd, talent_performance[] (with total_cost_cents)
GET /api/brand/campaigns/metrics → avg_turnaround_hours (removed from UI)
GET /api/brand/spend/analytics → ytd_spend, monthly_avg, projected_eoy
```

### Testing
- ESLint passes with no errors
- Rust `cargo check` compiles successfully

### Related
- Plan file: `.kilo/plans/1777819371362-swift-moon.md`