### PR TITLE
fix: add proper error logging for team invitation emails

### DIFF
--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -703,8 +703,25 @@ pub async fn create_for_agency(
     let body = lines.join("\n");
 
     // Best-effort email send
-    let _ =
-        crate::email::send_plain_text_email(&state, &email, &subject, &body, Some(&agency_name));
+    match crate::email::send_plain_text_email(&state, &email, &subject, &body, Some(&agency_name))
+    {
+        Ok(()) => {
+            tracing::info!(
+                email = %email,
+                agency = %agency_name,
+                "Agency talent invitation email sent successfully"
+            );
+        }
+        Err((code, error)) => {
+            tracing::error!(
+                email = %email,
+                agency = %agency_name,
+                status_code = %code,
+                error = %error,
+                "Failed to send agency talent invitation email"
+            );
+        }
+    }
 
     Ok(Json(json!({
         "status": "ok",

--- a/likelee-server/src/agency_talent_invites.rs
+++ b/likelee-server/src/agency_talent_invites.rs
@@ -703,8 +703,7 @@ pub async fn create_for_agency(
     let body = lines.join("\n");
 
     // Best-effort email send
-    match crate::email::send_plain_text_email(&state, &email, &subject, &body, Some(&agency_name))
-    {
+    match crate::email::send_plain_text_email(&state, &email, &subject, &body, Some(&agency_name)) {
         Ok(()) => {
             tracing::info!(
                 email = %email,

--- a/likelee-server/src/team/handlers.rs
+++ b/likelee-server/src/team/handlers.rs
@@ -291,13 +291,30 @@ pub async fn create_invite(
         invited_role.as_str().replace('_', " "),
         invite_url
     );
-    let _ = email::send_plain_text_email(
+    match email::send_plain_text_email(
         &state,
         invite.email.as_str(),
         subject.as_str(),
         body.as_str(),
         Some(scope.organization_name.as_str()),
-    );
+    ) {
+        Ok(()) => {
+            tracing::info!(
+                email = %invite.email,
+                organization = %scope.organization_name,
+                "Team invitation email sent successfully"
+            );
+        }
+        Err((code, error)) => {
+            tracing::error!(
+                email = %invite.email,
+                organization = %scope.organization_name,
+                status_code = %code,
+                error = %error,
+                "Failed to send team invitation email"
+            );
+        }
+    }
 
     Ok(Json(invite))
 }
@@ -428,13 +445,28 @@ pub async fn update_member_role(
         target_role.as_str().replace('_', " "),
         next_role.as_str().replace('_', " ")
     );
-    let _ = email::send_plain_text_email(
+    match email::send_plain_text_email(
         &state,
         updated.email.as_str(),
         subject.as_str(),
         body.as_str(),
         Some(scope.organization_name.as_str()),
-    );
+    ) {
+        Ok(()) => {
+            tracing::info!(
+                email = %updated.email,
+                "Role change notification email sent successfully"
+            );
+        }
+        Err((code, error)) => {
+            tracing::error!(
+                email = %updated.email,
+                status_code = %code,
+                error = %error,
+                "Failed to send role change notification email"
+            );
+        }
+    }
 
     Ok(Json(updated))
 }
@@ -536,13 +568,28 @@ pub async fn remove_member(
         "Hi,\n\nYou have been removed from {} on Likelee. If you believe this was an error, please contact the organization owner.",
         scope.organization_name
     );
-    let _ = email::send_plain_text_email(
+    match email::send_plain_text_email(
         &state,
         target_membership.email.as_str(),
         subject.as_str(),
         body.as_str(),
         Some(scope.organization_name.as_str()),
-    );
+    ) {
+        Ok(()) => {
+            tracing::info!(
+                email = %target_membership.email,
+                "Member removal notification email sent successfully"
+            );
+        }
+        Err((code, error)) => {
+            tracing::error!(
+                email = %target_membership.email,
+                status_code = %code,
+                error = %error,
+                "Failed to send member removal notification email"
+            );
+        }
+    }
 
     Ok(Json(ActionResponse {
         status: "ok".to_string(),


### PR DESCRIPTION
## Summary
- Replaced silent error swallowing (`let _ = ...`) with explicit match statements for all team invitation email sends
- Added structured tracing logs for both success and failure cases
- Enables debugging of production email delivery issues where invited members don't receive invitation emails

## Changes
- `likelee-server/src/team/handlers.rs`: Added error logging for team invite creation, role updates, and member removal emails
- `likelee-server/src/agency_talent_invites.rs`: Added error logging for agency talent invitation emails

## Why This Matters
Currently, email send failures are completely silent in production. This change will surface errors like:
- SMTP misconfiguration
- Network/firewall blocking SMTP ports
- TLS certificate validation failures
- Invalid sender/recipient addresses

After deploying, check production logs for:
- `"Team invitation email sent successfully"`
- `"Failed to send team invitation email"` (with error details)