### PR TITLE
Contract quickfix

### DIFF
--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -5662,8 +5662,7 @@ export default function BrandDashboard() {
                                         // meta.brand_signing_url (primary) or
                                         // meta.docuseal_signing_url (fallback).
                                         const signingUrl =
-                                          contract?.meta
-                                            ?.brand_signing_url ||
+                                          contract?.meta?.brand_signing_url ||
                                           contract?.meta
                                             ?.docuseal_signing_url ||
                                           contract?.signing_url ||

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -5546,7 +5546,9 @@ export default function BrandDashboard() {
                       </p>
                       <p className="text-xs text-gray-500">
                         Agency:{" "}
-                        {offer?.agencies?.agency_name || "Unknown Agency"}
+                        {offer?.target_name ||
+                          offer?.agencies?.agency_name ||
+                          "Agency"}
                       </p>
                       <p className="text-xs text-gray-500">
                         {String(offer?.status || "sent").replace(/_/g, " ")}
@@ -5656,8 +5658,14 @@ export default function BrandDashboard() {
                                       size="sm"
                                       className="bg-blue-600 hover:bg-blue-700 text-white shadow-sm"
                                       onClick={() => {
-                                        // Check if backend provides a signing URL
+                                        // Resolve signing URL — backend stores it in
+                                        // meta.brand_signing_url (primary) or
+                                        // meta.docuseal_signing_url (fallback).
                                         const signingUrl =
+                                          contract?.meta
+                                            ?.brand_signing_url ||
+                                          contract?.meta
+                                            ?.docuseal_signing_url ||
                                           contract?.signing_url ||
                                           contract?.docuseal_signing_url;
 


### PR DESCRIPTION
Fix contract hub signing flow and contract rendering issues.

- Resolve signing URL from meta.brand_signing_url first
- Fix agency name lookup using offer.target_name fallback
- Prevent duplicate signature block when DocuSeal fields already exist