### PR TITLE
fix(nginx): raise upload limit to 25M to fix 413 on file uploads

### DIFF
--- a/deploy/ec2/nginx.conf
+++ b/deploy/ec2/nginx.conf
@@ -16,6 +16,11 @@ http {
   gzip_proxied any;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
+  # Allow file uploads up to 25 MB (application limit is 20 MB; extra headroom
+  # for multipart overhead and metadata). Without this nginx defaults to 1 MB
+  # and returns 413 before the request reaches the backend or Supabase.
+  client_max_body_size 25M;
+
   upstream ui_upstream {
     server ui:8080;
   }
@@ -57,6 +62,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      client_max_body_size 25M;
       proxy_pass http://api_upstream;
     }
 


### PR DESCRIPTION


## Summary

Fixes file upload failures in production caused by Nginx rejecting request bodies larger than its default size limit.

## Changes

* Increased Nginx `client_max_body_size` from default (~1M) to `25M`
* Added upload size configuration at:

  * global `http` block
  * `/api` location block
* Kept application-level file validation limit at **20MB**

## Root Cause

Uploads worked locally because requests went directly to the application.
In production, requests pass through the AWS Nginx reverse proxy first, which rejected files above ~1MB with:

`413 Request Entity Too Large`

before the request could reach the backend or Supabase.

## Result

* Uploads up to 20MB now work correctly in production
* Requests larger than 20MB are still blocked by app validation

If you want a shorter, more GitHub-style PR description:

## What changed

Configured Nginx to allow larger request bodies for file uploads by setting `client_max_body_size` to `25M`.

## Why

Production uploads failed with `413 Request Entity Too Large` because Nginx defaulted to ~1MB max body size and rejected files before backend validation.

## Outcome

Production now supports uploads up to the app-enforced 20MB limit.
