### PR TITLE
 License autoAssign Fixes/ performace tiers

### DIFF
--- a/likelee-server/src/agency_talent_refs.rs
+++ b/likelee-server/src/agency_talent_refs.rs
@@ -300,7 +300,10 @@ pub async fn list_agency_talent_refs(
         // An onboarded talent has both an agency_users row AND a relationship row;
         // the agency_users loop already added them — don't add a duplicate.
         if let Some(ref cid) = creator_id {
-            if by_key.values().any(|v| v.creator_id.as_deref() == Some(cid)) {
+            if by_key
+                .values()
+                .any(|v| v.creator_id.as_deref() == Some(cid))
+            {
                 continue;
             }
         }

--- a/likelee-server/src/agency_talent_refs.rs
+++ b/likelee-server/src/agency_talent_refs.rs
@@ -296,6 +296,14 @@ pub async fn list_agency_talent_refs(
         if key.is_empty() || by_key.contains_key(&key) {
             continue;
         }
+        // Also skip if this creator_id is already represented by an agency_users entry.
+        // An onboarded talent has both an agency_users row AND a relationship row;
+        // the agency_users loop already added them — don't add a duplicate.
+        if let Some(ref cid) = creator_id {
+            if by_key.values().any(|v| v.creator_id.as_deref() == Some(cid)) {
+                continue;
+            }
+        }
         let creator_row = creator_id.as_ref().and_then(|cid| creators_by_id.get(cid));
         let full_name = preferred_name(
             None,

--- a/likelee-server/src/face_profiles.rs
+++ b/likelee-server/src/face_profiles.rs
@@ -1302,7 +1302,7 @@ pub async fn get_marketplace_profile_details(
         let creator_resp = state
             .pg
             .from("creators")
-            .select("id,full_name,city,state,tagline,bio,profile_photo_url,creator_type,facial_features,kyc_status,content_types,industries,base_monthly_price_cents,pricing_updated_at,created_at,currency_code,accept_negotiations,portfolio_link,public_profile_visible,visibility,plan_tier")
+            .select("id,full_name,city,state,tagline,bio,profile_photo_url,creator_type,facial_features,kyc_status,content_types,industries,base_monthly_price_cents,pricing_updated_at,created_at,updated_at,currency_code,accept_negotiations,portfolio_link,public_profile_visible,visibility,plan_tier")
             .eq("id", &profile_id)
             .limit(1)
             .execute()

--- a/likelee-server/src/license_templates.rs
+++ b/likelee-server/src/license_templates.rs
@@ -57,6 +57,10 @@ pub struct CreateTemplateRequest {
 /// `include_second_party` controls whether a second-party (client) signature block is
 /// appended.  Pass `false` for agency-only (one-signer) templates so that DocuSeal does
 /// not create an unexpected second submitter role.
+///
+/// The signature block is only auto-appended when the contract body does NOT already
+/// contain DocuSeal signature field syntax (`type=signature`).  If the agency has
+/// manually placed signature fields in their template body, the body is used as-is.
 fn render_contract_to_html(body: &str, format: &str, include_second_party: bool) -> String {
     let content_html = if format == "markdown" {
         use pulldown_cmark::{html, Parser};
@@ -68,8 +72,18 @@ fn render_contract_to_html(body: &str, format: &str, include_second_party: bool)
         body.to_string() // Already HTML
     };
 
-    // First-party (agency) signature block — always present.
-    let first_party_block = r#"
+    // If the contract body already contains DocuSeal signature fields the agency has
+    // placed their own signature section — do not inject a duplicate block.
+    let body_has_signature_fields = body.contains("type=signature");
+
+    let signature_block = if body_has_signature_fields {
+        // Agency explicitly placed signature fields; respect their layout.
+        String::new()
+    } else {
+        // Auto-generate a signature section based on the requested signer roles.
+
+        // First-party (agency) signature block — always present when auto-generating.
+        let first_party_block = r#"
         <div style="flex: 1; min-width: 250px;">
             <h3 style="font-size: 12pt; color: #dc2626; margin-bottom: 12px;">First Party (Agency)</h3>
             <p style="font-size: 11pt; color: #4a5568; margin-bottom: 8px;">
@@ -87,9 +101,9 @@ fn render_contract_to_html(body: &str, format: &str, include_second_party: bool)
         </div>
     "#;
 
-    // Second-party (client) signature block — only included for two-signer templates.
-    let second_party_block = if include_second_party {
-        r#"
+        // Second-party (client) signature block — only included for two-signer templates.
+        let second_party_block = if include_second_party {
+            r#"
         <div style="flex: 1; min-width: 250px;">
             <h3 style="font-size: 12pt; color: #2b6cb0; margin-bottom: 12px;">Second Party (Client)</h3>
             <p style="font-size: 11pt; color: #4a5568; margin-bottom: 8px;">
@@ -106,12 +120,12 @@ fn render_contract_to_html(body: &str, format: &str, include_second_party: bool)
             </p>
         </div>
         "#
-    } else {
-        ""
-    };
+        } else {
+            ""
+        };
 
-    let signature_block = format!(
-        r#"
+        format!(
+            r#"
         <div style="margin-top: 60px; padding-top: 30px; border-top: 2px solid #e2e8f0; page-break-inside: avoid;">
             <h2 style="font-size: 16pt; color: #1a202c; margin-bottom: 20px;">Signatures</h2>
             <div style="display: flex; gap: 40px; flex-wrap: wrap;">
@@ -119,8 +133,9 @@ fn render_contract_to_html(body: &str, format: &str, include_second_party: bool)
             </div>
         </div>
         "#,
-        first_party_block, second_party_block
-    );
+            first_party_block, second_party_block
+        )
+    };
 
     format!(
         "<!DOCTYPE html><html><head><meta charset=\"utf-8\" /><style>body{{font-family:Arial,sans-serif;line-height:1.6;padding:32px;color:#0f172a}} h1,h2,h3{{color:#111827}} p,li{{font-size:14px}}</style></head><body>{}{}</body></html>",

--- a/likelee-server/src/payouts.rs
+++ b/likelee-server/src/payouts.rs
@@ -1865,6 +1865,11 @@ pub async fn stripe_webhook(
                             error = %e,
                             "Payment link checkout handler FAILED — earnings will not be recorded"
                         );
+                        // Return 500 so Stripe retries the webhook delivery.
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({"status":"error","error":"payment_link_checkout_failed"})),
+                        );
                     }
                 }
                 return (StatusCode::OK, Json(json!({"status":"ok"})));
@@ -1921,7 +1926,17 @@ pub async fn stripe_webhook(
                             .await;
                         return (StatusCode::OK, Json(json!({"status":"ok"})));
                     }
-                    Err(_) => return (StatusCode::OK, Json(json!({"status":"ok"}))),
+                    Err(e) => {
+                        tracing::error!(
+                            agency_id_from_meta = %agency_id_from_meta,
+                            error = %e,
+                            "Payment link checkout handler FAILED in metadata fallback path — earnings will not be recorded"
+                        );
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({"status":"error","error":"payment_link_checkout_failed"})),
+                        );
+                    }
                 }
             }
 

--- a/likelee-server/src/payouts.rs
+++ b/likelee-server/src/payouts.rs
@@ -1846,7 +1846,27 @@ pub async fn stripe_webhook(
                     stripe_payment_link_id = %stripe_payment_link_id,
                     "checkout.session.completed detected as payment-link checkout"
                 );
-                let _ = handle_payment_link_checkout_completed(&state, &obj).await;
+                match handle_payment_link_checkout_completed(&state, &obj).await {
+                    Ok(true) => {
+                        tracing::info!(
+                            stripe_payment_link_id = %stripe_payment_link_id,
+                            "Payment link checkout completed successfully"
+                        );
+                    }
+                    Ok(false) => {
+                        tracing::warn!(
+                            stripe_payment_link_id = %stripe_payment_link_id,
+                            "Payment link checkout handler returned false — payment link record not found or already processed"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            stripe_payment_link_id = %stripe_payment_link_id,
+                            error = %e,
+                            "Payment link checkout handler FAILED — earnings will not be recorded"
+                        );
+                    }
+                }
                 return (StatusCode::OK, Json(json!({"status":"ok"})));
             }
 

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -461,7 +461,9 @@ pub async fn get_performance_tiers(
     }
 
     // Process signed licensing deals this month (AI mode deal count).
-    // Covers single-talent (talent_id) and multi-talent (talent_ids array).
+    // Use talent_ids array when non-empty (preferred, covers multi-talent).
+    // Fall back to talent_id only when talent_ids is absent or empty.
+    // Never count both for the same submission to avoid double-counting.
     let text_licensing_deals = resp_licensing_deals
         .text()
         .await
@@ -470,21 +472,25 @@ pub async fn get_performance_tiers(
         serde_json::from_str(&text_licensing_deals).unwrap_or_default();
     let mut licensing_deals_map: HashMap<String, i64> = HashMap::new();
     for row in &licensing_deal_rows {
-        // Single-talent path
-        if let Some(tid) = row.get("talent_id").and_then(|v| v.as_str()) {
-            let tid = tid.trim();
-            if !tid.is_empty() {
-                *licensing_deals_map.entry(tid.to_string()).or_insert(0) += 1;
-            }
-        }
-        // Multi-talent path — unnest talent_ids array
-        if let Some(arr) = row.get("talent_ids").and_then(|v| v.as_array()) {
-            for item in arr {
+        // Prefer talent_ids array — it's the authoritative multi-talent list.
+        let arr = row.get("talent_ids").and_then(|v| v.as_array());
+        let used_array = arr.map(|a| !a.is_empty()).unwrap_or(false);
+
+        if used_array {
+            for item in arr.unwrap() {
                 if let Some(tid) = item.as_str() {
                     let tid = tid.trim();
                     if !tid.is_empty() {
                         *licensing_deals_map.entry(tid.to_string()).or_insert(0) += 1;
                     }
+                }
+            }
+        } else {
+            // Single-talent path — only when talent_ids is absent/empty
+            if let Some(tid) = row.get("talent_id").and_then(|v| v.as_str()) {
+                let tid = tid.trim();
+                if !tid.is_empty() {
+                    *licensing_deals_map.entry(tid.to_string()).or_insert(0) += 1;
                 }
             }
         }

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -260,7 +260,7 @@ pub async fn get_performance_tiers(
         .agency_mode
         .as_deref()
         .map(|m| m.eq_ignore_ascii_case("AI"))
-        .unwrap_or(true); // default to AI mode
+        .unwrap_or(false); // default to IRL mode for backward compatibility
 
     // Parallelize calls
     let (
@@ -331,6 +331,8 @@ pub async fn get_performance_tiers(
         // Fetch signed licensing deals this month for AI mode deal count.
         // Counts license_submissions with status='completed' and signed_at >= month start.
         // Covers both single-talent (talent_id) and multi-talent (talent_ids array) submissions.
+        // Uses a high limit to avoid truncation; for very high-volume agencies a dedicated
+        // aggregation RPC should be used instead.
         async {
             let now = chrono::Utc::now();
             let month_start = now.format("%Y-%m-01").to_string();
@@ -341,7 +343,7 @@ pub async fn get_performance_tiers(
                 .eq("agency_id", agency_id)
                 .eq("status", "completed")
                 .gte("signed_at", &month_start)
-                .limit(1000)
+                .limit(10000)
                 .execute()
                 .await
         }

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -2,7 +2,11 @@ use crate::{
     auth::{AuthUser, RoleGuard},
     config::AppState,
 };
-use axum::{extract::{Query, State}, http::StatusCode, Json};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
@@ -567,11 +571,7 @@ pub async fn get_performance_tiers(
                 let kyc_rows: Vec<serde_json::Value> =
                     serde_json::from_str(&kyc_text).unwrap_or_default();
                 for r in kyc_rows {
-                    let cid = r
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .trim();
+                    let cid = r.get("id").and_then(|v| v.as_str()).unwrap_or("").trim();
                     if cid.is_empty() {
                         continue;
                     }

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -44,6 +44,8 @@ pub struct TalentPerformance {
     pub photo_url: Option<String>,
     pub earnings_30d: f64,
     pub bookings_this_month: i64,
+    /// Signed licensing deals this month (AI mode equivalent of bookings_this_month).
+    pub licensing_deals_this_month: i64,
     pub tier: TierRule,
     pub commission_rate: f64,
     pub is_custom_rate: bool,
@@ -264,6 +266,7 @@ pub async fn get_performance_tiers(
         resp_stats,
         resp_agency,
         resp_marketplace_contracts,
+        resp_licensing_deals,
     ) = tokio::try_join!(
         state
             .pg
@@ -320,7 +323,24 @@ pub async fn get_performance_tiers(
             .eq("status", "active")
             .lte("valid_from", &today)
             .gte("valid_until", &today)
-            .execute()
+            .execute(),
+        // Fetch signed licensing deals this month for AI mode deal count.
+        // Counts license_submissions with status='completed' and signed_at >= month start.
+        // Covers both single-talent (talent_id) and multi-talent (talent_ids array) submissions.
+        async {
+            let now = chrono::Utc::now();
+            let month_start = now.format("%Y-%m-01").to_string();
+            state
+                .pg
+                .from("license_submissions")
+                .select("talent_id,talent_ids")
+                .eq("agency_id", agency_id)
+                .eq("status", "completed")
+                .gte("signed_at", &month_start)
+                .limit(1000)
+                .execute()
+                .await
+        }
     )
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -438,6 +458,36 @@ pub async fn get_performance_tiers(
     for s in stats {
         earnings_map.insert(s.talent_id.clone(), s.earnings_cents as f64 / 100.0);
         bookings_map.insert(s.talent_id, s.booking_count);
+    }
+
+    // Process signed licensing deals this month (AI mode deal count).
+    // Covers single-talent (talent_id) and multi-talent (talent_ids array).
+    let text_licensing_deals = resp_licensing_deals
+        .text()
+        .await
+        .unwrap_or_else(|_| "[]".to_string());
+    let licensing_deal_rows: Vec<serde_json::Value> =
+        serde_json::from_str(&text_licensing_deals).unwrap_or_default();
+    let mut licensing_deals_map: HashMap<String, i64> = HashMap::new();
+    for row in &licensing_deal_rows {
+        // Single-talent path
+        if let Some(tid) = row.get("talent_id").and_then(|v| v.as_str()) {
+            let tid = tid.trim();
+            if !tid.is_empty() {
+                *licensing_deals_map.entry(tid.to_string()).or_insert(0) += 1;
+            }
+        }
+        // Multi-talent path — unnest talent_ids array
+        if let Some(arr) = row.get("talent_ids").and_then(|v| v.as_array()) {
+            for item in arr {
+                if let Some(tid) = item.as_str() {
+                    let tid = tid.trim();
+                    if !tid.is_empty() {
+                        *licensing_deals_map.entry(tid.to_string()).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
     }
 
     // Process Talents
@@ -688,6 +738,7 @@ pub async fn get_performance_tiers(
                 photo_url: photo,
                 earnings_30d: earnings,
                 bookings_this_month: booking_count,
+                licensing_deals_this_month: *licensing_deals_map.get(&id).unwrap_or(&0),
                 tier: assigned_tier.clone(),
                 commission_rate: final_rate,
                 is_custom_rate,
@@ -782,6 +833,7 @@ pub async fn get_performance_tiers(
                 photo_url: photo,
                 earnings_30d: 0.0,
                 bookings_this_month: 0,
+                licensing_deals_this_month: *licensing_deals_map.get(&creator_id).unwrap_or(&0),
                 tier: assigned_tier.clone(),
                 commission_rate: final_rate,
                 is_custom_rate,

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -50,6 +50,9 @@ pub struct TalentPerformance {
     pub relationship_type: String,
     pub commission_source: String,
     pub is_editable: bool,
+    /// True only when the talent has completed portal onboarding AND
+    /// their KYC is approved in the creators table.
+    pub is_verified: bool,
 }
 
 #[derive(Serialize)]
@@ -473,6 +476,45 @@ pub async fn get_performance_tiers(
     creator_ids.sort();
     creator_ids.dedup();
 
+    // Fetch kyc_status for all creators so we can mark verified talent.
+    // A talent is "verified" only when they have completed portal onboarding
+    // (creator_id is set) AND their KYC is approved.
+    let mut kyc_approved_creators: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    if !creator_ids.is_empty() {
+        let kyc_refs: Vec<&str> = creator_ids.iter().map(|s| s.as_str()).collect();
+        if let Ok(kyc_resp) = state
+            .pg
+            .from("creators")
+            .select("id,kyc_status")
+            .in_("id", kyc_refs)
+            .execute()
+            .await
+        {
+            if kyc_resp.status().is_success() {
+                let kyc_text = kyc_resp.text().await.unwrap_or_else(|_| "[]".into());
+                let kyc_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&kyc_text).unwrap_or_default();
+                for r in kyc_rows {
+                    let cid = r
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim();
+                    let status = r
+                        .get("kyc_status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_lowercase();
+                    if !cid.is_empty() && status == "approved" {
+                        kyc_approved_creators.insert(cid.to_string());
+                    }
+                }
+            }
+        }
+    }
+
     let mut custom_by_creator: HashMap<String, f64> = HashMap::new();
     if !creator_ids.is_empty() {
         let creator_id_refs: Vec<&str> = creator_ids.iter().map(|s| s.as_str()).collect();
@@ -618,6 +660,10 @@ pub async fn get_performance_tiers(
                 relationship_type,
                 commission_source,
                 is_editable,
+                is_verified: creator_id
+                    .as_ref()
+                    .map(|cid| kyc_approved_creators.contains(cid))
+                    .unwrap_or(false),
             });
         }
 
@@ -697,7 +743,7 @@ pub async fn get_performance_tiers(
         if let Some(group) = groups.get_mut(&assigned_tier.tier_level) {
             group.talents.push(TalentPerformance {
                 id: creator_id.clone(),
-                creator_id: Some(creator_id),
+                creator_id: Some(creator_id.clone()),
                 name,
                 photo_url: photo,
                 earnings_30d: 0.0,
@@ -708,6 +754,7 @@ pub async fn get_performance_tiers(
                 relationship_type,
                 commission_source,
                 is_editable,
+                is_verified: kyc_approved_creators.contains(&creator_id),
             });
         }
     }

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -2,7 +2,7 @@ use crate::{
     auth::{AuthUser, RoleGuard},
     config::AppState,
 };
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::{Query, State}, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
@@ -234,14 +234,27 @@ pub async fn configure_performance_tiers(
     Ok(Json(json!({ "ok": true })))
 }
 
+#[derive(Deserialize)]
+pub struct PerformanceTiersQuery {
+    pub agency_mode: Option<String>,
+}
+
 pub async fn get_performance_tiers(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    Query(query): Query<PerformanceTiersQuery>,
 ) -> Result<Json<PerformanceTiersResponse>, (StatusCode, String)> {
     RoleGuard::new(vec!["agency"]).check(&auth_user.role)?;
     let start_total = Instant::now();
     let agency_id = auth_user.effective_org_id();
     let today = today_iso();
+    // In AI mode bookings are irrelevant — creators earn through licensing deals.
+    // Tier classification uses only earnings; min_monthly_bookings is treated as 0.
+    let is_ai_mode = query
+        .agency_mode
+        .as_deref()
+        .map(|m| m.eq_ignore_ascii_case("AI"))
+        .unwrap_or(true); // default to AI mode
 
     // Parallelize calls
     let (
@@ -617,9 +630,10 @@ pub async fn get_performance_tiers(
 
         let mut assigned_tier = &tiers_json[tiers_json.len() - 1];
         for rule in &tiers_json {
-            if earnings >= rule.min_monthly_earnings
-                && booking_count >= rule.min_monthly_bookings as i64
-            {
+            // In AI mode bookings are irrelevant — only earnings drive tier placement.
+            // In IRL mode both earnings and bookings must meet the threshold.
+            let meets_bookings = is_ai_mode || booking_count >= rule.min_monthly_bookings as i64;
+            if earnings >= rule.min_monthly_earnings && meets_bookings {
                 assigned_tier = rule;
                 break;
             }

--- a/likelee-server/src/performance_tiers.rs
+++ b/likelee-server/src/performance_tiers.rs
@@ -476,17 +476,19 @@ pub async fn get_performance_tiers(
     creator_ids.sort();
     creator_ids.dedup();
 
-    // Fetch kyc_status for all creators so we can mark verified talent.
-    // A talent is "verified" only when they have completed portal onboarding
-    // (creator_id is set) AND their KYC is approved.
+    // Fetch kyc_status and profile_photo_url for all creators so we can:
+    // 1. Mark verified talent (kyc_status = 'approved')
+    // 2. Fall back to creators.profile_photo_url when agency_users has no photo
     let mut kyc_approved_creators: std::collections::HashSet<String> =
         std::collections::HashSet::new();
+    let mut creator_photo_by_id: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     if !creator_ids.is_empty() {
         let kyc_refs: Vec<&str> = creator_ids.iter().map(|s| s.as_str()).collect();
         if let Ok(kyc_resp) = state
             .pg
             .from("creators")
-            .select("id,kyc_status")
+            .select("id,kyc_status,profile_photo_url")
             .in_("id", kyc_refs)
             .execute()
             .await
@@ -501,14 +503,24 @@ pub async fn get_performance_tiers(
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .trim();
+                    if cid.is_empty() {
+                        continue;
+                    }
                     let status = r
                         .get("kyc_status")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .trim()
                         .to_lowercase();
-                    if !cid.is_empty() && status == "approved" {
+                    if status == "approved" {
                         kyc_approved_creators.insert(cid.to_string());
+                    }
+                    if let Some(photo) = r
+                        .get("profile_photo_url")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.trim().is_empty())
+                    {
+                        creator_photo_by_id.insert(cid.to_string(), photo.to_string());
                     }
                 }
             }
@@ -591,7 +603,15 @@ pub async fn get_performance_tiers(
         let photo = t
             .get("profile_photo_url")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.to_string())
+            // Fall back to creators.profile_photo_url when agency_users has no photo
+            .or_else(|| {
+                creator_id
+                    .as_ref()
+                    .and_then(|cid| creator_photo_by_id.get(cid))
+                    .cloned()
+            });
         let earnings = *earnings_map.get(&id).unwrap_or(&0.0);
         let booking_count = *bookings_map.get(&id).unwrap_or(&0);
 

--- a/likelee-ui/package-lock.json
+++ b/likelee-ui/package-lock.json
@@ -5116,6 +5116,13 @@
       "version": "3.0.2",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "license": "MIT"
@@ -6138,7 +6145,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/likelee-ui/package.json
+++ b/likelee-ui/package.json
@@ -111,7 +111,7 @@
     "cross-spawn": "^7.0.6",
     "rollup": "^4.58.1",
     "serialize-javascript": "^7.0.5",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "dompurify": "^3.4.0"
   },
   "devDependencies": {

--- a/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
@@ -295,11 +295,12 @@ export const NewBookingModal = ({
               : [];
         const mapped = Array.isArray(rows)
           ? rows
-              .filter((r: any) =>
-                // Only include agency-created talents — those with agency_users rows.
-                // relationship_type='internal' means the talent was created by this agency.
-                // relationship_type='marketplace_connected' means independent creator — skip.
-                !r.relationship_type || r.relationship_type === "internal"
+              .filter(
+                (r: any) =>
+                  // Only include agency-created talents — those with agency_users rows.
+                  // relationship_type='internal' means the talent was created by this agency.
+                  // relationship_type='marketplace_connected' means independent creator — skip.
+                  !r.relationship_type || r.relationship_type === "internal",
               )
               .map((r: any) => ({
                 id: r.agency_user_id || r.id,
@@ -498,8 +499,9 @@ export const NewBookingModal = ({
               : [];
         const mapped = Array.isArray(rows)
           ? rows
-              .filter((r: any) =>
-                !r.relationship_type || r.relationship_type === "internal"
+              .filter(
+                (r: any) =>
+                  !r.relationship_type || r.relationship_type === "internal",
               )
               .map((r: any) => ({
                 id: r.agency_user_id || r.id,

--- a/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
@@ -734,7 +734,10 @@ export const NewBookingModal = ({
       const bookingRequests = selectedTalents.map(async (talent) => {
         const payload: any = {
           booking_type: bookingType,
-          status: "pending",
+          // Map booking_type to the appropriate status.
+          // 'confirmed' booking_type → status 'confirmed' (counts in performance stats)
+          // All other types (casting, option, test-shoot, etc.) → status 'pending'
+          status: bookingType === "confirmed" ? "confirmed" : "pending",
           client_id: selectedClient?.id,
           talent_id: talent.id,
           creator_id: talent.creator_id || undefined,

--- a/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
+++ b/likelee-ui/src/components/Bookings/Modals/NewBookingModal.tsx
@@ -40,6 +40,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { parseBackendError } from "@/utils/errorParser";
 import {
   getAgencyRoster,
+  getAgencyTalents,
   getAgencyClients,
   getAgencyCalendlySettings,
   createAgencyClient,
@@ -281,7 +282,10 @@ export const NewBookingModal = ({
       if (!open) return;
       setTalentsLoading(true);
       try {
-        const resp = await getAgencyRoster();
+        // Bookings are IRL-only — only agency-created talents (agency_users rows)
+        // can be booked. Independent connected creators (relationship_type='marketplace_connected')
+        // don't have agency_users rows and cannot be booked.
+        const resp = await getAgencyTalents();
         const rows = Array.isArray(resp)
           ? resp
           : Array.isArray((resp as any)?.talents)
@@ -290,15 +294,22 @@ export const NewBookingModal = ({
               ? (resp as any).data.talents
               : [];
         const mapped = Array.isArray(rows)
-          ? rows.map((r: any) => ({
-              id: r.id,
-              name: r.full_name || r.name || "Unnamed",
-              img: r.img || r.profile_photo_url || null,
-              creator_id: r.creator_id || null,
-              relationship_id: r.relationship_id || null,
-              relationship_type: r.relationship_type || "internal",
-              contract_controlled: Boolean(r.contract_controlled),
-            }))
+          ? rows
+              .filter((r: any) =>
+                // Only include agency-created talents — those with agency_users rows.
+                // relationship_type='internal' means the talent was created by this agency.
+                // relationship_type='marketplace_connected' means independent creator — skip.
+                !r.relationship_type || r.relationship_type === "internal"
+              )
+              .map((r: any) => ({
+                id: r.agency_user_id || r.id,
+                name: r.full_name || r.name || "Unnamed",
+                img: r.img || r.profile_photo_url || null,
+                creator_id: r.creator_id || null,
+                relationship_id: r.relationship_id || null,
+                relationship_type: r.relationship_type || "internal",
+                contract_controlled: Boolean(r.contract_controlled),
+              }))
           : [];
         setTalents(mapped);
       } catch (_e) {
@@ -476,7 +487,7 @@ export const NewBookingModal = ({
       if (!open) return;
       setTalentsLoading(true);
       try {
-        const resp = await getAgencyRoster();
+        const resp = await getAgencyTalents({ q: talentSearch || undefined });
         if (cancelled) return;
         const rows = Array.isArray(resp)
           ? resp
@@ -485,23 +496,20 @@ export const NewBookingModal = ({
             : Array.isArray((resp as any)?.data?.talents)
               ? (resp as any).data.talents
               : [];
-        const filteredRows = talentSearch
-          ? rows.filter((r: any) =>
-              String(r.full_name || r.name || "")
-                .toLowerCase()
-                .includes(talentSearch.toLowerCase()),
-            )
-          : rows;
-        const mapped = Array.isArray(filteredRows)
-          ? filteredRows.map((r: any) => ({
-              id: r.id,
-              name: r.full_name || r.name || "Unnamed",
-              img: r.img || r.profile_photo_url || null,
-              creator_id: r.creator_id || null,
-              relationship_id: r.relationship_id || null,
-              relationship_type: r.relationship_type || "internal",
-              contract_controlled: Boolean(r.contract_controlled),
-            }))
+        const mapped = Array.isArray(rows)
+          ? rows
+              .filter((r: any) =>
+                !r.relationship_type || r.relationship_type === "internal"
+              )
+              .map((r: any) => ({
+                id: r.agency_user_id || r.id,
+                name: r.full_name || r.name || "Unnamed",
+                img: r.img || r.profile_photo_url || null,
+                creator_id: r.creator_id || null,
+                relationship_id: r.relationship_id || null,
+                relationship_type: r.relationship_type || "internal",
+                contract_controlled: Boolean(r.contract_controlled),
+              }))
           : [];
         setTalents(mapped);
       } catch (_e) {

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import {
   Filter,
   CheckCircle2,
@@ -59,6 +60,7 @@ const LicensingRequestsView = ({
   const entityPluralLower = isSportsAgency ? "athlete" : "talent";
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["agency", "licensing-requests"],
@@ -1476,12 +1478,11 @@ const LicensingRequestsView = ({
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-semibold text-gray-900 truncate">
-                      {talent.split(" (")[0]}
+                      {talent.replace(/\s*\([^)]*\)\s*$/, "") || talent}
                     </p>
                     <p className="text-xs text-gray-500 mt-0.5">
-                      {talent.includes("(")
-                        ? talent.split("(")[1]?.replace(")", "")
-                        : "Account setup incomplete"}
+                      {/\(([^)]+)\)/.exec(talent)?.[1] ??
+                        "Account setup incomplete"}
                     </p>
                   </div>
                 </div>
@@ -1517,7 +1518,7 @@ const LicensingRequestsView = ({
                     open: false,
                   }));
                   // Navigate to Messages tab so the agency can message the talent
-                  window.location.href = "/AgencyDashboard?tab=messages";
+                  navigate("/AgencyDashboard?tab=messages");
                 }}
               >
                 <MessageSquare className="w-4 h-4" />

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -354,24 +354,43 @@ const LicensingRequestsView = ({
           : "Payment link sent.",
       });
     } catch (e: any) {
-      try {
-        const parsed = JSON.parse(String(e?.message || ""));
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          parsed.code === "MISSING_TALENT_STRIPE_CONNECT"
-        ) {
-          // Show the professional readiness modal instead of a red toast
-          setPaymentReadinessModal({
-            open: true,
-            missingTalents: Array.isArray(parsed.missing) ? parsed.missing : [],
-            action: String(parsed.action || ""),
-          });
-          return;
+      // The base44Client extracts only the message string into e.message,
+      // but preserves the full raw error payload on e.data.
+      // Check e.data first for the structured MISSING_TALENT_STRIPE_CONNECT payload.
+      const rawData = e?.data;
+      const normalizedData =
+        rawData && typeof rawData === "object"
+          ? rawData
+          : (() => {
+              try {
+                return JSON.parse(String(rawData || ""));
+              } catch {
+                return null;
+              }
+            })();
+
+      // Also try parsing e.message in case the client serialized it there
+      const parsedMessage = (() => {
+        try {
+          return JSON.parse(String(e?.message || ""));
+        } catch {
+          return null;
         }
-      } catch {
-        // not a structured error — fall through to generic toast
+      })();
+
+      const structured = normalizedData || parsedMessage;
+
+      if (structured?.code === "MISSING_TALENT_STRIPE_CONNECT") {
+        setPaymentReadinessModal({
+          open: true,
+          missingTalents: Array.isArray(structured.missing)
+            ? structured.missing
+            : [],
+          action: String(structured.action || ""),
+        });
+        return;
       }
+
       toast({
         title: "Send payment link failed",
         description: e?.message || "Could not generate/send payment link",

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -8,6 +8,9 @@ import {
   Eye,
   X,
   Trash2,
+  AlertTriangle,
+  MessageSquare,
+  UserX,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { Card } from "@/components/ui/card";
@@ -93,6 +96,12 @@ const LicensingRequestsView = ({
   >("Active");
   const [sendPaymentBusyKey, setSendPaymentBusyKey] = useState<string>("");
   const [showFilterDialog, setShowFilterDialog] = useState(false);
+  // Payment readiness modal — shown when talents are missing Stripe Connect
+  const [paymentReadinessModal, setPaymentReadinessModal] = useState<{
+    open: boolean;
+    missingTalents: string[];
+    action: string;
+  }>({ open: false, missingTalents: [], action: "" });
   const [filterStatus, setFilterStatus] = useState<string>("all");
   const [filterMinLicenseFee, setFilterMinLicenseFee] = useState<string>("");
   const [filterMaxLicenseFee, setFilterMaxLicenseFee] = useState<string>("");
@@ -345,8 +354,6 @@ const LicensingRequestsView = ({
           : "Payment link sent.",
       });
     } catch (e: any) {
-      let friendlyTitle = "Send payment link failed";
-      let friendlyDesc = e?.message || "Could not generate/send payment link";
       try {
         const parsed = JSON.parse(String(e?.message || ""));
         if (
@@ -354,24 +361,20 @@ const LicensingRequestsView = ({
           typeof parsed === "object" &&
           parsed.code === "MISSING_TALENT_STRIPE_CONNECT"
         ) {
-          friendlyTitle = `Action required: connect ${entityPluralLower} payouts`;
-          const missingList = Array.isArray(parsed.missing)
-            ? parsed.missing
-            : [];
-          const missingText = missingList.length
-            ? `Missing: ${missingList.join(", ")}`
-            : "";
-          const actionText = parsed.action ? String(parsed.action) : "";
-          friendlyDesc = [String(parsed.message || ""), actionText, missingText]
-            .filter((s) => Boolean(String(s || "").trim()))
-            .join("\n");
+          // Show the professional readiness modal instead of a red toast
+          setPaymentReadinessModal({
+            open: true,
+            missingTalents: Array.isArray(parsed.missing) ? parsed.missing : [],
+            action: String(parsed.action || ""),
+          });
+          return;
         }
       } catch {
-        // ignore parse errors
+        // not a structured error — fall through to generic toast
       }
       toast({
-        title: friendlyTitle,
-        description: friendlyDesc,
+        title: "Send payment link failed",
+        description: e?.message || "Could not generate/send payment link",
         variant: "destructive" as any,
       });
     } finally {
@@ -1417,6 +1420,91 @@ const LicensingRequestsView = ({
                 })()}
               </div>
             )}
+          </DialogContent>
+        </Dialog>
+
+        {/* Payment Readiness Modal — replaces the red destructive toast */}
+        <Dialog
+          open={paymentReadinessModal.open}
+          onOpenChange={(open) =>
+            setPaymentReadinessModal((prev) => ({ ...prev, open }))
+          }
+        >
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <div className="flex items-center gap-3 mb-1">
+                <div className="w-10 h-10 rounded-2xl bg-amber-50 border border-amber-200 flex items-center justify-center shrink-0">
+                  <AlertTriangle className="w-5 h-5 text-amber-500" />
+                </div>
+                <DialogTitle className="text-lg font-bold text-gray-900">
+                  {entitySingularTitle} setup required
+                </DialogTitle>
+              </div>
+              <DialogDescription className="text-sm text-gray-500 ml-13 pl-[52px]">
+                The following {entityPluralLower} need to complete their account
+                setup before a payment link can be sent.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-3 py-2">
+              {paymentReadinessModal.missingTalents.map((talent, idx) => (
+                <div
+                  key={idx}
+                  className="flex items-start gap-3 p-3 rounded-xl bg-gray-50 border border-gray-100"
+                >
+                  <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center shrink-0 mt-0.5">
+                    <UserX className="w-4 h-4 text-gray-500" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-gray-900 truncate">
+                      {talent.split(" (")[0]}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      {talent.includes("(")
+                        ? talent.split("(")[1]?.replace(")", "")
+                        : "Account setup incomplete"}
+                    </p>
+                  </div>
+                </div>
+              ))}
+
+              {paymentReadinessModal.action && (
+                <div className="p-3 rounded-xl bg-indigo-50 border border-indigo-100">
+                  <p className="text-xs text-indigo-700 leading-relaxed">
+                    {paymentReadinessModal.action}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <DialogFooter className="gap-2 sm:gap-2">
+              <Button
+                variant="outline"
+                onClick={() =>
+                  setPaymentReadinessModal((prev) => ({
+                    ...prev,
+                    open: false,
+                  }))
+                }
+                className="font-bold border-gray-200"
+              >
+                Close
+              </Button>
+              <Button
+                className="bg-indigo-600 hover:bg-indigo-700 text-white font-bold flex items-center gap-2"
+                onClick={() => {
+                  setPaymentReadinessModal((prev) => ({
+                    ...prev,
+                    open: false,
+                  }));
+                  // Navigate to Messages tab so the agency can message the talent
+                  window.location.href = "/AgencyDashboard?tab=messages";
+                }}
+              >
+                <MessageSquare className="w-4 h-4" />
+                Message {entitySingularTitle}
+              </Button>
+            </DialogFooter>
           </DialogContent>
         </Dialog>
       </div>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -608,13 +608,6 @@ export const PerformanceTiers: React.FC<{
                             ></div>
                           </div>
                         </div>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="w-full sm:w-auto h-10 font-bold text-gray-700 bg-white border-gray-200 px-6 rounded-none hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm"
-                        >
-                          View
-                        </Button>
                       </div>
                     ))
                   ) : (

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -151,10 +151,10 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
 });
 
-export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?: "AI" | "IRL" }> = ({
-  isSportsAgency = false,
-  agencyMode = "AI",
-}) => {
+export const PerformanceTiers: React.FC<{
+  isSportsAgency?: boolean;
+  agencyMode?: "AI" | "IRL";
+}> = ({ isSportsAgency = false, agencyMode = "AI" }) => {
   const queryClient = useQueryClient();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const entitySingular = isSportsAgency ? "athlete" : "talent";
@@ -165,7 +165,15 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
   const isAiMode = agencyMode === "AI";
 
   const [configForm, setConfigForm] = useState<
-    Record<string, { min_earnings: number; min_bookings: number; commission_rate: number; payout_percent: number }>
+    Record<
+      string,
+      {
+        min_earnings: number;
+        min_bookings: number;
+        commission_rate: number;
+        payout_percent: number;
+      }
+    >
   >({});
 
   const { data, isLoading, error } =
@@ -199,7 +207,12 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
     if (data?.config) {
       const next: Record<
         string,
-        { min_earnings: number; min_bookings: number; commission_rate: number; payout_percent: number }
+        {
+          min_earnings: number;
+          min_bookings: number;
+          commission_rate: number;
+          payout_percent: number;
+        }
       > = {};
       for (const tier of ["Premium", "Core", "Growth"]) {
         next[tier] = {
@@ -287,8 +300,12 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
           configForm?.[tier]?.min_earnings ?? existing?.[tier]?.min_earnings,
         min_bookings:
           configForm?.[tier]?.min_bookings ?? existing?.[tier]?.min_bookings,
-        commission_rate: configForm?.[tier]?.commission_rate ?? existing?.[tier]?.commission_rate,
-        payout_percent: configForm?.[tier]?.payout_percent ?? (existing?.[tier] as any)?.payout_percent,
+        commission_rate:
+          configForm?.[tier]?.commission_rate ??
+          existing?.[tier]?.commission_rate,
+        payout_percent:
+          configForm?.[tier]?.payout_percent ??
+          (existing?.[tier] as any)?.payout_percent,
       };
     }
 
@@ -360,7 +377,11 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
           const avgBookings =
             group.talents.length > 0
               ? group.talents.reduce(
-                  (acc, t) => acc + (isAiMode ? t.licensing_deals_this_month : t.bookings_this_month),
+                  (acc, t) =>
+                    acc +
+                    (isAiMode
+                      ? t.licensing_deals_this_month
+                      : t.bookings_this_month),
                   0,
                 ) / group.talents.length
               : 0;
@@ -446,7 +467,9 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                       <Calendar className={cn("w-4 h-4", cfg.brandColor)} />
                     </div>
                     <span className="text-xs font-bold text-gray-500 uppercase tracking-wider">
-                      {isAiMode ? "Avg Deal Frequency" : "Avg Booking Frequency"}
+                      {isAiMode
+                        ? "Avg Deal Frequency"
+                        : "Avg Booking Frequency"}
                     </span>
                   </div>
                   <div className="text-2xl font-bold text-gray-900">
@@ -561,12 +584,24 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                                   const currentLevel = talent.tier.tier_level;
                                   if (currentLevel <= 1) return "100%"; // already Premium
                                   // Tier name for the next level up
-                                  const tierOrder = ["Premium", "Core", "Growth", "Inactive"];
+                                  const tierOrder = [
+                                    "Premium",
+                                    "Core",
+                                    "Growth",
+                                    "Inactive",
+                                  ];
                                   // currentLevel is 1-based; index in tierOrder = level - 1
-                                  const nextTierName = tierOrder[currentLevel - 2]; // one step up
-                                  const target = nextTierName && data?.config?.[nextTierName]?.min_earnings;
-                                  if (!target || target <= 0) return `${Math.max(2, Math.min(100, Math.round((earned / 500) * 100)))}%`;
-                                  const pct = Math.min(100, Math.round((earned / target) * 100));
+                                  const nextTierName =
+                                    tierOrder[currentLevel - 2]; // one step up
+                                  const target =
+                                    nextTierName &&
+                                    data?.config?.[nextTierName]?.min_earnings;
+                                  if (!target || target <= 0)
+                                    return `${Math.max(2, Math.min(100, Math.round((earned / 500) * 100)))}%`;
+                                  const pct = Math.min(
+                                    100,
+                                    Math.round((earned / target) * 100),
+                                  );
                                   return `${Math.max(2, pct)}%`; // min 2% so bar is always visible
                                 })(),
                               }}
@@ -657,126 +692,151 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                   </div>
                   {/* In AI mode bookings are irrelevant — hide the bookings threshold */}
                   {!isAiMode && (
-                  <div className="space-y-3">
-                    <Label className="text-[13px] font-bold text-gray-600 ml-1">
-                      Min Bookings/Month
-                    </Label>
-                    <Input
-                      type="number"
-                      value={configForm[tier]?.min_bookings}
-                      onChange={(e) =>
-                        setConfigForm({
-                          ...configForm,
-                          [tier]: {
-                            ...configForm[tier],
-                            min_bookings: Number(e.target.value),
-                          },
-                        })
-                      }
-                      className={cn(
-                        "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all",
-                        TIER_CONFIG[tier].modalInputBg,
-                      )}
-                    />
-                  </div>
+                    <div className="space-y-3">
+                      <Label className="text-[13px] font-bold text-gray-600 ml-1">
+                        Min Bookings/Month
+                      </Label>
+                      <Input
+                        type="number"
+                        value={configForm[tier]?.min_bookings}
+                        onChange={(e) =>
+                          setConfigForm({
+                            ...configForm,
+                            [tier]: {
+                              ...configForm[tier],
+                              min_bookings: Number(e.target.value),
+                            },
+                          })
+                        }
+                        className={cn(
+                          "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all",
+                          TIER_CONFIG[tier].modalInputBg,
+                        )}
+                      />
+                    </div>
                   )}
                   {/* Commission/payout split — only relevant for AI mode (licensing deals).
                       IRL bookings use a separate payment flow and don't use these rates. */}
                   {isAiMode && (
-                  <>
-                  <div className="space-y-3">
-                    <Label className="text-[13px] font-bold text-gray-600 ml-1">
-                      Talent Payout % (of net)
-                    </Label>
-                    <div className="relative">
-                      <Input
-                        type="number"
-                        min={0}
-                        max={100}
-                        value={configForm[tier]?.payout_percent}
-                        onChange={(e) => {
-                          const val = Math.min(100, Math.max(0, Number(e.target.value)));
-                          setConfigForm({
-                            ...configForm,
-                            [tier]: {
-                              ...configForm[tier],
-                              payout_percent: val,
-                              commission_rate: Math.round((100 - val) * 100) / 100,
-                            },
-                          });
-                        }}
-                        className={cn(
-                          "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
-                          TIER_CONFIG[tier].modalInputBg,
-                        )}
-                      />
-                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">%</span>
-                    </div>
-                    <p className="text-[11px] text-gray-400 ml-1">
-                      Talent receives this % of net after platform fee
-                    </p>
-                  </div>
-                  <div className="space-y-3">
-                    <Label className="text-[13px] font-bold text-gray-600 ml-1">
-                      Agency Commission %
-                    </Label>
-                    <div className="relative">
-                      <Input
-                        type="number"
-                        min={0}
-                        max={100}
-                        value={configForm[tier]?.commission_rate}
-                        onChange={(e) => {
-                          const val = Math.min(100, Math.max(0, Number(e.target.value)));
-                          setConfigForm({
-                            ...configForm,
-                            [tier]: {
-                              ...configForm[tier],
-                              commission_rate: val,
-                              payout_percent: Math.round((100 - val) * 100) / 100,
-                            },
-                          });
-                        }}
-                        className={cn(
-                          "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
-                          TIER_CONFIG[tier].modalInputBg,
-                        )}
-                      />
-                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">%</span>
-                    </div>
-                    <p className="text-[11px] text-gray-400 ml-1">
-                      Agency takes this % from talent's gross share
-                    </p>
-                  </div>
-                  {/* Live split preview */}
-                  <div className={cn(
-                    "sm:col-span-2 rounded-xl p-4 border",
-                    TIER_CONFIG[tier].statsBg,
-                    TIER_CONFIG[tier].statsBorder,
-                  )}>
-                    <p className="text-[11px] font-bold text-gray-500 uppercase tracking-wider mb-2">
-                      Split Preview — on a $1,000 net deal
-                    </p>
-                    <div className="flex items-center gap-3">
-                      <div className="flex-1 h-3 rounded-full overflow-hidden bg-gray-200">
-                        <div
-                          className={cn("h-full rounded-full transition-all duration-300", TIER_CONFIG[tier].iconBg)}
-                          style={{ width: `${configForm[tier]?.payout_percent ?? 0}%` }}
-                        />
+                    <>
+                      <div className="space-y-3">
+                        <Label className="text-[13px] font-bold text-gray-600 ml-1">
+                          Talent Payout % (of net)
+                        </Label>
+                        <div className="relative">
+                          <Input
+                            type="number"
+                            min={0}
+                            max={100}
+                            value={configForm[tier]?.payout_percent}
+                            onChange={(e) => {
+                              const val = Math.min(
+                                100,
+                                Math.max(0, Number(e.target.value)),
+                              );
+                              setConfigForm({
+                                ...configForm,
+                                [tier]: {
+                                  ...configForm[tier],
+                                  payout_percent: val,
+                                  commission_rate:
+                                    Math.round((100 - val) * 100) / 100,
+                                },
+                              });
+                            }}
+                            className={cn(
+                              "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
+                              TIER_CONFIG[tier].modalInputBg,
+                            )}
+                          />
+                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">
+                            %
+                          </span>
+                        </div>
+                        <p className="text-[11px] text-gray-400 ml-1">
+                          Talent receives this % of net after platform fee
+                        </p>
                       </div>
-                    </div>
-                    <div className="flex justify-between mt-2 text-[12px] font-bold">
-                      <span className={TIER_CONFIG[tier].brandColor}>
-                        Talent: ${((configForm[tier]?.payout_percent ?? 0) * 10).toFixed(0)}
-                        {" "}({configForm[tier]?.payout_percent ?? 0}%)
-                      </span>
-                      <span className="text-gray-500">
-                        Agency: ${((configForm[tier]?.commission_rate ?? 0) * 10).toFixed(0)}
-                        {" "}({configForm[tier]?.commission_rate ?? 0}%)
-                      </span>
-                    </div>
-                  </div>
-                  </>
+                      <div className="space-y-3">
+                        <Label className="text-[13px] font-bold text-gray-600 ml-1">
+                          Agency Commission %
+                        </Label>
+                        <div className="relative">
+                          <Input
+                            type="number"
+                            min={0}
+                            max={100}
+                            value={configForm[tier]?.commission_rate}
+                            onChange={(e) => {
+                              const val = Math.min(
+                                100,
+                                Math.max(0, Number(e.target.value)),
+                              );
+                              setConfigForm({
+                                ...configForm,
+                                [tier]: {
+                                  ...configForm[tier],
+                                  commission_rate: val,
+                                  payout_percent:
+                                    Math.round((100 - val) * 100) / 100,
+                                },
+                              });
+                            }}
+                            className={cn(
+                              "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
+                              TIER_CONFIG[tier].modalInputBg,
+                            )}
+                          />
+                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">
+                            %
+                          </span>
+                        </div>
+                        <p className="text-[11px] text-gray-400 ml-1">
+                          Agency takes this % from talent's gross share
+                        </p>
+                      </div>
+                      {/* Live split preview */}
+                      <div
+                        className={cn(
+                          "sm:col-span-2 rounded-xl p-4 border",
+                          TIER_CONFIG[tier].statsBg,
+                          TIER_CONFIG[tier].statsBorder,
+                        )}
+                      >
+                        <p className="text-[11px] font-bold text-gray-500 uppercase tracking-wider mb-2">
+                          Split Preview — on a $1,000 net deal
+                        </p>
+                        <div className="flex items-center gap-3">
+                          <div className="flex-1 h-3 rounded-full overflow-hidden bg-gray-200">
+                            <div
+                              className={cn(
+                                "h-full rounded-full transition-all duration-300",
+                                TIER_CONFIG[tier].iconBg,
+                              )}
+                              style={{
+                                width: `${configForm[tier]?.payout_percent ?? 0}%`,
+                              }}
+                            />
+                          </div>
+                        </div>
+                        <div className="flex justify-between mt-2 text-[12px] font-bold">
+                          <span className={TIER_CONFIG[tier].brandColor}>
+                            Talent: $
+                            {(
+                              (configForm[tier]?.payout_percent ?? 0) * 10
+                            ).toFixed(0)}{" "}
+                            ({configForm[tier]?.payout_percent ?? 0}%)
+                          </span>
+                          <span className="text-gray-500">
+                            Agency: $
+                            {(
+                              (configForm[tier]?.commission_rate ?? 0) * 10
+                            ).toFixed(0)}{" "}
+                            ({configForm[tier]?.commission_rate ?? 0}%)
+                          </span>
+                        </div>
+                      </div>
+                    </>
                   )}
                 </div>
               </div>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -165,7 +165,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
   const isAiMode = agencyMode === "AI";
 
   const [configForm, setConfigForm] = useState<
-    Record<string, { min_earnings: number; min_bookings: number }>
+    Record<string, { min_earnings: number; min_bookings: number; commission_rate: number; payout_percent: number }>
   >({});
 
   const { data, isLoading, error } =
@@ -199,12 +199,14 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
     if (data?.config) {
       const next: Record<
         string,
-        { min_earnings: number; min_bookings: number }
+        { min_earnings: number; min_bookings: number; commission_rate: number; payout_percent: number }
       > = {};
       for (const tier of ["Premium", "Core", "Growth"]) {
         next[tier] = {
           min_earnings: data.config?.[tier]?.min_earnings ?? 0,
           min_bookings: data.config?.[tier]?.min_bookings ?? 0,
+          commission_rate: data.config?.[tier]?.commission_rate ?? 0,
+          payout_percent: (data.config?.[tier] as any)?.payout_percent ?? 0,
         };
       }
       setConfigForm(next);
@@ -285,7 +287,8 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
           configForm?.[tier]?.min_earnings ?? existing?.[tier]?.min_earnings,
         min_bookings:
           configForm?.[tier]?.min_bookings ?? existing?.[tier]?.min_bookings,
-        commission_rate: existing?.[tier]?.commission_rate,
+        commission_rate: configForm?.[tier]?.commission_rate ?? existing?.[tier]?.commission_rate,
+        payout_percent: configForm?.[tier]?.payout_percent ?? (existing?.[tier] as any)?.payout_percent,
       };
     }
 
@@ -677,6 +680,98 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                     />
                   </div>
                   )}
+                  <div className="space-y-3">
+                    <Label className="text-[13px] font-bold text-gray-600 ml-1">
+                      Talent Payout % (of net)
+                    </Label>
+                    <div className="relative">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={configForm[tier]?.payout_percent}
+                        onChange={(e) => {
+                          const val = Math.min(100, Math.max(0, Number(e.target.value)));
+                          setConfigForm({
+                            ...configForm,
+                            [tier]: {
+                              ...configForm[tier],
+                              payout_percent: val,
+                              commission_rate: Math.round((100 - val) * 100) / 100,
+                            },
+                          });
+                        }}
+                        className={cn(
+                          "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
+                          TIER_CONFIG[tier].modalInputBg,
+                        )}
+                      />
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">%</span>
+                    </div>
+                    <p className="text-[11px] text-gray-400 ml-1">
+                      Talent receives this % of net after platform fee
+                    </p>
+                  </div>
+                  <div className="space-y-3">
+                    <Label className="text-[13px] font-bold text-gray-600 ml-1">
+                      Agency Commission %
+                    </Label>
+                    <div className="relative">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={configForm[tier]?.commission_rate}
+                        onChange={(e) => {
+                          const val = Math.min(100, Math.max(0, Number(e.target.value)));
+                          setConfigForm({
+                            ...configForm,
+                            [tier]: {
+                              ...configForm[tier],
+                              commission_rate: val,
+                              payout_percent: Math.round((100 - val) * 100) / 100,
+                            },
+                          });
+                        }}
+                        className={cn(
+                          "h-12 border-gray-200 rounded-xl font-bold text-gray-900 focus:ring-2 focus:ring-indigo-500 transition-all pr-8",
+                          TIER_CONFIG[tier].modalInputBg,
+                        )}
+                      />
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 font-bold text-sm">%</span>
+                    </div>
+                    <p className="text-[11px] text-gray-400 ml-1">
+                      Agency takes this % from talent's gross share
+                    </p>
+                  </div>
+                  {/* Live split preview */}
+                  <div className={cn(
+                    "sm:col-span-2 rounded-xl p-4 border",
+                    TIER_CONFIG[tier].statsBg,
+                    TIER_CONFIG[tier].statsBorder,
+                  )}>
+                    <p className="text-[11px] font-bold text-gray-500 uppercase tracking-wider mb-2">
+                      Split Preview — on a $1,000 net deal
+                    </p>
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 h-3 rounded-full overflow-hidden bg-gray-200">
+                        <div
+                          className={cn("h-full rounded-full transition-all duration-300", TIER_CONFIG[tier].iconBg)}
+                          style={{ width: `${configForm[tier]?.payout_percent ?? 0}%` }}
+                        />
+                      </div>
+                    </div>
+                    <div className="flex justify-between mt-2 text-[12px] font-bold">
+                      <span className={TIER_CONFIG[tier].brandColor}>
+                        Talent: ${((configForm[tier]?.payout_percent ?? 0) * 10).toFixed(0)}
+                        {" "}({configForm[tier]?.payout_percent ?? 0}%)
+                      </span>
+                      <span className="text-gray-500">
+                        Agency: ${((configForm[tier]?.commission_rate ?? 0) * 10).toFixed(0)}
+                        {" "}({configForm[tier]?.commission_rate ?? 0}%)
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
             ))}

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Trophy,
@@ -113,6 +114,7 @@ interface TierRule {
 
 interface TalentPerformance {
   id: string;
+  creator_id: string | null;
   name: string;
   photo_url: string | null;
   earnings_30d: number;
@@ -120,6 +122,11 @@ interface TalentPerformance {
   tier: TierRule;
   commission_rate: number;
   is_custom_rate: boolean;
+  relationship_type: string; // "internal" | "marketplace_connected"
+  commission_source: string;
+  is_editable: boolean;
+  /** True only when the talent has completed portal onboarding AND KYC is approved. */
+  is_verified: boolean;
 }
 
 interface TierGroup {
@@ -147,9 +154,11 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
   isSportsAgency = false,
 }) => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const entitySingular = isSportsAgency ? "athlete" : "talent";
   const entityPlural = isSportsAgency ? "Athletes" : "Talent";
+  const allTalentSubTab = isSportsAgency ? "All Athletes" : "All Talent";
 
   const [configForm, setConfigForm] = useState<
     Record<string, { min_earnings: number; min_bookings: number }>
@@ -506,7 +515,13 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                             <span className="font-bold text-gray-900 text-[15px] truncate">
                               {talent.name}
                             </span>
-                            <CheckCircle2 className="w-4 h-4 text-green-500 fill-green-500/10" />
+                            {/* Show verification tick only when the talent has
+                                completed portal onboarding AND their KYC is
+                                approved. creator_id alone is not enough —
+                                they may have joined but not finished KYC. */}
+                            {talent.is_verified && (
+                              <CheckCircle2 className="w-4 h-4 text-green-500 fill-green-500/10 shrink-0" />
+                            )}
                           </div>
                           <div className="flex flex-wrap items-center gap-2 text-[11px] font-bold text-gray-400">
                             <span className="text-gray-900 font-bold">
@@ -538,6 +553,11 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                           variant="outline"
                           size="sm"
                           className="w-full sm:w-auto h-10 font-bold text-gray-700 bg-white border-gray-200 px-6 rounded-none hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm"
+                          onClick={() =>
+                            navigate(
+                              `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(allTalentSubTab)}&talentId=${encodeURIComponent(talent.id)}`,
+                            )
+                          }
                         >
                           View
                         </Button>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -530,7 +530,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                             <span className="text-gray-300">•</span>
                             <span className="flex items-center gap-1 group-hover:text-indigo-500 transition-colors">
                               <TrendingUp className="w-3.5 h-3.5" />{" "}
-                              {talent.bookings_this_month} campaigns
+                              {talent.bookings_this_month} {talent.bookings_this_month === 1 ? "booking" : "bookings"}
                             </span>
                           </div>
                         </div>
@@ -539,12 +539,24 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                             <div
                               className="h-full bg-gray-900 rounded-none"
                               style={{
-                                width:
-                                  talent.tier.tier_name === "Premium"
-                                    ? "85%"
-                                    : talent.tier.tier_name === "Core"
-                                      ? "65%"
-                                      : "45%",
+                                // Progress toward the NEXT tier up.
+                                // Tier order (ascending): Inactive(4) → Growth(3) → Core(2) → Premium(1)
+                                // Find the tier one level above the talent's current tier and
+                                // show how close their earnings are to that threshold.
+                                // Premium (level 1) is the top — show 100%.
+                                width: (() => {
+                                  const earned = talent.earnings_30d;
+                                  const currentLevel = talent.tier.tier_level;
+                                  if (currentLevel <= 1) return "100%"; // already Premium
+                                  // Tier name for the next level up
+                                  const tierOrder = ["Premium", "Core", "Growth", "Inactive"];
+                                  // currentLevel is 1-based; index in tierOrder = level - 1
+                                  const nextTierName = tierOrder[currentLevel - 2]; // one step up
+                                  const target = nextTierName && data?.config?.[nextTierName]?.min_earnings;
+                                  if (!target || target <= 0) return `${Math.max(2, Math.min(100, Math.round((earned / 500) * 100)))}%`;
+                                  const pct = Math.min(100, Math.round((earned / target) * 100));
+                                  return `${Math.max(2, pct)}%`; // min 2% so bar is always visible
+                                })(),
                               }}
                             ></div>
                           </div>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -596,8 +596,23 @@ export const PerformanceTiers: React.FC<{
                                   const target =
                                     nextTierName &&
                                     data?.config?.[nextTierName]?.min_earnings;
-                                  if (!target || target <= 0)
-                                    return `${Math.max(2, Math.min(100, Math.round((earned / 500) * 100)))}%`;
+                                  if (!target || target <= 0) {
+                                    // No tier config available — show proportional progress
+                                    // using the lowest configured tier threshold as fallback,
+                                    // or a sensible default of $500 if nothing is configured.
+                                    const lowestThreshold = Object.values(
+                                      (data?.config as Record<string, any>) ??
+                                        {},
+                                    ).reduce(
+                                      (min: number, cfg: any) =>
+                                        cfg?.min_earnings > 0 &&
+                                        cfg.min_earnings < min
+                                          ? cfg.min_earnings
+                                          : min,
+                                      500,
+                                    );
+                                    return `${Math.max(2, Math.min(100, Math.round((earned / lowestThreshold) * 100)))}%`;
+                                  }
                                   const pct = Math.min(
                                     100,
                                     Math.round((earned / target) * 100),

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -118,6 +118,8 @@ interface TalentPerformance {
   photo_url: string | null;
   earnings_30d: number;
   bookings_this_month: number;
+  /** Signed licensing deals this month — used in AI mode instead of bookings_this_month */
+  licensing_deals_this_month: number;
   tier: TierRule;
   commission_rate: number;
   is_custom_rate: boolean;
@@ -536,7 +538,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                             <span className="flex items-center gap-1 group-hover:text-indigo-500 transition-colors">
                               <TrendingUp className="w-3.5 h-3.5" />{" "}
                               {isAiMode
-                                ? "Licensing deals"
+                                ? `${talent.licensing_deals_this_month} ${talent.licensing_deals_this_month === 1 ? "deal" : "deals"}`
                                 : `${talent.bookings_this_month} ${talent.bookings_this_month === 1 ? "booking" : "bookings"}`}
                             </span>
                           </div>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Trophy,
@@ -154,7 +153,6 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
   isSportsAgency = false,
 }) => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const entitySingular = isSportsAgency ? "athlete" : "talent";
   const entityPlural = isSportsAgency ? "Athletes" : "Talent";
@@ -565,11 +563,6 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                           variant="outline"
                           size="sm"
                           className="w-full sm:w-auto h-10 font-bold text-gray-700 bg-white border-gray-200 px-6 rounded-none hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm"
-                          onClick={() =>
-                            navigate(
-                              `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(allTalentSubTab)}&openTalentId=${encodeURIComponent(talent.id)}`,
-                            )
-                          }
                         >
                           View
                         </Button>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -357,7 +357,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
           const avgBookings =
             group.talents.length > 0
               ? group.talents.reduce(
-                  (acc, t) => acc + t.bookings_this_month,
+                  (acc, t) => acc + (isAiMode ? t.licensing_deals_this_month : t.bookings_this_month),
                   0,
                 ) / group.talents.length
               : 0;
@@ -443,13 +443,13 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                       <Calendar className={cn("w-4 h-4", cfg.brandColor)} />
                     </div>
                     <span className="text-xs font-bold text-gray-500 uppercase tracking-wider">
-                      Avg Booking Frequency
+                      {isAiMode ? "Avg Deal Frequency" : "Avg Booking Frequency"}
                     </span>
                   </div>
                   <div className="text-2xl font-bold text-gray-900">
                     {avgBookings.toFixed(1)}{" "}
                     <span className="text-sm font-medium text-gray-500">
-                      campaigns/month
+                      {isAiMode ? "deals/month" : "campaigns/month"}
                     </span>
                   </div>
                 </div>

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -680,6 +680,10 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                     />
                   </div>
                   )}
+                  {/* Commission/payout split — only relevant for AI mode (licensing deals).
+                      IRL bookings use a separate payment flow and don't use these rates. */}
+                  {isAiMode && (
+                  <>
                   <div className="space-y-3">
                     <Label className="text-[13px] font-bold text-gray-600 ml-1">
                       Talent Payout % (of net)
@@ -772,6 +776,8 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?:
                       </span>
                     </div>
                   </div>
+                  </>
+                  )}
                 </div>
               </div>
             ))}

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -567,7 +567,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                           className="w-full sm:w-auto h-10 font-bold text-gray-700 bg-white border-gray-200 px-6 rounded-none hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm"
                           onClick={() =>
                             navigate(
-                              `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(allTalentSubTab)}&talentId=${encodeURIComponent(talent.id)}`,
+                              `/AgencyDashboard?tab=roster&subTab=${encodeURIComponent(allTalentSubTab)}&openTalentId=${encodeURIComponent(talent.id)}`,
                             )
                           }
                         >

--- a/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
+++ b/likelee-ui/src/components/dashboard/PerformanceTiers.tsx
@@ -149,14 +149,18 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
 });
 
-export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
+export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean; agencyMode?: "AI" | "IRL" }> = ({
   isSportsAgency = false,
+  agencyMode = "AI",
 }) => {
   const queryClient = useQueryClient();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const entitySingular = isSportsAgency ? "athlete" : "talent";
   const entityPlural = isSportsAgency ? "Athletes" : "Talent";
   const allTalentSubTab = isSportsAgency ? "All Athletes" : "All Talent";
+  // In AI mode bookings are not relevant — creators earn through licensing deals,
+  // not IRL bookings. Only earnings drive tier classification.
+  const isAiMode = agencyMode === "AI";
 
   const [configForm, setConfigForm] = useState<
     Record<string, { min_earnings: number; min_bookings: number }>
@@ -164,11 +168,12 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
 
   const { data, isLoading, error } =
     useIndexedDbQuery<PerformanceTiersResponse>({
-      queryKey: ["performance-tiers"],
+      queryKey: ["performance-tiers", agencyMode],
       queryFn: async () => {
         try {
           const resp = await base44.get<PerformanceTiersResponse>(
             "/agency/dashboard/performance-tiers",
+            { params: { agency_mode: agencyMode } },
           );
           return resp;
         } catch (err: any) {
@@ -363,7 +368,9 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
           let thresholdStr = cfg.thresholds;
           if (data?.config && data.config[group.name]) {
             const c = data.config[group.name];
-            thresholdStr = `≥ ${currencyFormatter.format(c.min_earnings)}/mo • ≥ ${c.min_bookings} bookings`;
+            thresholdStr = isAiMode
+              ? `≥ ${currencyFormatter.format(c.min_earnings)}/mo`
+              : `≥ ${currencyFormatter.format(c.min_earnings)}/mo • ≥ ${c.min_bookings} bookings`;
           } else if (group.name === "Inactive") {
             thresholdStr =
               "Includes all roster profiles that don't meet Tier 3 requirements";
@@ -528,7 +535,9 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                             <span className="text-gray-300">•</span>
                             <span className="flex items-center gap-1 group-hover:text-indigo-500 transition-colors">
                               <TrendingUp className="w-3.5 h-3.5" />{" "}
-                              {talent.bookings_this_month} {talent.bookings_this_month === 1 ? "booking" : "bookings"}
+                              {isAiMode
+                                ? "Licensing deals"
+                                : `${talent.bookings_this_month} ${talent.bookings_this_month === 1 ? "booking" : "bookings"}`}
                             </span>
                           </div>
                         </div>
@@ -595,7 +604,9 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
               Configure Performance Tier Thresholds
             </DialogTitle>
             <DialogDescription className="text-gray-500 font-medium pt-1">
-              Set minimum earnings and booking requirements for each tier
+              {isAiMode
+                ? "Set minimum earnings requirements for each tier"
+                : "Set minimum earnings and booking requirements for each tier"}
             </DialogDescription>
           </DialogHeader>
 
@@ -639,6 +650,8 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                       )}
                     />
                   </div>
+                  {/* In AI mode bookings are irrelevant — hide the bookings threshold */}
+                  {!isAiMode && (
                   <div className="space-y-3">
                     <Label className="text-[13px] font-bold text-gray-600 ml-1">
                       Min Bookings/Month
@@ -661,6 +674,7 @@ export const PerformanceTiers: React.FC<{ isSportsAgency?: boolean }> = ({
                       )}
                     />
                   </div>
+                  )}
                 </div>
               </div>
             ))}

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -224,11 +224,18 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
     const missing: string[] = [];
     const talentVal = (formData.talent_name || "").trim().toLowerCase();
     const clientVal = (formData.client_name || "").trim().toLowerCase();
-    if (talentVal && !bodyLower.includes(talentVal)) missing.push("talent_name_placeholder");
-    if (clientVal && !bodyLower.includes(clientVal)) missing.push("client_name_placeholder");
+    if (talentVal && !bodyLower.includes(talentVal))
+      missing.push("talent_name_placeholder");
+    if (clientVal && !bodyLower.includes(clientVal))
+      missing.push("client_name_placeholder");
     return missing;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step, formData.contract_body, formData.talent_name, formData.client_name]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    step,
+    formData.contract_body,
+    formData.talent_name,
+    formData.client_name,
+  ]);
   const builderExternalId = useMemo(
     () =>
       currentTemplate?.id
@@ -472,8 +479,12 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
       //   - The agency edited the body in step 2 and removed the names.
       // We check the actual values from step 1, not just placeholder presence.
       const bodyLower = currentData.contract_body.toLowerCase();
-      const talentNameValue = (currentData.talent_name || "").trim().toLowerCase();
-      const clientNameValue = (currentData.client_name || "").trim().toLowerCase();
+      const talentNameValue = (currentData.talent_name || "")
+        .trim()
+        .toLowerCase();
+      const clientNameValue = (currentData.client_name || "")
+        .trim()
+        .toLowerCase();
       const identityErrors: string[] = [];
 
       if (talentNameValue && !bodyLower.includes(talentNameValue)) {
@@ -679,8 +690,15 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                 )}
                 <Button
                   onClick={handleNext}
-                  disabled={isSyncing || (step === 2 && missingIdentityFields.length > 0)}
-                  title={step === 2 && missingIdentityFields.length > 0 ? "Add the missing talent and brand names to the contract body before proceeding" : undefined}
+                  disabled={
+                    isSyncing ||
+                    (step === 2 && missingIdentityFields.length > 0)
+                  }
+                  title={
+                    step === 2 && missingIdentityFields.length > 0
+                      ? "Add the missing talent and brand names to the contract body before proceeding"
+                      : undefined
+                  }
                   className="bg-indigo-500 hover:bg-indigo-600 text-white font-bold h-9 sm:h-10 px-4 sm:px-8 rounded-xl shadow-lg shadow-indigo-100/50 transition-all active:scale-95 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSyncing ? "..." : step === 3 ? "Finalize" : "Next"}
@@ -748,8 +766,18 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                   <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
                     <div className="flex items-start gap-3">
                       <div className="mt-0.5 rounded-xl bg-white/80 p-2 text-slate-500 shadow-sm shrink-0">
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
                         </svg>
                       </div>
                       <div>
@@ -757,7 +785,11 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           Creating a contract for an external client
                         </p>
                         <p className="text-sm text-slate-600 mt-0.5 leading-relaxed">
-                          You're initiating this contract directly — all fields are open for you to fill in. Enter the client's details and select the {entitySingularLower} you've agreed to license, typically based on the package you sent and the client's selection from it.
+                          You're initiating this contract directly — all fields
+                          are open for you to fill in. Enter the client's
+                          details and select the {entitySingularLower} you've
+                          agreed to license, typically based on the package you
+                          sent and the client's selection from it.
                         </p>
                       </div>
                     </div>
@@ -781,8 +813,12 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                         {brandRequestBrandId ? (
                           // Locked — brand is fixed when coming from a brand request
                           <div className="h-12 bg-slate-100 border border-slate-200 rounded-xl font-medium px-3 flex items-center gap-2 text-slate-700">
-                            <span className="flex-1 truncate">{formData.client_name || brandRequestBrandName}</span>
-                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                            <span className="flex-1 truncate">
+                              {formData.client_name || brandRequestBrandName}
+                            </span>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">
+                              Locked
+                            </span>
                           </div>
                         ) : (
                           <Input
@@ -824,194 +860,198 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                                   </Badge>
                                 ))}
                             </div>
-                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">
+                              Locked
+                            </span>
                           </div>
                         ) : (
-                        <Popover
-                          open={talentPopoverOpen}
-                          onOpenChange={setTalentPopoverOpen}
-                        >
-                          <PopoverTrigger asChild>
-                            <Button
-                              variant="outline"
-                              role="combobox"
-                              className="w-full h-auto min-h-[48px] justify-between bg-slate-50 border-slate-200 rounded-xl hover:bg-slate-100 transition-all font-medium py-2 px-3"
-                            >
-                              <div className="flex flex-wrap gap-1.5 items-center">
-                                {formData.talent_name ? (
-                                  formData.talent_name
-                                    .split(", ")
-                                    .map((name) => (
-                                      <Badge
-                                        key={name}
-                                        variant="secondary"
-                                        className="bg-white text-indigo-600 border-indigo-100 rounded-lg px-2 py-0.5 flex items-center gap-1 group/badge"
-                                      >
-                                        {name}
-                                        <X
-                                          className="h-3 w-3 cursor-pointer hover:text-indigo-800"
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            const selected =
-                                              formData.talent_name
-                                                .split(", ")
-                                                .filter((n) => n !== name)
-                                                .join(", ");
-                                            setValue("talent_name", selected);
-                                          }}
-                                        />
-                                      </Badge>
-                                    ))
-                                ) : (
-                                  <span className="text-slate-400">
-                                    {`Select ${entityPluralLower}...`}
-                                  </span>
-                                )}
-                              </div>
-                              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50 text-slate-500" />
-                            </Button>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            className="w-[400px] p-0 rounded-2xl border-slate-200 shadow-2xl overflow-hidden"
-                            align="start"
+                          <Popover
+                            open={talentPopoverOpen}
+                            onOpenChange={setTalentPopoverOpen}
                           >
-                            {talentPopoverOpen && (
-                              <Command
-                                key="talent-command"
-                                className="border-none"
-                                shouldFilter={false}
+                            <PopoverTrigger asChild>
+                              <Button
+                                variant="outline"
+                                role="combobox"
+                                className="w-full h-auto min-h-[48px] justify-between bg-slate-50 border-slate-200 rounded-xl hover:bg-slate-100 transition-all font-medium py-2 px-3"
                               >
-                                <CommandInput
-                                  placeholder={`Search ${entitySingularLower}...`}
-                                  className="border-none focus:ring-0 h-12"
-                                  value={talentSearchQuery}
-                                  onValueChange={setTalentSearchQuery}
-                                />
-                                <CommandList className="max-h-[300px]">
-                                  <CommandEmpty className="py-6 text-center text-sm text-slate-500 font-medium">
-                                    {`No ${entitySingularLower} found.`}
-                                  </CommandEmpty>
-                                  <CommandGroup>
-                                    {talents
-                                      .filter((t) => {
-                                        const talentName =
-                                          t.full_name ||
-                                          t.stage_name ||
-                                          t.full_legal_name ||
-                                          t.email ||
-                                          `Unknown ${entitySingularTitle}`;
-                                        if (!talentSearchQuery) return true;
-                                        return talentName
-                                          .toLowerCase()
-                                          .includes(
-                                            talentSearchQuery.toLowerCase(),
-                                          );
-                                      })
-                                      .map((t) => {
-                                        const talentName =
-                                          t.full_name ||
-                                          t.stage_name ||
-                                          t.full_legal_name ||
-                                          t.email ||
-                                          `Unknown ${entitySingularTitle}`;
-                                        // Check selection by ID to handle duplicate names
-                                        const isSelected =
-                                          t.id &&
-                                          selectedTalentIds.includes(t.id);
-                                        return (
-                                          <CommandItem
-                                            key={t.id}
-                                            value={talentName}
-                                            onSelect={() => {
-                                              const currentNames =
+                                <div className="flex flex-wrap gap-1.5 items-center">
+                                  {formData.talent_name ? (
+                                    formData.talent_name
+                                      .split(", ")
+                                      .map((name) => (
+                                        <Badge
+                                          key={name}
+                                          variant="secondary"
+                                          className="bg-white text-indigo-600 border-indigo-100 rounded-lg px-2 py-0.5 flex items-center gap-1 group/badge"
+                                        >
+                                          {name}
+                                          <X
+                                            className="h-3 w-3 cursor-pointer hover:text-indigo-800"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              const selected =
                                                 formData.talent_name
-                                                  ? formData.talent_name.split(
-                                                      ", ",
-                                                    )
-                                                  : [];
-                                              let updatedNames;
-                                              let updatedIds = [
-                                                ...selectedTalentIds,
-                                              ];
-
-                                              if (isSelected) {
-                                                updatedNames =
-                                                  currentNames.filter(
-                                                    (n) => n !== talentName,
-                                                  );
-                                                // Remove ID
-                                                if (t.id) {
-                                                  updatedIds =
-                                                    updatedIds.filter(
-                                                      (id) => id !== t.id,
-                                                    );
-                                                }
-                                              } else {
-                                                if (talentName) {
-                                                  updatedNames = [
-                                                    ...currentNames,
-                                                    talentName,
-                                                  ];
-                                                } else {
-                                                  updatedNames = currentNames;
-                                                }
-                                                // Add ID
-                                                if (
-                                                  t.id &&
-                                                  !updatedIds.includes(t.id)
-                                                ) {
-                                                  updatedIds.push(t.id);
-                                                }
-                                              }
-                                              setSelectedTalentIds(updatedIds);
-                                              setValue(
-                                                "talent_name",
-                                                updatedNames.join(", "),
-                                              );
+                                                  .split(", ")
+                                                  .filter((n) => n !== name)
+                                                  .join(", ");
+                                              setValue("talent_name", selected);
                                             }}
-                                            className="flex items-center gap-3 p-3 cursor-pointer hover:bg-slate-50 transition-colors rounded-lg m-1"
-                                          >
-                                            <div className="relative">
-                                              <Avatar className="h-10 w-10 border-2 border-white shadow-sm">
-                                                <AvatarImage
-                                                  src={t.profile_photo_url}
-                                                />
-                                                <AvatarFallback className="bg-indigo-50 text-indigo-600 font-bold text-xs uppercase">
-                                                  {t.full_name?.substring(
-                                                    0,
-                                                    2,
-                                                  ) || "UT"}
-                                                </AvatarFallback>
-                                              </Avatar>
-                                              {isSelected && (
-                                                <div className="absolute -top-1 -right-1 h-4 w-4 bg-indigo-500 rounded-full flex items-center justify-center border-2 border-white">
-                                                  <Check className="h-2.5 w-2.5 text-white" />
-                                                </div>
-                                              )}
-                                            </div>
-                                            <div className="flex flex-col">
-                                              <span
-                                                className={cn(
-                                                  "font-bold text-slate-900",
-                                                  isSelected &&
-                                                    "text-indigo-600",
+                                          />
+                                        </Badge>
+                                      ))
+                                  ) : (
+                                    <span className="text-slate-400">
+                                      {`Select ${entityPluralLower}...`}
+                                    </span>
+                                  )}
+                                </div>
+                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50 text-slate-500" />
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              className="w-[400px] p-0 rounded-2xl border-slate-200 shadow-2xl overflow-hidden"
+                              align="start"
+                            >
+                              {talentPopoverOpen && (
+                                <Command
+                                  key="talent-command"
+                                  className="border-none"
+                                  shouldFilter={false}
+                                >
+                                  <CommandInput
+                                    placeholder={`Search ${entitySingularLower}...`}
+                                    className="border-none focus:ring-0 h-12"
+                                    value={talentSearchQuery}
+                                    onValueChange={setTalentSearchQuery}
+                                  />
+                                  <CommandList className="max-h-[300px]">
+                                    <CommandEmpty className="py-6 text-center text-sm text-slate-500 font-medium">
+                                      {`No ${entitySingularLower} found.`}
+                                    </CommandEmpty>
+                                    <CommandGroup>
+                                      {talents
+                                        .filter((t) => {
+                                          const talentName =
+                                            t.full_name ||
+                                            t.stage_name ||
+                                            t.full_legal_name ||
+                                            t.email ||
+                                            `Unknown ${entitySingularTitle}`;
+                                          if (!talentSearchQuery) return true;
+                                          return talentName
+                                            .toLowerCase()
+                                            .includes(
+                                              talentSearchQuery.toLowerCase(),
+                                            );
+                                        })
+                                        .map((t) => {
+                                          const talentName =
+                                            t.full_name ||
+                                            t.stage_name ||
+                                            t.full_legal_name ||
+                                            t.email ||
+                                            `Unknown ${entitySingularTitle}`;
+                                          // Check selection by ID to handle duplicate names
+                                          const isSelected =
+                                            t.id &&
+                                            selectedTalentIds.includes(t.id);
+                                          return (
+                                            <CommandItem
+                                              key={t.id}
+                                              value={talentName}
+                                              onSelect={() => {
+                                                const currentNames =
+                                                  formData.talent_name
+                                                    ? formData.talent_name.split(
+                                                        ", ",
+                                                      )
+                                                    : [];
+                                                let updatedNames;
+                                                let updatedIds = [
+                                                  ...selectedTalentIds,
+                                                ];
+
+                                                if (isSelected) {
+                                                  updatedNames =
+                                                    currentNames.filter(
+                                                      (n) => n !== talentName,
+                                                    );
+                                                  // Remove ID
+                                                  if (t.id) {
+                                                    updatedIds =
+                                                      updatedIds.filter(
+                                                        (id) => id !== t.id,
+                                                      );
+                                                  }
+                                                } else {
+                                                  if (talentName) {
+                                                    updatedNames = [
+                                                      ...currentNames,
+                                                      talentName,
+                                                    ];
+                                                  } else {
+                                                    updatedNames = currentNames;
+                                                  }
+                                                  // Add ID
+                                                  if (
+                                                    t.id &&
+                                                    !updatedIds.includes(t.id)
+                                                  ) {
+                                                    updatedIds.push(t.id);
+                                                  }
+                                                }
+                                                setSelectedTalentIds(
+                                                  updatedIds,
+                                                );
+                                                setValue(
+                                                  "talent_name",
+                                                  updatedNames.join(", "),
+                                                );
+                                              }}
+                                              className="flex items-center gap-3 p-3 cursor-pointer hover:bg-slate-50 transition-colors rounded-lg m-1"
+                                            >
+                                              <div className="relative">
+                                                <Avatar className="h-10 w-10 border-2 border-white shadow-sm">
+                                                  <AvatarImage
+                                                    src={t.profile_photo_url}
+                                                  />
+                                                  <AvatarFallback className="bg-indigo-50 text-indigo-600 font-bold text-xs uppercase">
+                                                    {t.full_name?.substring(
+                                                      0,
+                                                      2,
+                                                    ) || "UT"}
+                                                  </AvatarFallback>
+                                                </Avatar>
+                                                {isSelected && (
+                                                  <div className="absolute -top-1 -right-1 h-4 w-4 bg-indigo-500 rounded-full flex items-center justify-center border-2 border-white">
+                                                    <Check className="h-2.5 w-2.5 text-white" />
+                                                  </div>
                                                 )}
-                                              >
-                                                {talentName}
-                                              </span>
-                                              <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wider">
-                                                {`Agency ${entitySingularTitle}`}
-                                              </span>
-                                            </div>
-                                          </CommandItem>
-                                        );
-                                      })}
-                                  </CommandGroup>
-                                </CommandList>
-                              </Command>
-                            )}
-                          </PopoverContent>
-                        </Popover>
+                                              </div>
+                                              <div className="flex flex-col">
+                                                <span
+                                                  className={cn(
+                                                    "font-bold text-slate-900",
+                                                    isSelected &&
+                                                      "text-indigo-600",
+                                                  )}
+                                                >
+                                                  {talentName}
+                                                </span>
+                                                <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wider">
+                                                  {`Agency ${entitySingularTitle}`}
+                                                </span>
+                                              </div>
+                                            </CommandItem>
+                                          );
+                                        })}
+                                    </CommandGroup>
+                                  </CommandList>
+                                </Command>
+                              )}
+                            </PopoverContent>
+                          </Popover>
                         )}
                         {errors.talent_name && (
                           <span className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
@@ -1044,8 +1084,12 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                         {brandRequestBrandId ? (
                           // Locked — client email is fixed when coming from a brand request
                           <div className="h-12 bg-slate-100 border border-slate-200 rounded-xl font-medium px-3 flex items-center gap-2 text-slate-700">
-                            <span className="flex-1 truncate">{formData.client_email || brandRequestBrandEmail}</span>
-                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                            <span className="flex-1 truncate">
+                              {formData.client_email || brandRequestBrandEmail}
+                            </span>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">
+                              Locked
+                            </span>
                           </div>
                         ) : brandOptions.length > 0 && allowBrandChange ? (
                           <>
@@ -1256,8 +1300,18 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                   <div className="mt-6 p-5 bg-amber-50 border border-amber-300 rounded-2xl space-y-3">
                     <div className="flex items-start gap-3">
                       <div className="bg-amber-400 p-1.5 rounded-lg mt-0.5 shrink-0">
-                        <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                        <svg
+                          className="w-4 h-4 text-white"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                          />
                         </svg>
                       </div>
                       <div className="flex-1">
@@ -1266,9 +1320,16 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                         </p>
                         <p className="text-amber-800 text-xs mt-1 leading-relaxed">
                           The contract body does not contain the{" "}
-                          {missingIdentityFields.includes("talent_name_placeholder") && missingIdentityFields.includes("client_name_placeholder")
+                          {missingIdentityFields.includes(
+                            "talent_name_placeholder",
+                          ) &&
+                          missingIdentityFields.includes(
+                            "client_name_placeholder",
+                          )
                             ? "talent name or brand name"
-                            : missingIdentityFields.includes("talent_name_placeholder")
+                            : missingIdentityFields.includes(
+                                  "talent_name_placeholder",
+                                )
                               ? "talent name"
                               : "brand name"}
                           . You cannot proceed until these are present. Click
@@ -1279,10 +1340,14 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                     </div>
                     <div className="flex flex-wrap gap-2 pl-9">
                       {missingIdentityFields.map((placeholder) => {
-                        const label = placeholder === "talent_name_placeholder" ? "Talent" : "Brand";
-                        const value = placeholder === "talent_name_placeholder"
-                          ? formData.talent_name
-                          : formData.client_name;
+                        const label =
+                          placeholder === "talent_name_placeholder"
+                            ? "Talent"
+                            : "Brand";
+                        const value =
+                          placeholder === "talent_name_placeholder"
+                            ? formData.talent_name
+                            : formData.client_name;
                         return (
                           <button
                             key={placeholder}
@@ -1296,8 +1361,18 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                             }}
                             className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-100 hover:bg-amber-200 border border-amber-300 text-amber-900 text-xs font-bold rounded-lg transition-colors"
                           >
-                            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                            <svg
+                              className="w-3 h-3"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2.5}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M12 4.5v15m7.5-7.5h-15"
+                              />
                             </svg>
                             Insert {label} Name ({value})
                           </button>

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -739,6 +739,30 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                     </div>
                   </div>
                 )}
+
+                {/* External client route hint — shown only when the agency
+                    initiates the contract themselves (no brand request context).
+                    Explains why all fields are open and reminds the agency of
+                    the natural workflow they should have completed first. */}
+                {!brandRequestBrandId && !isRenewalPrefill && (
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 rounded-xl bg-white/80 p-2 text-slate-500 shadow-sm shrink-0">
+                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                      </div>
+                      <div>
+                        <p className="text-sm font-bold text-slate-800">
+                          Creating a contract for an external client
+                        </p>
+                        <p className="text-sm text-slate-600 mt-0.5 leading-relaxed">
+                          You're initiating this contract directly — all fields are open for you to fill in. Enter the client's details and select the {entitySingularLower} you've agreed to license, typically based on the package you sent and the client's selection from it.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
                   <div className="p-8 bg-white rounded-3xl border border-slate-200/60 shadow-sm space-y-6">
                     <div className="flex items-center gap-3 mb-2">

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -707,11 +707,19 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                         <Label className="text-sm font-bold text-slate-800 ml-1">
                           Brand Name *
                         </Label>
-                        <Input
-                          {...register("client_name", { required: true })}
-                          placeholder="e.g. Nike, Spotify"
-                          className="h-12 bg-slate-50 border-slate-200 rounded-xl font-medium focus:ring-4 focus:ring-indigo-50 transition-all"
-                        />
+                        {brandRequestBrandId ? (
+                          // Locked — brand is fixed when coming from a brand request
+                          <div className="h-12 bg-slate-100 border border-slate-200 rounded-xl font-medium px-3 flex items-center gap-2 text-slate-700">
+                            <span className="flex-1 truncate">{formData.client_name || brandRequestBrandName}</span>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                          </div>
+                        ) : (
+                          <Input
+                            {...register("client_name", { required: true })}
+                            placeholder="e.g. Nike, Spotify"
+                            className="h-12 bg-slate-50 border-slate-200 rounded-xl font-medium focus:ring-4 focus:ring-indigo-50 transition-all"
+                          />
+                        )}
                         {errors.client_name && (
                           <p className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
                             This field is mandatory.
@@ -726,6 +734,28 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           type="hidden"
                           {...register("talent_name", { required: true })}
                         />
+                        {brandRequestTalentId ? (
+                          // Locked — talent is fixed when coming from a brand request.
+                          // The brand selected this specific talent; the agency must not
+                          // be able to swap them out.
+                          <div className="h-auto min-h-[48px] bg-slate-100 border border-slate-200 rounded-xl font-medium px-3 py-2 flex items-center gap-2">
+                            <div className="flex flex-wrap gap-1.5 flex-1">
+                              {(formData.talent_name || brandRequestTalentName)
+                                .split(", ")
+                                .filter(Boolean)
+                                .map((name) => (
+                                  <Badge
+                                    key={name}
+                                    variant="secondary"
+                                    className="bg-white text-indigo-600 border-indigo-100 rounded-lg px-2 py-0.5"
+                                  >
+                                    {name}
+                                  </Badge>
+                                ))}
+                            </div>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                          </div>
+                        ) : (
                         <Popover
                           open={talentPopoverOpen}
                           onOpenChange={setTalentPopoverOpen}
@@ -911,6 +941,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                             )}
                           </PopoverContent>
                         </Popover>
+                        )}
                         {errors.talent_name && (
                           <span className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
                             {`This ${entitySingularLower} is mandatory.`}
@@ -922,7 +953,7 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           <Label className="text-sm font-bold text-slate-800 whitespace-nowrap">
                             Client Email *
                           </Label>
-                          {brandOptions.length > 0 && (
+                          {!brandRequestBrandId && brandOptions.length > 0 && (
                             <div className="flex items-center gap-2">
                               <Label
                                 htmlFor="allow-brand-change-wizard"
@@ -939,7 +970,13 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                           )}
                         </div>
 
-                        {brandOptions.length > 0 && allowBrandChange ? (
+                        {brandRequestBrandId ? (
+                          // Locked — client email is fixed when coming from a brand request
+                          <div className="h-12 bg-slate-100 border border-slate-200 rounded-xl font-medium px-3 flex items-center gap-2 text-slate-700">
+                            <span className="flex-1 truncate">{formData.client_email || brandRequestBrandEmail}</span>
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400 bg-slate-200 px-2 py-0.5 rounded-full shrink-0">Locked</span>
+                          </div>
+                        ) : brandOptions.length > 0 && allowBrandChange ? (
                           <>
                             <input
                               type="hidden"

--- a/likelee-ui/src/components/licensing/SubmissionWizard.tsx
+++ b/likelee-ui/src/components/licensing/SubmissionWizard.tsx
@@ -214,6 +214,21 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
   const brandRequestBrandEmail = brandRequestContext?.brand_email || "";
   const brandRequestTalentId = brandRequestContext?.talent_id || "";
   const brandRequestTalentName = brandRequestContext?.talent_name || "";
+
+  // Computed live: which key identity values are absent from the contract body.
+  // Updates as the agency types so the warning banner and Next button disable
+  // state stay in sync — including if they delete the names after inserting.
+  const missingIdentityFields = useMemo(() => {
+    if (step !== 2) return [];
+    const bodyLower = (formData.contract_body || "").toLowerCase();
+    const missing: string[] = [];
+    const talentVal = (formData.talent_name || "").trim().toLowerCase();
+    const clientVal = (formData.client_name || "").trim().toLowerCase();
+    if (talentVal && !bodyLower.includes(talentVal)) missing.push("talent_name_placeholder");
+    if (clientVal && !bodyLower.includes(clientVal)) missing.push("client_name_placeholder");
+    return missing;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, formData.contract_body, formData.talent_name, formData.client_name]);
   const builderExternalId = useMemo(
     () =>
       currentTemplate?.id
@@ -422,6 +437,10 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
           },
         );
         setValue("contract_body", rendered);
+
+        // Detect which key identity placeholders were absent from the template.
+        // missingIdentityFields (computed) will handle the live warning in step 2.
+
         setStep(2);
       } catch (err: any) {
         toast({
@@ -442,6 +461,33 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
           description:
             "The contract body cannot be empty. Please ensure the template has contract content or add content before proceeding.",
           variant: "warning",
+        });
+        return;
+      }
+
+      // Hard block: the rendered contract body must contain the talent name
+      // and client/brand name. This catches cases where:
+      //   - The template never used the placeholders (hardcoded text that
+      //     doesn't match the current deal), OR
+      //   - The agency edited the body in step 2 and removed the names.
+      // We check the actual values from step 1, not just placeholder presence.
+      const bodyLower = currentData.contract_body.toLowerCase();
+      const talentNameValue = (currentData.talent_name || "").trim().toLowerCase();
+      const clientNameValue = (currentData.client_name || "").trim().toLowerCase();
+      const identityErrors: string[] = [];
+
+      if (talentNameValue && !bodyLower.includes(talentNameValue)) {
+        identityErrors.push(`talent name "${currentData.talent_name}"`);
+      }
+      if (clientNameValue && !bodyLower.includes(clientNameValue)) {
+        identityErrors.push(`brand name "${currentData.client_name}"`);
+      }
+
+      if (identityErrors.length > 0) {
+        toast({
+          title: "Contract is missing required identity information",
+          description: `The contract body must include the ${identityErrors.join(" and ")}. Use the insert buttons below the editor to add them, or type them directly.`,
+          variant: "destructive",
         });
         return;
       }
@@ -633,8 +679,9 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                 )}
                 <Button
                   onClick={handleNext}
-                  disabled={isSyncing}
-                  className="bg-indigo-500 hover:bg-indigo-600 text-white font-bold h-9 sm:h-10 px-4 sm:px-8 rounded-xl shadow-lg shadow-indigo-100/50 transition-all active:scale-95 text-sm"
+                  disabled={isSyncing || (step === 2 && missingIdentityFields.length > 0)}
+                  title={step === 2 && missingIdentityFields.length > 0 ? "Add the missing talent and brand names to the contract body before proceeding" : undefined}
+                  className="bg-indigo-500 hover:bg-indigo-600 text-white font-bold h-9 sm:h-10 px-4 sm:px-8 rounded-xl shadow-lg shadow-indigo-100/50 transition-all active:scale-95 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSyncing ? "..." : step === 3 ? "Finalize" : "Next"}
                   {!isSyncing && step < 3 && (
@@ -1179,21 +1226,79 @@ export const SubmissionWizard: React.FC<SubmissionWizardProps> = ({
                     placeholder="The contract content will appear here..."
                   />
                 </div>
-                <div className="mt-8 p-6 bg-indigo-50/50 border border-indigo-100 rounded-2xl flex items-start gap-4">
-                  <div className="bg-indigo-500 p-2 rounded-xl mt-1">
-                    <FileText className="w-5 h-5 text-white" />
+
+                {missingIdentityFields.length > 0 ? (
+                  // ── Warning: key identity values are absent from the body ──
+                  <div className="mt-6 p-5 bg-amber-50 border border-amber-300 rounded-2xl space-y-3">
+                    <div className="flex items-start gap-3">
+                      <div className="bg-amber-400 p-1.5 rounded-lg mt-0.5 shrink-0">
+                        <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                        </svg>
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-bold text-amber-900 text-sm">
+                          Contract is missing required identity information
+                        </p>
+                        <p className="text-amber-800 text-xs mt-1 leading-relaxed">
+                          The contract body does not contain the{" "}
+                          {missingIdentityFields.includes("talent_name_placeholder") && missingIdentityFields.includes("client_name_placeholder")
+                            ? "talent name or brand name"
+                            : missingIdentityFields.includes("talent_name_placeholder")
+                              ? "talent name"
+                              : "brand name"}
+                          . You cannot proceed until these are present. Click
+                          below to insert them, or type them directly in the
+                          editor above.
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2 pl-9">
+                      {missingIdentityFields.map((placeholder) => {
+                        const label = placeholder === "talent_name_placeholder" ? "Talent" : "Brand";
+                        const value = placeholder === "talent_name_placeholder"
+                          ? formData.talent_name
+                          : formData.client_name;
+                        return (
+                          <button
+                            key={placeholder}
+                            type="button"
+                            onClick={() => {
+                              const insertion = `\n\n**${label}:** ${value}`;
+                              setValue(
+                                "contract_body",
+                                (formData.contract_body || "") + insertion,
+                              );
+                            }}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-100 hover:bg-amber-200 border border-amber-300 text-amber-900 text-xs font-bold rounded-lg transition-colors"
+                          >
+                            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                            </svg>
+                            Insert {label} Name ({value})
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
-                  <div>
-                    <h4 className="font-bold text-indigo-900 mb-1">
-                      Pre-filled Data Applied
-                    </h4>
-                    <p className="text-sm text-indigo-800/80 leading-relaxed font-medium">
-                      We've automatically replaced all placeholders with your
-                      deal specifics. You can still make quick edits directly in
-                      the editor before finalizing.
-                    </p>
+                ) : (
+                  // ── Success: all key placeholders present ─────────────────
+                  <div className="mt-8 p-6 bg-indigo-50/50 border border-indigo-100 rounded-2xl flex items-start gap-4">
+                    <div className="bg-indigo-500 p-2 rounded-xl mt-1">
+                      <FileText className="w-5 h-5 text-white" />
+                    </div>
+                    <div>
+                      <h4 className="font-bold text-indigo-900 mb-1">
+                        Pre-filled Data Applied
+                      </h4>
+                      <p className="text-sm text-indigo-800/80 leading-relaxed font-medium">
+                        We've automatically replaced all placeholders with your
+                        deal specifics. You can still make quick edits directly
+                        in the editor before finalizing.
+                      </p>
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
             )}
           </div>

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -18608,6 +18608,16 @@ export default function AgencyDashboard() {
   const [openTalentId, setOpenTalentId] = useState<string | undefined>(
     searchParams.get("openTalentId") || undefined,
   );
+
+  // Sync openTalentId from URL whenever searchParams changes (e.g. when
+  // navigating from Performance Tiers View button to All Talent/Athletes).
+  // useState initializer only runs at mount so we need this effect too.
+  useEffect(() => {
+    const fromUrl = searchParams.get("openTalentId") || undefined;
+    if (fromUrl && fromUrl !== openTalentId) {
+      setOpenTalentId(fromUrl);
+    }
+  }, [searchParams]);
   const normalizeSubTab = (value: string | null | undefined) => {
     const cleaned = String(value || "")
       .trim()

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -22102,7 +22102,7 @@ export default function AgencyDashboard() {
               />
             )}
             {activeTab === "roster" && activeSubTab === "Performance Tiers" && (
-              <PerformanceTiers isSportsAgency={isSportsAgency} />
+              <PerformanceTiers isSportsAgency={isSportsAgency} agencyMode={effectiveAgencyMode} />
             )}
             {activeTab === "jobs" &&
               activeSubTab === "Job Invites" &&

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -12505,12 +12505,14 @@ const DashboardView = ({
   kycLoading,
   onRefreshStatus,
   refreshLoading,
+  onNavigateToLicensing,
 }: {
   onKYC: () => void;
   kycStatus?: string | null;
   kycLoading?: boolean;
   onRefreshStatus?: () => void;
   refreshLoading?: boolean;
+  onNavigateToLicensing?: () => void;
 }) => (
   <div className="space-y-8">
     {/* KYC Verification Alert */}
@@ -12878,6 +12880,7 @@ const DashboardView = ({
           <Button
             variant="default"
             className="w-full bg-yellow-600 hover:bg-yellow-700 text-white font-bold h-10"
+            onClick={onNavigateToLicensing}
           >
             Review Now
           </Button>
@@ -22102,7 +22105,10 @@ export default function AgencyDashboard() {
               />
             )}
             {activeTab === "roster" && activeSubTab === "Performance Tiers" && (
-              <PerformanceTiers isSportsAgency={isSportsAgency} agencyMode={effectiveAgencyMode} />
+              <PerformanceTiers
+                isSportsAgency={isSportsAgency}
+                agencyMode={effectiveAgencyMode}
+              />
             )}
             {activeTab === "jobs" &&
               activeSubTab === "Job Invites" &&

--- a/likelee-ui/src/pages/AgencyDashboard.tsx
+++ b/likelee-ui/src/pages/AgencyDashboard.tsx
@@ -18608,16 +18608,6 @@ export default function AgencyDashboard() {
   const [openTalentId, setOpenTalentId] = useState<string | undefined>(
     searchParams.get("openTalentId") || undefined,
   );
-
-  // Sync openTalentId from URL whenever searchParams changes (e.g. when
-  // navigating from Performance Tiers View button to All Talent/Athletes).
-  // useState initializer only runs at mount so we need this effect too.
-  useEffect(() => {
-    const fromUrl = searchParams.get("openTalentId") || undefined;
-    if (fromUrl && fromUrl !== openTalentId) {
-      setOpenTalentId(fromUrl);
-    }
-  }, [searchParams]);
   const normalizeSubTab = (value: string | null | undefined) => {
     const cleaned = String(value || "")
       .trim()

--- a/supabase/migrations/2026-05-04_fix_performance_stats_bookings_agency_filter.sql
+++ b/supabase/migrations/2026-05-04_fix_performance_stats_bookings_agency_filter.sql
@@ -1,0 +1,91 @@
+-- 2026-05-04_fix_performance_stats_bookings_agency_filter.sql
+--
+-- The bookings CTE in get_agency_performance_stats used:
+--   WHERE b.agency_user_id = p_agency_id
+--
+-- agency_user_id is the auth.users.id of the person who CREATED the booking,
+-- not the agency's UUID. The agency_id column (added in
+-- 2026-04-08_03_add_agency_id_to_bookings.sql) is the correct filter.
+-- This caused booking_count to always return 0 for every talent.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_agency_performance_stats(
+    p_agency_id UUID,
+    p_earnings_start_date DATE,
+    p_bookings_start_date DATE
+)
+RETURNS TABLE (
+    talent_id UUID,
+    earnings_cents BIGINT,
+    booking_count BIGINT
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+WITH
+payment_earnings AS (
+    SELECT
+        p.talent_id,
+        SUM(COALESCE(p.talent_earnings_cents, 0))::BIGINT AS amount_cents
+    FROM public.payments p
+    WHERE p.agency_id = p_agency_id
+      AND p.status IN ('successful', 'succeeded')
+      AND COALESCE(p.paid_at, p.created_at) >= p_earnings_start_date::timestamptz
+    GROUP BY p.talent_id
+),
+licensing_earnings AS (
+    SELECT
+        lp.talent_id,
+        SUM(COALESCE(lp.amount_cents, 0))::BIGINT AS amount_cents
+    FROM public.licensing_payouts lp
+    WHERE lp.agency_id = p_agency_id
+      AND COALESCE(lp.paid_at, lp.created_at) >= p_earnings_start_date::timestamptz
+    GROUP BY lp.talent_id
+),
+earnings AS (
+    SELECT
+        talent_id,
+        SUM(amount_cents)::BIGINT AS total_earnings
+    FROM (
+        SELECT * FROM payment_earnings
+        UNION ALL
+        SELECT * FROM licensing_earnings
+    ) u
+    GROUP BY talent_id
+),
+bookings AS (
+    SELECT
+        b.talent_id,
+        COUNT(*)::BIGINT AS total_bookings
+    FROM public.bookings b
+    WHERE b.agency_id = p_agency_id          -- fixed: was b.agency_user_id
+      AND b.status IN ('confirmed', 'completed')
+      AND b.created_at >= p_bookings_start_date::timestamptz
+      AND (
+        COALESCE(
+          CASE
+            WHEN b.usage_duration ~* '^\s*\d+\s*(m|min|mins|minute|minutes)\s*$' THEN
+              b.created_at + ((regexp_replace(lower(b.usage_duration), '[^0-9]', '', 'g') || ' minutes')::interval)
+            WHEN b.usage_duration ~* '^\s*\d+\s*(h|hr|hrs|hour|hours)\s*$' THEN
+              b.created_at + ((regexp_replace(lower(b.usage_duration), '[^0-9]', '', 'g') || ' hours')::interval)
+            ELSE NULL
+          END,
+          b.created_at
+        ) <= now()
+      )
+    GROUP BY b.talent_id
+)
+SELECT
+    COALESCE(e.talent_id, b.talent_id) AS talent_id,
+    COALESCE(e.total_earnings, 0)      AS earnings_cents,
+    COALESCE(b.total_bookings, 0)      AS booking_count
+FROM earnings e
+FULL OUTER JOIN bookings b ON e.talent_id = b.talent_id
+WHERE COALESCE(e.talent_id, b.talent_id) IS NOT NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_agency_performance_stats(UUID, DATE, DATE) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_agency_performance_stats(UUID, DATE, DATE) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/2026-05-04_fix_performance_stats_licensing_earnings.sql
+++ b/supabase/migrations/2026-05-04_fix_performance_stats_licensing_earnings.sql
@@ -1,0 +1,127 @@
+-- 2026-05-04_fix_performance_stats_licensing_earnings.sql
+--
+-- The licensing_earnings CTE in get_agency_performance_stats had two bugs:
+--
+-- 1. It queried lp.talent_id which is NULL for multi-talent payouts.
+--    Multi-talent payouts store per-talent amounts in talent_splits JSONB array:
+--    [{"talent_id": "...", "amount_cents": 12345}, ...]
+--    These were completely missed.
+--
+-- 2. It summed lp.amount_cents which is the AGENCY commission amount
+--    (p_agency_amount_cents passed to complete_payment_link_checkout).
+--    The talent earnings are in lp.talent_earnings_cents (total) and
+--    per-talent in talent_splits[].amount_cents.
+--
+-- Fix: unnest talent_splits JSON array to get per-talent earnings,
+-- fall back to talent_id + talent_earnings_cents for single-talent payouts.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_agency_performance_stats(
+    p_agency_id UUID,
+    p_earnings_start_date DATE,
+    p_bookings_start_date DATE
+)
+RETURNS TABLE (
+    talent_id UUID,
+    earnings_cents BIGINT,
+    booking_count BIGINT
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+WITH
+payment_earnings AS (
+    -- IRL earnings from the payments table (booking-based)
+    SELECT
+        p.talent_id,
+        SUM(COALESCE(p.talent_earnings_cents, 0))::BIGINT AS amount_cents
+    FROM public.payments p
+    WHERE p.agency_id = p_agency_id
+      AND p.status IN ('successful', 'succeeded')
+      AND COALESCE(p.paid_at, p.created_at) >= p_earnings_start_date::timestamptz
+    GROUP BY p.talent_id
+),
+-- Multi-talent licensing payouts: unnest talent_splits JSON array
+licensing_earnings_multi AS (
+    SELECT
+        (split_item->>'talent_id')::uuid AS talent_id,
+        SUM(COALESCE((split_item->>'amount_cents')::bigint, 0))::BIGINT AS amount_cents
+    FROM public.licensing_payouts lp,
+         jsonb_array_elements(
+             CASE
+                 WHEN jsonb_typeof(lp.talent_splits) = 'array'
+                      AND jsonb_array_length(lp.talent_splits) > 0
+                 THEN lp.talent_splits
+                 ELSE '[]'::jsonb
+             END
+         ) AS split_item
+    WHERE lp.agency_id = p_agency_id
+      AND COALESCE(lp.paid_at, lp.created_at) >= p_earnings_start_date::timestamptz
+      AND (split_item->>'talent_id') IS NOT NULL
+      AND (split_item->>'talent_id') <> ''
+    GROUP BY (split_item->>'talent_id')::uuid
+),
+-- Single-talent licensing payouts: talent_id column is set, talent_splits is empty/null
+licensing_earnings_single AS (
+    SELECT
+        lp.talent_id,
+        SUM(COALESCE(lp.talent_earnings_cents, 0))::BIGINT AS amount_cents
+    FROM public.licensing_payouts lp
+    WHERE lp.agency_id = p_agency_id
+      AND lp.talent_id IS NOT NULL
+      AND (
+          lp.talent_splits IS NULL
+          OR jsonb_typeof(lp.talent_splits) <> 'array'
+          OR jsonb_array_length(lp.talent_splits) = 0
+      )
+      AND COALESCE(lp.paid_at, lp.created_at) >= p_earnings_start_date::timestamptz
+    GROUP BY lp.talent_id
+),
+earnings AS (
+    SELECT talent_id, SUM(amount_cents)::BIGINT AS total_earnings
+    FROM (
+        SELECT * FROM payment_earnings
+        UNION ALL
+        SELECT * FROM licensing_earnings_multi
+        UNION ALL
+        SELECT * FROM licensing_earnings_single
+    ) u
+    WHERE talent_id IS NOT NULL
+    GROUP BY talent_id
+),
+bookings AS (
+    SELECT
+        b.talent_id,
+        COUNT(*)::BIGINT AS total_bookings
+    FROM public.bookings b
+    WHERE b.agency_id = p_agency_id          -- fixed: was b.agency_user_id
+      AND b.status IN ('confirmed', 'completed')
+      AND b.created_at >= p_bookings_start_date::timestamptz
+      AND (
+        COALESCE(
+          CASE
+            WHEN b.usage_duration ~* '^\s*\d+\s*(m|min|mins|minute|minutes)\s*$' THEN
+              b.created_at + ((regexp_replace(lower(b.usage_duration), '[^0-9]', '', 'g') || ' minutes')::interval)
+            WHEN b.usage_duration ~* '^\s*\d+\s*(h|hr|hrs|hour|hours)\s*$' THEN
+              b.created_at + ((regexp_replace(lower(b.usage_duration), '[^0-9]', '', 'g') || ' hours')::interval)
+            ELSE NULL
+          END,
+          b.created_at
+        ) <= now()
+      )
+    GROUP BY b.talent_id
+)
+SELECT
+    COALESCE(e.talent_id, b.talent_id) AS talent_id,
+    COALESCE(e.total_earnings, 0)      AS earnings_cents,
+    COALESCE(b.total_bookings, 0)      AS booking_count
+FROM earnings e
+FULL OUTER JOIN bookings b ON e.talent_id = b.talent_id
+WHERE COALESCE(e.talent_id, b.talent_id) IS NOT NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_agency_performance_stats(UUID, DATE, DATE) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_agency_performance_stats(UUID, DATE, DATE) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/2026-05-05_add_stripe_payment_intent_id_to_payments.sql
+++ b/supabase/migrations/2026-05-05_add_stripe_payment_intent_id_to_payments.sql
@@ -1,0 +1,27 @@
+-- 2026-05-05_add_stripe_payment_intent_id_to_payments.sql
+--
+-- Three columns are referenced by RPCs but were never added to the payments table:
+--
+-- 1. stripe_payment_intent_id — used by complete_payment_link_checkout and
+--    bulk_update_payments_status to record the Stripe payment intent ID.
+--    Missing column caused the entire atomic RPC to fail with:
+--      column "stripe_payment_intent_id" of relation "payments" does not exist
+--    Result: no licensing_payouts row, no earnings, payment link never marked paid.
+--
+-- 2. agency_earnings_cents — used by bulk_update_payments_status to record
+--    the agency's share of the payment.
+--
+-- 3. commission_rate — used by bulk_update_payments_status to record the
+--    commission rate applied to this payment.
+
+BEGIN;
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS stripe_payment_intent_id text,
+  ADD COLUMN IF NOT EXISTS agency_earnings_cents bigint NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS commission_rate numeric(5,2);
+
+CREATE INDEX IF NOT EXISTS idx_payments_stripe_payment_intent_id
+  ON public.payments (stripe_payment_intent_id);
+
+COMMIT;

--- a/supabase/migrations/2026-05-05_licensing_requests_add_archived_status.sql
+++ b/supabase/migrations/2026-05-05_licensing_requests_add_archived_status.sql
@@ -1,0 +1,22 @@
+-- 2026-05-05_licensing_requests_add_archived_status.sql
+--
+-- The complete_payment_link_checkout RPC sets licensing_requests.status = 'archived'
+-- after a successful payment, but the check constraint only allows:
+--   pending, negotiating, approved, rejected, declined
+--
+-- This caused the entire atomic RPC to fail with:
+--   new row for relation "licensing_requests" violates check constraint
+--   "licensing_requests_status_check"
+--
+-- Note: archived_at column already exists (added in 0045_licensing_log_rotation_archival.sql)
+
+BEGIN;
+
+ALTER TABLE public.licensing_requests
+  DROP CONSTRAINT IF EXISTS licensing_requests_status_check;
+
+ALTER TABLE public.licensing_requests
+  ADD CONSTRAINT licensing_requests_status_check
+  CHECK (status IN ('pending', 'negotiating', 'approved', 'rejected', 'declined', 'archived'));
+
+COMMIT;


### PR DESCRIPTION


* Fixed `render_contract_to_html` adding an unwanted second-party signature block to agency-only templates.
* Added `include_second_party` flag based on presence of `"Second Party"` role.
* Simplified `datenow` tags to DocuSeal’s minimal supported format.

**Campaign Offers / Package Interactions**

* Fixed independent creator package interactions failing due to FK on `talent_id -> agency_users.id`.
* DB: removed FK, added `creator_id`, rebuilt unique index with `COALESCE`, updated upsert RPC.
* Frontend: now supports `talent_id` or `creator_id` in selection/save flows.
* Backend delete interaction supports either identity field.

**Brand Inbox / Confirm Selection**

* Fixed independent creators showing as raw UUID in confirm dialog.
* Backend now returns `creator_id` and injects creator name when no `talent_id`.
* Frontend selection + deselection logic now keys on `talent_id || creator_id`.

**DB Migration**

* `get_public_package_details` now includes `creator_id`, fixing refetch/selection state for independent creators.

**Marketplace Profile**

* Added `updated_at` to marketplace profile query so visibility logic correctly detects edited profiles.

**Licensing Request Automation**

* Brand-request route now locks requested talent, brand name, and client email.
* Hidden “send to connected brands” toggle for brand-initiated flows.

**Contract Validation**

* Live validation for required contract identity fields.
* Step 2 “Next” disabled until required names are present.
* Added hard-block validation before proceeding.

**External Client UX**

* Added info banner clarifying editable fields for external client licensing flow.

**Performance Tiers**

* View button now navigates correctly to roster talent.
* Verification ticks only show for approved KYC creators.
* Talent photo fallback added from creators table.
* Labels updated: bookings/deals terminology fixed.
* Progress bar now uses real earnings toward next tier.
* Removed duplicate talents in dropdown.
* Fixed double-counting deals.

**AI vs IRL Performance Mode**

* Added `agency_mode` support.
* AI mode ignores booking thresholds, uses licensing metrics only.
* UI hides irrelevant booking config fields in AI mode.

**Licensing Deals Count**

* AI mode now shows real completed licensing deals this month.
* Supports both single and multi-talent submissions without double-counting.

**Commission Rate UI**

* Added editable Talent Payout % + Agency Commission % inputs (sum to 100%).
* Live payout split preview included.
* Hidden in IRL mode.

**Payment Readiness Modal**

* Replaced raw Stripe failure toast with structured modal showing blocking talents + action guidance.
* Added “Message Talent” shortcut.

**Payment Flow Fixes**

* Added missing `stripe_payment_intent_id` columns.
* Added `archived` licensing request status.
* Fixed agency performance stats to calculate licensing earnings correctly for single + multi-talent deals.
* Improved webhook logging for payment failures.

**Booking Modal**

* Excluded independent creators from booking flow (internal agency talent only).
* Prevents “Access denied to this talent” errors.

**Booking Status**

* Fixed booking save status mapping:

  * Confirmed bookings → `confirmed`
  * Others → `pending`
