### PR TITLE
Add 20MB size limit for talent package cover images

### DIFF
--- a/likelee-server/src/agencies.rs
+++ b/likelee-server/src/agencies.rs
@@ -25,6 +25,9 @@ use tracing::{info, warn};
 
 pub use crate::team::resolve_effective_agency_id;
 
+// Maximum file size for package cover images (20MB)
+const MAX_PACKAGE_COVER_IMAGE_BYTES: i64 = 20 * 1024 * 1024;
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct AgencyProfilePayload {
     pub agency_name: Option<String>,
@@ -931,6 +934,7 @@ pub async fn upload_agency_storage_file(
     let mut file_name = None;
     let mut mime_type = None;
     let mut folder_id: Option<String> = None;
+    let mut source_type: Option<String> = None;
     let mut visibility = StorageVisibility::Private;
     let mut bytes: Vec<u8> = vec![];
 
@@ -948,6 +952,15 @@ pub async fn upload_agency_storage_file(
                     .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
                 if !txt.trim().is_empty() {
                     folder_id = Some(txt);
+                }
+            }
+            "source_type" => {
+                let txt = field
+                    .text()
+                    .await
+                    .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+                if !txt.trim().is_empty() {
+                    source_type = Some(txt.trim().to_string());
                 }
             }
             "visibility" => {
@@ -978,19 +991,33 @@ pub async fn upload_agency_storage_file(
 
     let new_size = bytes.len() as i64;
 
-    // Check for 20MB limit on package cover images
-    // Package cover images are typically uploaded with visibility=public and no folder_id
-    let is_likely_cover_image = visibility == StorageVisibility::Public && folder_id.is_none();
-    let max_cover_size = 20 * 1024 * 1024; // 20MB in bytes
-
-    if is_likely_cover_image && new_size > max_cover_size {
-        return Err((
-            StatusCode::PAYLOAD_TOO_LARGE,
-            format!(
-                "Package cover image size exceeds the maximum limit of 20MB. Your file is {:.2}MB. Please compress or resize your image and try again.",
-                new_size as f64 / (1024.0 * 1024.0)
-            ),
-        ));
+    // Validate package cover images
+    let is_package_cover = source_type.as_deref() == Some("package_cover");
+    
+    if is_package_cover {
+        // Validate MIME type for cover images
+        let is_image = mime_type
+            .as_ref()
+            .map(|m| m.starts_with("image/"))
+            .unwrap_or(false);
+        
+        if !is_image {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Package cover must be an image file (JPEG, PNG, etc.)".into(),
+            ));
+        }
+        
+        // Enforce 20MB size limit for cover images
+        if new_size > MAX_PACKAGE_COVER_IMAGE_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "Package cover image size exceeds the maximum limit of 20MB. Your file is {:.2}MB. Please compress or resize your image and try again.",
+                    new_size as f64 / (1024.0 * 1024.0)
+                ),
+            ));
+        }
     }
 
     // Quota enforcement

--- a/likelee-server/src/agencies.rs
+++ b/likelee-server/src/agencies.rs
@@ -993,21 +993,21 @@ pub async fn upload_agency_storage_file(
 
     // Validate package cover images
     let is_package_cover = source_type.as_deref() == Some("package_cover");
-    
+
     if is_package_cover {
         // Validate MIME type for cover images
         let is_image = mime_type
             .as_ref()
             .map(|m| m.starts_with("image/"))
             .unwrap_or(false);
-        
+
         if !is_image {
             return Err((
                 StatusCode::BAD_REQUEST,
                 "Package cover must be an image file (JPEG, PNG, etc.)".into(),
             ));
         }
-        
+
         // Enforce 20MB size limit for cover images
         if new_size > MAX_PACKAGE_COVER_IMAGE_BYTES {
             return Err((

--- a/likelee-server/src/agencies.rs
+++ b/likelee-server/src/agencies.rs
@@ -976,10 +976,26 @@ pub async fn upload_agency_storage_file(
         return Err((StatusCode::BAD_REQUEST, "missing file".into()));
     }
 
+    let new_size = bytes.len() as i64;
+
+    // Check for 20MB limit on package cover images
+    // Package cover images are typically uploaded with visibility=public and no folder_id
+    let is_likely_cover_image = visibility == StorageVisibility::Public && folder_id.is_none();
+    let max_cover_size = 20 * 1024 * 1024; // 20MB in bytes
+
+    if is_likely_cover_image && new_size > max_cover_size {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "Package cover image size exceeds the maximum limit of 20MB. Your file is {:.2}MB. Please compress or resize your image and try again.",
+                new_size as f64 / (1024.0 * 1024.0)
+            ),
+        ));
+    }
+
     // Quota enforcement
     let limit = ensure_storage_settings_row(&state, &agency_id).await?;
     let used = get_agency_used_storage_bytes(&state, &agency_id).await?;
-    let new_size = bytes.len() as i64;
     if used + new_size > limit {
         return Err((
             StatusCode::PAYLOAD_TOO_LARGE,

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -873,6 +873,23 @@ export function CreatePackageWizard({
                                 });
                                 return;
                               }
+
+                              // Check file size (20MB limit)
+                              const maxSize = 20 * 1024 * 1024; // 20MB in bytes
+                              if (file.size > maxSize) {
+                                const fileSizeMB = (
+                                  file.size /
+                                  (1024 * 1024)
+                                ).toFixed(2);
+                                toast({
+                                  title: "File too large",
+                                  description: `Package cover image must be 20MB or less. Your file is ${fileSizeMB}MB. Please compress or resize your image and try again.`,
+                                  variant: "destructive",
+                                });
+                                e.target.value = "";
+                                return;
+                              }
+
                               setCoverUploading(true);
                               try {
                                 const fd = new FormData();

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -772,7 +772,8 @@ export function CreatePackageWizard({
                         Cover Image
                       </Label>
                       <p className="text-xs text-gray-500">
-                        JPG, PNG, or GIF. Maximum {MAX_PACKAGE_COVER_IMAGE_MB}MB.
+                        JPG, PNG, or GIF. Maximum {MAX_PACKAGE_COVER_IMAGE_MB}
+                        MB.
                       </p>
                       <div className="flex gap-3">
                         <Input

--- a/likelee-ui/src/components/packages/CreatePackageWizard.tsx
+++ b/likelee-ui/src/components/packages/CreatePackageWizard.tsx
@@ -59,6 +59,10 @@ import { useTeamAccess } from "@/features/team/useTeamAccess";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/auth/AuthProvider";
 
+// Maximum file size for package cover images (20MB) - must match backend constant
+const MAX_PACKAGE_COVER_IMAGE_BYTES = 20 * 1024 * 1024;
+const MAX_PACKAGE_COVER_IMAGE_MB = 20;
+
 export type CreatePackageWizardMode =
   | "template"
   | "package"
@@ -141,75 +145,6 @@ export function CreatePackageWizard({
     client_name: "",
     client_email: "",
     items: [] as any[],
-  };
-
-  const handleCoverUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e?.target;
-    const file = (input?.files?.[0] as File | undefined) ?? undefined;
-    if (input) input.value = "";
-    if (!file) return;
-
-    if (!supabase || !user?.id) {
-      toast({
-        title: "Upload unavailable",
-        description: "Please sign in again and retry the upload.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    if (!file.type?.startsWith("image/")) {
-      toast({
-        title: "Invalid file",
-        description: "Please choose an image file.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    setIsUploadingCover(true);
-    try {
-      const safeName = (file.name || "cover")
-        .toString()
-        .replace(/[^a-zA-Z0-9_.-]/g, "_");
-      const ext = safeName.includes(".")
-        ? safeName.split(".").pop()
-        : file.type?.includes("png")
-          ? "png"
-          : "jpg";
-      const rand =
-        (globalThis as any)?.crypto?.randomUUID?.() ||
-        `${Date.now()}_${Math.random().toString(16).slice(2)}`;
-      const path = `agency/${user.id}/packages/covers/cover_${rand}.${ext}`;
-
-      const { error } = await supabase.storage
-        .from("likelee-public")
-        .upload(path, file, {
-          upsert: true,
-          contentType: file.type || "image/jpeg",
-        });
-      if (error) throw error;
-
-      const { data } = supabase.storage
-        .from("likelee-public")
-        .getPublicUrl(path);
-      const publicUrl = data?.publicUrl || "";
-      if (!publicUrl) {
-        throw new Error("missing_public_url");
-      }
-
-      setFormData((prev) => ({ ...prev, cover_image_url: publicUrl }));
-      toast({ title: "Cover image uploaded" });
-    } catch (err: any) {
-      const msg = String(err?.message || err);
-      toast({
-        title: "Cover upload failed",
-        description: msg,
-        variant: "destructive",
-      });
-    } finally {
-      setIsUploadingCover(false);
-    }
   };
 
   const [formData, setFormData] = useState(initialFormData);
@@ -836,6 +771,9 @@ export function CreatePackageWizard({
                       <Label className="text-[11px] font-bold uppercase tracking-wider text-gray-600">
                         Cover Image
                       </Label>
+                      <p className="text-xs text-gray-500">
+                        JPG, PNG, or GIF. Maximum {MAX_PACKAGE_COVER_IMAGE_MB}MB.
+                      </p>
                       <div className="flex gap-3">
                         <Input
                           placeholder="https://images.unsplash.com/..."
@@ -875,15 +813,14 @@ export function CreatePackageWizard({
                               }
 
                               // Check file size (20MB limit)
-                              const maxSize = 20 * 1024 * 1024; // 20MB in bytes
-                              if (file.size > maxSize) {
+                              if (file.size > MAX_PACKAGE_COVER_IMAGE_BYTES) {
                                 const fileSizeMB = (
                                   file.size /
                                   (1024 * 1024)
                                 ).toFixed(2);
                                 toast({
                                   title: "File too large",
-                                  description: `Package cover image must be 20MB or less. Your file is ${fileSizeMB}MB. Please compress or resize your image and try again.`,
+                                  description: `Package cover image must be ${MAX_PACKAGE_COVER_IMAGE_MB}MB or less. Your file is ${fileSizeMB}MB. Please compress or resize your image and try again.`,
                                   variant: "destructive",
                                 });
                                 e.target.value = "";
@@ -894,6 +831,7 @@ export function CreatePackageWizard({
                               try {
                                 const fd = new FormData();
                                 fd.append("visibility", "public");
+                                fd.append("source_type", "package_cover");
                                 fd.append("file", file);
                                 const resp = await base44.post<{
                                   file_url?: string;


### PR DESCRIPTION
## Summary
Implements a 20MB maximum file size limit for talent package cover images with clear, descriptive error messages.

## Changes
- **Backend**: Added validation in `upload_agency_storage_file` to enforce 20MB limit
- **Frontend**: Added client-side validation before upload to provide immediate feedback

## Error Messages
Users now see helpful messages like:
> Package cover image must be 20MB or less. Your file is 25.3MB. Please compress or resize your image and try again.

Closes #609 