### PR TITLE
Bugs fixes: Fix/polish: creator dashboard, brand contract hub, 

### DIFF
--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5111,12 +5111,157 @@ pub async fn delete_offer_contract(
 /// Called exclusively from `mark_brand_package_done` — assignments are always
 /// created automatically from the brand's package selection, never manually.
 ///
+/// Resolve any incoming ID to a `creator_id` string.
+///
+/// The package snapshot may contain any of:
+///   - A `creators.id` directly (independent connected creator)
+///   - An `agency_users.id` (internal talent with a creator account)
+///   - An `agency_users.creator_id` (same as above, stored differently)
+///   - An `agency_talent_relationships.id` (legacy roster id)
+///
+/// We always resolve to `creator_id` because that is the canonical, universal
+/// identity for every talent — internal or independent.  The `agency_users.id`
+/// (talent_id) is optional metadata stored alongside it.
+async fn resolve_creator_id_for_assignment(
+    state: &AppState,
+    agency_id: &str,
+    raw_id: &str,
+) -> Result<(String, Option<String>), (StatusCode, String)> {
+    // 1) Direct match: raw_id IS a creators.id AND the creator is connected to
+    //    this agency (either via agency_users or agency_talent_relationships).
+    let cr_resp = state
+        .pg
+        .from("creators")
+        .select("id")
+        .eq("id", raw_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if cr_resp.status().is_success() {
+        let cr_text = cr_resp.text().await.unwrap_or_default();
+        let cr_rows: Vec<serde_json::Value> = serde_json::from_str(&cr_text).unwrap_or_default();
+        if cr_rows.first().is_some() {
+            // Verify the creator is connected to this agency.
+            // Check agency_users first (internal talent).
+            let au_resp = state
+                .pg
+                .from("agency_users")
+                .select("id")
+                .eq("agency_id", agency_id)
+                .or(format!("creator_id.eq.{},user_id.eq.{}", raw_id, raw_id))
+                .limit(1)
+                .execute()
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            if au_resp.status().is_success() {
+                let au_text = au_resp.text().await.unwrap_or_default();
+                let au_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&au_text).unwrap_or_default();
+                if let Some(au_row) = au_rows.first() {
+                    let talent_id = au_row
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    return Ok((raw_id.to_string(), talent_id));
+                }
+            }
+            // Check agency_talent_relationships (independent connected creator).
+            let rel_resp = state
+                .pg
+                .from("agency_talent_relationships")
+                .select("id")
+                .eq("agency_id", agency_id)
+                .eq("creator_id", raw_id)
+                .limit(1)
+                .execute()
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            if rel_resp.status().is_success() {
+                let rel_text = rel_resp.text().await.unwrap_or_default();
+                let rel_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&rel_text).unwrap_or_default();
+                if rel_rows.first().is_some() {
+                    // Independent creator — no agency_users.id, creator_id only.
+                    return Ok((raw_id.to_string(), None));
+                }
+            }
+        }
+    }
+
+    // 2) raw_id is an agency_users.id — look up the creator_id from that row.
+    let au_resp = state
+        .pg
+        .from("agency_users")
+        .select("id,creator_id")
+        .eq("id", raw_id)
+        .eq("agency_id", agency_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if au_resp.status().is_success() {
+        let au_text = au_resp.text().await.unwrap_or_default();
+        let au_rows: Vec<serde_json::Value> = serde_json::from_str(&au_text).unwrap_or_default();
+        if let Some(au_row) = au_rows.first() {
+            let creator_id = au_row
+                .get("creator_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !creator_id.is_empty() {
+                return Ok((creator_id, Some(raw_id.to_string())));
+            }
+        }
+    }
+
+    // 3) raw_id is an agency_talent_relationships.id — look up creator_id.
+    let rel_resp = state
+        .pg
+        .from("agency_talent_relationships")
+        .select("creator_id")
+        .eq("id", raw_id)
+        .eq("agency_id", agency_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if rel_resp.status().is_success() {
+        let rel_text = rel_resp.text().await.unwrap_or_default();
+        let rel_rows: Vec<serde_json::Value> = serde_json::from_str(&rel_text).unwrap_or_default();
+        if let Some(rel_row) = rel_rows.first() {
+            let creator_id = rel_row
+                .get("creator_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !creator_id.is_empty() {
+                return Ok((creator_id, None));
+            }
+        }
+    }
+
+    Err((
+        StatusCode::NOT_FOUND,
+        format!("talent not found for id: {}", raw_id),
+    ))
+}
+
+/// Internal helper: insert a single talent assignment for an offer.
+///
+/// Called exclusively from `mark_brand_package_done` — assignments are always
+/// created automatically from the brand's package selection, never manually.
+///
+/// Accepts any resolvable ID shape (creators.id, agency_users.id, relationship id)
+/// and always stores the assignment keyed by creator_id.
+///
 /// Returns the upserted assignment row on success.
 async fn insert_offer_talent_assignment_internal(
     state: &AppState,
     agency_id: &str,
     offer_id: &str,
-    // Accepts any resolvable ID shape: agency_users.id, creator_id, or legacy roster id.
     talent_id_or_creator_id: &str,
 ) -> Result<serde_json::Value, (StatusCode, String)> {
     let raw_id = talent_id_or_creator_id.trim();
@@ -5124,35 +5269,15 @@ async fn insert_offer_talent_assignment_internal(
         return Err((StatusCode::BAD_REQUEST, "talent_id is required".to_string()));
     }
 
-    // Resolve to canonical agency_users row using the multi-shape resolver.
-    let talent = resolve_agency_talent(state, agency_id, raw_id).await?;
-
-    let canonical_talent_id = talent
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_string();
-
-    let creator_id = talent
-        .get("creator_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .trim()
-        .to_string();
-
-    if creator_id.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "This talent must create a creator account before they can be assigned to a contract."
-                .to_string(),
-        ));
-    }
+    // Resolve to (creator_id, Option<agency_users_id>).
+    // creator_id is the canonical identity for all talent types.
+    let (creator_id, agency_user_id) =
+        resolve_creator_id_for_assignment(state, agency_id, raw_id).await?;
 
     let insert_payload = json!({
         "offer_id": offer_id,
         "agency_id": agency_id,
-        "talent_id": if canonical_talent_id.is_empty() { serde_json::Value::Null } else { json!(canonical_talent_id) },
+        "talent_id": agency_user_id.as_deref().map(|s| json!(s)).unwrap_or(serde_json::Value::Null),
         "creator_id": creator_id,
         "status": "assigned",
         "assigned_by": agency_id,

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -254,6 +254,10 @@ pub struct CreateOfferContractRequest {
 #[derive(Debug, Deserialize)]
 pub struct SendOfferContractRequest {
     pub contract_id: Option<String>,
+    /// When true, always create a fresh DocuSeal submission even if one already
+    /// exists. Used by the resend flow so the brand gets a new signing URL.
+    #[serde(default)]
+    pub force_new_submission: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3562,7 +3566,8 @@ pub async fn send_offer_contract(
             ));
         }
 
-        let submission_missing = contract_data.get("docuseal_submission_id").is_none()
+        let submission_missing = payload.force_new_submission
+            || contract_data.get("docuseal_submission_id").is_none()
             || contract_data["docuseal_submission_id"].is_null();
 
         if submission_missing && (target_type == "creator" || target_type == "talent") {

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -5146,7 +5146,7 @@ async fn resolve_creator_id_for_assignment(
     if cr_resp.status().is_success() {
         let cr_text = cr_resp.text().await.unwrap_or_default();
         let cr_rows: Vec<serde_json::Value> = serde_json::from_str(&cr_text).unwrap_or_default();
-        if cr_rows.first().is_some() {
+        if !cr_rows.is_empty() {
             // Verify the creator is connected to this agency.
             // Check agency_users first (internal talent).
             let au_resp = state
@@ -5186,7 +5186,7 @@ async fn resolve_creator_id_for_assignment(
                 let rel_text = rel_resp.text().await.unwrap_or_default();
                 let rel_rows: Vec<serde_json::Value> =
                     serde_json::from_str(&rel_text).unwrap_or_default();
-                if rel_rows.first().is_some() {
+                if !rel_rows.is_empty() {
                     // Independent creator — no agency_users.id, creator_id only.
                     return Ok((raw_id.to_string(), None));
                 }

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -1856,6 +1856,7 @@ const BrandConnectionsView = ({
                                     []
                                   ).map((a: any) => {
                                     const talent = a?.agency_users || {};
+                                    const creator = a?.creators || {};
                                     const tid = String(a?.talent_id || "");
                                     const assignmentId = String(a?.id || "");
                                     const creatorId = String(
@@ -1863,6 +1864,13 @@ const BrandConnectionsView = ({
                                         a?.agency_users?.creator_id ||
                                         "",
                                     ).trim();
+                                    // Name: prefer agency_users fields (internal talent),
+                                    // fall back to creators.full_name (independent creator).
+                                    const displayName =
+                                      talent?.stage_name ||
+                                      talent?.full_legal_name ||
+                                      creator?.full_name ||
+                                      "Talent";
                                     return (
                                       <div
                                         key={String(a?.id)}
@@ -1874,9 +1882,7 @@ const BrandConnectionsView = ({
                                           </div>
                                           <div>
                                             <p className="text-sm font-semibold text-gray-900">
-                                              {talent?.stage_name ||
-                                                talent?.full_legal_name ||
-                                                "Talent"}
+                                              {displayName}
                                             </p>
                                             <p className="text-xs text-green-600 font-medium">
                                               Selected by brand

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -5222,7 +5222,8 @@ export default function BrandDashboard() {
     const status = String(statusRaw || "sent").toLowerCase();
     if (status === "opened") return "Sign Required";
     if (status === "sent") return "Sent";
-    if (status === "partially_signed" || status === "signed") return "Awaiting Creator";
+    if (status === "partially_signed" || status === "signed")
+      return "Awaiting Creator";
     if (status === "completed") return "Completed";
     if (status === "declined" || status === "rejected") return "Declined";
     return status.replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
@@ -5817,10 +5818,24 @@ export default function BrandDashboard() {
                               )}
                             >
                               {(() => {
-                                const st = String(row?.docuseal_status || "").toLowerCase();
-                                if (st === "sent" || st === "opened") return <Mail className="h-3.5 w-3.5 mr-1.5" />;
-                                if (st === "completed") return <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />;
-                                if (st === "partially_signed" || st === "signed") return <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />;
+                                const st = String(
+                                  row?.docuseal_status || "",
+                                ).toLowerCase();
+                                if (st === "sent" || st === "opened")
+                                  return (
+                                    <Mail className="h-3.5 w-3.5 mr-1.5" />
+                                  );
+                                if (st === "completed")
+                                  return (
+                                    <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
+                                  );
+                                if (
+                                  st === "partially_signed" ||
+                                  st === "signed"
+                                )
+                                  return (
+                                    <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
+                                  );
                                 return null;
                               })()}
                               {formatContractStatusLabel(row?.docuseal_status)}
@@ -5836,8 +5851,14 @@ export default function BrandDashboard() {
                                   then DocuSeal sends to the creator automatically.
                                   Not shown for completed (both signed) or draft (not sent yet). */}
                               {(() => {
-                                const st = String(row?.docuseal_status || "").toLowerCase();
-                                const canResend = st === "sent" || st === "opened" || st === "partially_signed" || st === "signed";
+                                const st = String(
+                                  row?.docuseal_status || "",
+                                ).toLowerCase();
+                                const canResend =
+                                  st === "sent" ||
+                                  st === "opened" ||
+                                  st === "partially_signed" ||
+                                  st === "signed";
                                 if (!canResend) return null;
 
                                 return (
@@ -5847,41 +5868,81 @@ export default function BrandDashboard() {
                                     aria-label="Resend"
                                     type="button"
                                     onClick={async () => {
-                                      const offerId = String(row?.offer_id || "");
+                                      const offerId = String(
+                                        row?.offer_id || "",
+                                      );
                                       const contractId = String(row?.id || "");
                                       if (!offerId || !contractId) {
-                                        toast({ title: "Resend failed", description: "Missing offer or contract ID.", variant: "destructive" as any });
+                                        toast({
+                                          title: "Resend failed",
+                                          description:
+                                            "Missing offer or contract ID.",
+                                          variant: "destructive" as any,
+                                        });
                                         return;
                                       }
                                       try {
                                         // Always create a fresh submission — never reuse an old signing URL
-                                        const result = await base44.post<{ contract?: any }>(
+                                        const result = await base44.post<{
+                                          contract?: any;
+                                        }>(
                                           `/api/campaign-offers/${encodeURIComponent(offerId)}/contracts/send`,
-                                          { contract_id: contractId, force_new_submission: true },
+                                          {
+                                            contract_id: contractId,
+                                            force_new_submission: true,
+                                          },
                                         );
                                         const newContract = result?.contract;
                                         const newSigningUrl =
-                                          newContract?.meta?.brand_signing_url ||
-                                          newContract?.meta?.agency_signing_url ||
-                                          newContract?.meta?.docuseal_signing_url;
+                                          newContract?.meta
+                                            ?.brand_signing_url ||
+                                          newContract?.meta
+                                            ?.agency_signing_url ||
+                                          newContract?.meta
+                                            ?.docuseal_signing_url;
                                         if (newContract) {
                                           // Update the row in place with the fresh contract data
                                           setContractHubRows((prev) =>
                                             prev.map((existing: any) =>
-                                              String(existing?.id) === contractId
-                                                ? { ...newContract, offer_id: existing?.offer_id, campaign_name: existing?.campaign_name, creator_name: existing?.creator_name }
+                                              String(existing?.id) ===
+                                              contractId
+                                                ? {
+                                                    ...newContract,
+                                                    offer_id:
+                                                      existing?.offer_id,
+                                                    campaign_name:
+                                                      existing?.campaign_name,
+                                                    creator_name:
+                                                      existing?.creator_name,
+                                                  }
                                                 : existing,
                                             ),
                                           );
                                         }
                                         if (newSigningUrl) {
-                                          window.open(String(newSigningUrl), "_blank");
-                                          toast({ title: "New contract ready", description: "Sign the document — it will be sent to the creator automatically." });
+                                          window.open(
+                                            String(newSigningUrl),
+                                            "_blank",
+                                          );
+                                          toast({
+                                            title: "New contract ready",
+                                            description:
+                                              "Sign the document — it will be sent to the creator automatically.",
+                                          });
                                         } else {
-                                          toast({ title: "Contract resent", description: "Check your email for the new signing link." });
+                                          toast({
+                                            title: "Contract resent",
+                                            description:
+                                              "Check your email for the new signing link.",
+                                          });
                                         }
                                       } catch (e: any) {
-                                        toast({ title: "Resend failed", description: e?.message || "Please try again.", variant: "destructive" as any });
+                                        toast({
+                                          title: "Resend failed",
+                                          description:
+                                            e?.message || "Please try again.",
+                                          variant: "destructive" as any,
+                                        });
                                       }
                                     }}
                                   >

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -1481,6 +1481,8 @@ export default function BrandDashboard() {
                     offer?.offer_title ||
                     "Campaign offer",
                 ),
+                // Preserve creator/agency name from the offer for display
+                creator_name: String(offer?.target_name || "").trim() || null,
               }));
             }),
           )
@@ -5197,24 +5199,34 @@ export default function BrandDashboard() {
   };
   const contractStatusBadgeClass = (statusRaw: unknown) => {
     const status = String(statusRaw || "").toLowerCase();
-    if (status === "signed") {
+    if (status === "completed") {
       return "inline-flex min-w-28 items-center rounded-md border border-emerald-300 bg-emerald-100 px-2.5 py-1 text-emerald-700 font-semibold";
+    }
+    if (status === "partially_signed" || status === "signed") {
+      // Brand signed, waiting for creator — amber/waiting tone
+      return "inline-flex min-w-28 items-center rounded-md border border-amber-300 bg-amber-100 px-2.5 py-1 text-amber-700 font-semibold";
+    }
+    if (status === "opened") {
+      // Brand opened but hasn't signed yet — blue/action-needed tone
+      return "inline-flex min-w-28 items-center rounded-md border border-blue-300 bg-blue-100 px-2.5 py-1 text-blue-700 font-semibold";
     }
     if (status === "sent") {
       return "inline-flex min-w-28 items-center rounded-md border border-blue-300 bg-blue-100 px-2.5 py-1 text-blue-700 font-semibold";
-    }
-    if (status === "opened") {
-      return "inline-flex min-w-28 items-center rounded-md border border-amber-300 bg-amber-100 px-2.5 py-1 text-amber-700 font-semibold";
     }
     if (status === "declined" || status === "rejected") {
       return "inline-flex min-w-28 items-center rounded-md border border-red-300 bg-red-100 px-2.5 py-1 text-red-700 font-semibold";
     }
     return "inline-flex min-w-28 items-center rounded-md border border-gray-300 bg-white px-2.5 py-1 text-gray-700 font-semibold";
   };
-  const formatContractStatusLabel = (statusRaw: unknown) =>
-    String(statusRaw || "sent")
-      .replace(/_/g, " ")
-      .replace(/\b\w/g, (m) => m.toUpperCase());
+  const formatContractStatusLabel = (statusRaw: unknown) => {
+    const status = String(statusRaw || "sent").toLowerCase();
+    if (status === "opened") return "Sign Required";
+    if (status === "sent") return "Sent";
+    if (status === "partially_signed" || status === "signed") return "Awaiting Creator";
+    if (status === "completed") return "Completed";
+    if (status === "declined" || status === "rejected") return "Declined";
+    return status.replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
+  };
 
   const handleDeliverableReview = async (
     offerId: string,
@@ -5785,7 +5797,10 @@ export default function BrandDashboard() {
                             {String(row?.campaign_name || "Campaign offer")}
                           </td>
                           <td className="px-2 py-2 text-gray-700">
-                            {offer?.creators?.full_name || "Unknown Creator"}
+                            {row?.creator_name ||
+                              offer?.target_name ||
+                              offer?.creators?.full_name ||
+                              "Creator"}
                           </td>
                           <td className="px-2 py-2 text-gray-700">
                             {String(
@@ -5801,16 +5816,13 @@ export default function BrandDashboard() {
                                 row?.docuseal_status,
                               )}
                             >
-                              {String(
-                                row?.docuseal_status || "",
-                              ).toLowerCase() === "sent" && (
-                                <Mail className="h-3.5 w-3.5 mr-1.5" />
-                              )}
-                              {String(
-                                row?.docuseal_status || "",
-                              ).toLowerCase() === "signed" && (
-                                <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
-                              )}
+                              {(() => {
+                                const st = String(row?.docuseal_status || "").toLowerCase();
+                                if (st === "sent" || st === "opened") return <Mail className="h-3.5 w-3.5 mr-1.5" />;
+                                if (st === "completed") return <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />;
+                                if (st === "partially_signed" || st === "signed") return <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />;
+                                return null;
+                              })()}
                               {formatContractStatusLabel(row?.docuseal_status)}
                             </span>
                           </td>
@@ -5819,65 +5831,64 @@ export default function BrandDashboard() {
                           </td>
                           <td className="px-2 py-2">
                             <div className="flex items-center gap-3">
-                              <button
-                                className="text-blue-600 hover:text-blue-700"
-                                title="Resend"
-                                aria-label="Resend"
-                                type="button"
-                                onClick={async () => {
-                                  try {
-                                    await base44.post(
-                                      `/api/campaign-offers/${encodeURIComponent(
-                                        String(row?.offer_id || ""),
-                                      )}/contracts/send`,
-                                      { contract_id: String(row?.id || "") },
-                                    );
-                                    const refreshed = await base44.get<{
-                                      contracts?: any[];
-                                    }>(
-                                      `/api/campaign-offers/${encodeURIComponent(
-                                        String(row?.offer_id || ""),
-                                      )}/contracts`,
-                                    );
-                                    const refreshedContracts = Array.isArray(
-                                      refreshed?.contracts,
-                                    )
-                                      ? refreshed.contracts
-                                      : [];
-                                    setContractHubRows((prev) =>
-                                      prev.map((existing: any) => {
-                                        if (
-                                          String(existing?.id) !==
-                                          String(row?.id)
-                                        )
-                                          return existing;
-                                        const fresh = refreshedContracts.find(
-                                          (c: any) =>
-                                            String(c?.id) === String(row?.id),
+                              {/* Resend — always creates a fresh DocuSeal submission from the same
+                                  template so the brand gets a new signing URL. The brand signs,
+                                  then DocuSeal sends to the creator automatically.
+                                  Not shown for completed (both signed) or draft (not sent yet). */}
+                              {(() => {
+                                const st = String(row?.docuseal_status || "").toLowerCase();
+                                const canResend = st === "sent" || st === "opened" || st === "partially_signed" || st === "signed";
+                                if (!canResend) return null;
+
+                                return (
+                                  <button
+                                    className="text-blue-600 hover:text-blue-700"
+                                    title="Resend — create new contract for brand to sign"
+                                    aria-label="Resend"
+                                    type="button"
+                                    onClick={async () => {
+                                      const offerId = String(row?.offer_id || "");
+                                      const contractId = String(row?.id || "");
+                                      if (!offerId || !contractId) {
+                                        toast({ title: "Resend failed", description: "Missing offer or contract ID.", variant: "destructive" as any });
+                                        return;
+                                      }
+                                      try {
+                                        // Always create a fresh submission — never reuse an old signing URL
+                                        const result = await base44.post<{ contract?: any }>(
+                                          `/api/campaign-offers/${encodeURIComponent(offerId)}/contracts/send`,
+                                          { contract_id: contractId, force_new_submission: true },
                                         );
-                                        return fresh
-                                          ? {
-                                              ...fresh,
-                                              offer_id: existing?.offer_id,
-                                              campaign_name:
-                                                existing?.campaign_name,
-                                            }
-                                          : existing;
-                                      }),
-                                    );
-                                    toast({ title: "Contract resent" });
-                                  } catch (e: any) {
-                                    toast({
-                                      title: "Resend failed",
-                                      description:
-                                        e?.message || "Please try again.",
-                                      variant: "destructive" as any,
-                                    });
-                                  }
-                                }}
-                              >
-                                <RefreshCw className="h-4 w-4" />
-                              </button>
+                                        const newContract = result?.contract;
+                                        const newSigningUrl =
+                                          newContract?.meta?.brand_signing_url ||
+                                          newContract?.meta?.agency_signing_url ||
+                                          newContract?.meta?.docuseal_signing_url;
+                                        if (newContract) {
+                                          // Update the row in place with the fresh contract data
+                                          setContractHubRows((prev) =>
+                                            prev.map((existing: any) =>
+                                              String(existing?.id) === contractId
+                                                ? { ...newContract, offer_id: existing?.offer_id, campaign_name: existing?.campaign_name, creator_name: existing?.creator_name }
+                                                : existing,
+                                            ),
+                                          );
+                                        }
+                                        if (newSigningUrl) {
+                                          window.open(String(newSigningUrl), "_blank");
+                                          toast({ title: "New contract ready", description: "Sign the document — it will be sent to the creator automatically." });
+                                        } else {
+                                          toast({ title: "Contract resent", description: "Check your email for the new signing link." });
+                                        }
+                                      } catch (e: any) {
+                                        toast({ title: "Resend failed", description: e?.message || "Please try again.", variant: "destructive" as any });
+                                      }
+                                    }}
+                                  >
+                                    <RefreshCw className="h-4 w-4" />
+                                  </button>
+                                );
+                              })()}
                               <button
                                 className="text-red-600 hover:text-red-700"
                                 title="Archive"
@@ -5912,19 +5923,26 @@ export default function BrandDashboard() {
                               >
                                 <Archive className="h-4 w-4" />
                               </button>
-                              {row?.meta?.docuseal_document_url && (
-                                <a
-                                  href={String(row.meta.docuseal_document_url)}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  download
-                                  title="Download"
-                                  aria-label="Download"
-                                  className="text-blue-700 hover:text-blue-800"
-                                >
-                                  <Download className="h-4 w-4" />
-                                </a>
-                              )}
+                              {/* Download — check both signed_document_url and meta.docuseal_document_url */}
+                              {(() => {
+                                const docUrl =
+                                  row?.signed_document_url ||
+                                  row?.meta?.docuseal_document_url ||
+                                  row?.meta?.signed_document_url;
+                                return docUrl ? (
+                                  <a
+                                    href={String(docUrl)}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    download
+                                    title="Download signed contract"
+                                    aria-label="Download"
+                                    className="text-blue-700 hover:text-blue-800"
+                                  >
+                                    <Download className="h-4 w-4" />
+                                  </a>
+                                ) : null;
+                              })()}
                             </div>
                           </td>
                         </tr>

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { DobInput } from "@/components/ui/DobInput";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -26,6 +27,7 @@ import {
   markTalentAssetRequestViewed,
   scrapeInstagramProfile,
 } from "@/api/functions";
+import { getCacheItem, setCacheItem } from "@/lib/localStorageCache";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -553,8 +555,46 @@ export default function CreatorDashboard() {
   };
   const [activeSection, setActiveSection] = useState("dashboard");
   const [settingsTab, setSettingsTab] = useState("profile"); // 'profile' | 'rules' | 'billing'
-  const [creatorBilling, setCreatorBilling] = useState<any>(null);
-  const [creatorBillingLoaded, setCreatorBillingLoaded] = useState(false);
+
+  // ── Billing — multi-layer cache ──────────────────────────────────────────
+  // Layer 1: localStorage — survives page refresh, seeds initial state instantly
+  // Layer 2: React Query — in-memory, stale-while-revalidate, shared with prefetcher
+  // Layer 3: Network — background revalidation, never blocks render
+  const BILLING_CACHE_KEY = `creator_billing_${user?.id || "anon"}`;
+  const BILLING_STALE_MS = 5 * 60 * 1000; // 5 min — matches backend session cache
+
+  // Seed initial data from localStorage so the correct plan shows immediately
+  // on page load without any network round-trip.
+  const cachedBilling = useMemo(() => {
+    const entry = getCacheItem<any>(BILLING_CACHE_KEY);
+    if (!entry) return null;
+    const age = Date.now() - entry.timestamp;
+    // Accept cache up to 24h old as seed — React Query will revalidate in bg
+    return age < 24 * 60 * 60 * 1000 ? entry.data : null;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [BILLING_CACHE_KEY]);
+
+  const billingQuery = useQuery({
+    queryKey: ["creator", "billing", "status", user?.id],
+    queryFn: async () => {
+      const data = await getCreatorBillingStatus();
+      // Persist to localStorage so next page load is instant
+      setCacheItem(BILLING_CACHE_KEY, data);
+      return data;
+    },
+    // Seed from localStorage — no flash of "Free" on refresh
+    initialData: cachedBilling ?? undefined,
+    // Data is fresh for 5 min — matches backend session cache TTL
+    staleTime: BILLING_STALE_MS,
+    gcTime: 60 * 60 * 1000, // keep in memory for 1h
+    enabled: !!user?.id,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+  });
+
+  const creatorBilling = billingQuery.data ?? null;
+  const creatorBillingLoaded = !billingQuery.isLoading || !!cachedBilling;
+  // ─────────────────────────────────────────────────────────────────────────
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < 1024);
   const [agencyInvites, setAgencyInvites] = useState<any[]>([]);
@@ -3801,28 +3841,6 @@ export default function CreatorDashboard() {
       setSettingsTab(nextSettings);
     }
   }, [searchParams]);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadBilling() {
-      try {
-        const resp = await getCreatorBillingStatus();
-        if (!cancelled) {
-          setCreatorBilling(resp);
-        }
-      } catch (error) {
-        console.error("Failed to load creator billing status", error);
-      } finally {
-        if (!cancelled) {
-          setCreatorBillingLoaded(true);
-        }
-      }
-    }
-    void loadBilling();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const creatorPlanTier = String(creatorBilling?.plan_tier || "free");
   const trialActive = !!creatorBilling?.trial_active;

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -571,7 +571,7 @@ export default function CreatorDashboard() {
     const age = Date.now() - entry.timestamp;
     // Accept cache up to 24h old as seed — React Query will revalidate in bg
     return age < 24 * 60 * 60 * 1000 ? entry.data : null;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [BILLING_CACHE_KEY]);
 
   const billingQuery = useQuery({
@@ -3181,7 +3181,11 @@ export default function CreatorDashboard() {
   const [contractsTab, setContractsTab] = useState("active");
   const [showImageUploadModal, setShowImageUploadModal] = useState(false);
   const [showRestrictionsModal, setShowRestrictionsModal] = useState(false);
-  const [deleteVoiceModal, setDeleteVoiceModal] = useState<{ open: boolean; uiId: any; serverId: any }>({ open: false, uiId: null, serverId: null });
+  const [deleteVoiceModal, setDeleteVoiceModal] = useState<{
+    open: boolean;
+    uiId: any;
+    serverId: any;
+  }>({ open: false, uiId: null, serverId: null });
   const [isDeletingVoice, setIsDeletingVoice] = useState(false);
   const [newRestriction, setNewRestriction] = useState("");
   const [newBrand, setNewBrand] = useState("");
@@ -4358,19 +4362,28 @@ export default function CreatorDashboard() {
             Content Tracking
           </h3>
           <p className="text-gray-500 max-w-md leading-relaxed mb-8">
-            See every piece of content brands create using your likeness — views, engagement, platforms, and live status — all in one place.
+            See every piece of content brands create using your likeness —
+            views, engagement, platforms, and live status — all in one place.
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full max-w-lg">
             {[
-              { label: "Brand Content Feed", desc: "All authorized content in one view" },
-              { label: "Engagement Metrics", desc: "Views, reach & engagement rates" },
+              {
+                label: "Brand Content Feed",
+                desc: "All authorized content in one view",
+              },
+              {
+                label: "Engagement Metrics",
+                desc: "Views, reach & engagement rates",
+              },
               { label: "Live Detection", desc: "Know when content goes live" },
             ].map((feature) => (
               <div
                 key={feature.label}
                 className="bg-white border border-gray-100 rounded-xl p-4 text-left shadow-sm"
               >
-                <p className="text-sm font-semibold text-gray-800 mb-1">{feature.label}</p>
+                <p className="text-sm font-semibold text-gray-800 mb-1">
+                  {feature.label}
+                </p>
                 <p className="text-xs text-gray-400">{feature.desc}</p>
               </div>
             ))}
@@ -5300,22 +5313,43 @@ export default function CreatorDashboard() {
   const confirmDeleteRecording = async () => {
     const { uiId, serverId } = deleteVoiceModal;
     if (!serverId) {
-      toast({ title: t("creatorDashboard.voice.deleteFailedTitle", "Delete failed"), description: t("creatorDashboard.voice.deleteFailedDesc", "Missing recording id."), variant: "destructive" });
+      toast({
+        title: t("creatorDashboard.voice.deleteFailedTitle", "Delete failed"),
+        description: t(
+          "creatorDashboard.voice.deleteFailedDesc",
+          "Missing recording id.",
+        ),
+        variant: "destructive",
+      });
       setDeleteVoiceModal({ open: false, uiId: null, serverId: null });
       return;
     }
     try {
       setIsDeletingVoice(true);
-      await base44.delete(`/voice/recordings/${encodeURIComponent(String(serverId))}`);
+      await base44.delete(
+        `/voice/recordings/${encodeURIComponent(String(serverId))}`,
+      );
       setVoiceLibrary((prev) =>
-        prev.filter((r) => r.id !== uiId && String(r?.server_recording_id || r?.id) !== String(serverId)),
+        prev.filter(
+          (r) =>
+            r.id !== uiId &&
+            String(r?.server_recording_id || r?.id) !== String(serverId),
+        ),
       );
       setDeleteVoiceModal({ open: false, uiId: null, serverId: null });
-      toast({ title: t("creatorDashboard.voice.deleteSuccess", "Recording deleted") });
+      toast({
+        title: t("creatorDashboard.voice.deleteSuccess", "Recording deleted"),
+      });
     } catch (err: any) {
       toast({
         title: t("creatorDashboard.voice.deleteFailedTitle", "Delete failed"),
-        description: typeof err?.message === "string" ? err.message : t("creatorDashboard.voice.deleteFailedDesc", "Failed to delete recording."),
+        description:
+          typeof err?.message === "string"
+            ? err.message
+            : t(
+                "creatorDashboard.voice.deleteFailedDesc",
+                "Failed to delete recording.",
+              ),
         variant: "destructive",
       });
     } finally {
@@ -13308,7 +13342,12 @@ export default function CreatorDashboard() {
       </Dialog>
 
       {/* Delete Voice Recording Modal */}
-      <Dialog open={deleteVoiceModal.open} onOpenChange={(open) => !isDeletingVoice && setDeleteVoiceModal((prev) => ({ ...prev, open }))}>
+      <Dialog
+        open={deleteVoiceModal.open}
+        onOpenChange={(open) =>
+          !isDeletingVoice && setDeleteVoiceModal((prev) => ({ ...prev, open }))
+        }
+      >
         <DialogContent className="max-w-sm rounded-2xl p-0 overflow-hidden">
           <div className="p-6">
             <div className="flex items-center justify-center w-14 h-14 rounded-full bg-red-50 mx-auto mb-5">
@@ -13316,10 +13355,16 @@ export default function CreatorDashboard() {
             </div>
             <DialogHeader className="text-center space-y-2 mb-6">
               <DialogTitle className="text-xl font-bold text-gray-900 text-center">
-                {t("creatorDashboard.voice.deleteConfirmation.title", "Delete Recording?")}
+                {t(
+                  "creatorDashboard.voice.deleteConfirmation.title",
+                  "Delete Recording?",
+                )}
               </DialogTitle>
               <DialogDescription className="text-gray-500 text-sm text-center leading-relaxed">
-                {t("creatorDashboard.voice.deleteConfirmation.description", "This action cannot be undone. The recording will be permanently removed.")}
+                {t(
+                  "creatorDashboard.voice.deleteConfirmation.description",
+                  "This action cannot be undone. The recording will be permanently removed.",
+                )}
               </DialogDescription>
             </DialogHeader>
             <div className="flex gap-3">
@@ -13327,7 +13372,13 @@ export default function CreatorDashboard() {
                 variant="outline"
                 className="flex-1 h-11 rounded-xl border-2 border-gray-200 font-semibold"
                 disabled={isDeletingVoice}
-                onClick={() => setDeleteVoiceModal({ open: false, uiId: null, serverId: null })}
+                onClick={() =>
+                  setDeleteVoiceModal({
+                    open: false,
+                    uiId: null,
+                    serverId: null,
+                  })
+                }
               >
                 {t("common.cancel", "Cancel")}
               </Button>
@@ -13337,9 +13388,15 @@ export default function CreatorDashboard() {
                 onClick={confirmDeleteRecording}
               >
                 {isDeletingVoice ? (
-                  <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Deleting…</>
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Deleting…
+                  </>
                 ) : (
-                  t("creatorDashboard.voice.deleteConfirmation.action", "Delete")
+                  t(
+                    "creatorDashboard.voice.deleteConfirmation.action",
+                    "Delete",
+                  )
                 )}
               </Button>
             </div>

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -3181,6 +3181,8 @@ export default function CreatorDashboard() {
   const [contractsTab, setContractsTab] = useState("active");
   const [showImageUploadModal, setShowImageUploadModal] = useState(false);
   const [showRestrictionsModal, setShowRestrictionsModal] = useState(false);
+  const [deleteVoiceModal, setDeleteVoiceModal] = useState<{ open: boolean; uiId: any; serverId: any }>({ open: false, uiId: null, serverId: null });
+  const [isDeletingVoice, setIsDeletingVoice] = useState(false);
   const [newRestriction, setNewRestriction] = useState("");
   const [newBrand, setNewBrand] = useState("");
   const [selectedImageSection, setSelectedImageSection] = useState(null);
@@ -4332,12 +4334,6 @@ export default function CreatorDashboard() {
   );
 
   const renderContent = () => {
-    const showingExamples = contentItems.length === 0;
-    const itemsToShow = showingExamples ? exampleContentItems : contentItems;
-    // For now, we don't have real detections state, so we assume empty if not showing examples
-    const detectionsToShow = showingExamples ? exampleDetections : [];
-    const detectionsCount = detectionsToShow.length;
-
     return (
       <div className="space-y-6">
         <div>
@@ -4349,131 +4345,37 @@ export default function CreatorDashboard() {
           </p>
         </div>
 
-        {showingExamples && (
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 flex gap-3">
-            <AlertCircle className="h-5 w-5 text-blue-600 shrink-0 mt-0.5" />
-            <p className="text-blue-900 text-sm">
-              {t("creatorDashboard.content.welcome.message")}
-            </p>
+        {/* Coming Soon */}
+        <div className="flex flex-col items-center justify-center py-24 px-6 bg-gradient-to-b from-gray-50 to-white rounded-2xl border border-gray-200 text-center">
+          <div className="w-20 h-20 rounded-2xl bg-[#32C8D1]/10 flex items-center justify-center mb-6 shadow-sm">
+            <Eye className="w-10 h-10 text-[#32C8D1]" />
           </div>
-        )}
-
-        {/* Tabs */}
-        <div className="border-b border-gray-200">
-          <div className="flex gap-6">
-            <button
-              onClick={() => setContentTab("brand_content")}
-              className={`pb-3 border-b-2 font-medium flex items-center gap-2 ${
-                contentTab === "brand_content"
-                  ? "border-[#32C8D1] text-[#32C8D1]"
-                  : "border-transparent text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              {t("creatorDashboard.content.tabs.brandContent")}
-              <Badge className="bg-gray-100 text-gray-900 hover:bg-gray-200 ml-1">
-                {itemsToShow.length}
-              </Badge>
-            </button>
+          <div className="inline-flex items-center gap-2 bg-[#32C8D1]/10 text-[#32C8D1] text-xs font-bold uppercase tracking-widest px-4 py-1.5 rounded-full mb-5">
+            <span className="w-1.5 h-1.5 rounded-full bg-[#32C8D1] animate-pulse" />
+            Coming Soon
+          </div>
+          <h3 className="text-2xl font-bold text-gray-900 mb-3">
+            Content Tracking
+          </h3>
+          <p className="text-gray-500 max-w-md leading-relaxed mb-8">
+            See every piece of content brands create using your likeness — views, engagement, platforms, and live status — all in one place.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full max-w-lg">
+            {[
+              { label: "Brand Content Feed", desc: "All authorized content in one view" },
+              { label: "Engagement Metrics", desc: "Views, reach & engagement rates" },
+              { label: "Live Detection", desc: "Know when content goes live" },
+            ].map((feature) => (
+              <div
+                key={feature.label}
+                className="bg-white border border-gray-100 rounded-xl p-4 text-left shadow-sm"
+              >
+                <p className="text-sm font-semibold text-gray-800 mb-1">{feature.label}</p>
+                <p className="text-xs text-gray-400">{feature.desc}</p>
+              </div>
+            ))}
           </div>
         </div>
-
-        {contentTab === "brand_content" && (
-          <>
-            <div className="flex items-center gap-2 text-sm text-blue-800 bg-blue-50 p-3 rounded-lg border border-blue-100">
-              <Eye className="h-4 w-4" />
-              {t("creatorDashboard.content.brandContent.info")}
-            </div>
-
-            {itemsToShow.length > 0 ? (
-              <div className="grid md:grid-cols-3 gap-6">
-                {itemsToShow.map((item) => (
-                  <Card
-                    key={item.id}
-                    className="overflow-hidden border border-gray-200 shadow-sm hover:shadow-md transition-shadow"
-                  >
-                    <div className="relative aspect-video bg-gray-100">
-                      <img
-                        src={item.thumbnail_url}
-                        alt={item.title}
-                        className="w-full h-full object-cover"
-                      />
-                      {item.is_live && (
-                        <Badge className="absolute top-3 right-3 bg-green-500 text-white border-none px-2 py-0.5 text-xs font-bold uppercase tracking-wide">
-                          Live
-                        </Badge>
-                      )}
-                      {item.brand_logo && (
-                        <div className="absolute bottom-3 left-3 w-8 h-8 rounded-full bg-white p-1 shadow-sm">
-                          <img
-                            src={item.brand_logo}
-                            alt={item.brand}
-                            className="w-full h-full object-contain rounded-full"
-                          />
-                        </div>
-                      )}
-                    </div>
-                    <div className="p-4">
-                      <div className="flex items-start justify-between mb-3">
-                        <div>
-                          <h3 className="font-bold text-gray-900 text-base">
-                            {item.brand}
-                          </h3>
-                          <p className="text-sm text-gray-500">
-                            {(item as any).titleKey
-                              ? t(
-                                  `creatorDashboard.content.examples.${(item as any).titleKey}`,
-                                )
-                              : item.title}
-                          </p>
-                        </div>
-                        <Badge
-                          variant="secondary"
-                          className="text-xs font-normal"
-                        >
-                          {item.platform}
-                        </Badge>
-                      </div>
-
-                      <div className="grid grid-cols-2 gap-4 pt-3 border-t border-gray-100">
-                        <div>
-                          <p className="text-xs text-gray-500 mb-0.5">
-                            {t("creatorDashboard.content.brandContent.views")}
-                          </p>
-                          <p className="font-bold text-gray-900 text-sm">
-                            {item.views}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-gray-500 mb-0.5">
-                            {t(
-                              "creatorDashboard.content.brandContent.engagement",
-                            )}
-                          </p>
-                          <p className="font-bold text-gray-900 text-sm">
-                            {item.engagement}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="mt-3 pt-3 border-t border-gray-100 text-xs text-gray-400">
-                        {t("creatorDashboard.content.brandContent.published", {
-                          date: new Date(item.published_at).toLocaleDateString(
-                            i18n.language,
-                          ),
-                        })}
-                      </div>
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            ) : (
-              <div className="text-center py-12 bg-gray-50 rounded-lg border border-gray-200">
-                <p className="text-gray-500">
-                  {t("creatorDashboard.content.brandContent.noContent")}
-                </p>
-              </div>
-            )}
-          </>
-        )}
       </div>
     );
   };
@@ -5392,30 +5294,33 @@ export default function CreatorDashboard() {
   const deleteRecording = async (id) => {
     const rec = voiceLibrary.find((r) => r.id === id);
     const sid = rec?.server_recording_id || rec?.id;
+    setDeleteVoiceModal({ open: true, uiId: id, serverId: sid });
+  };
 
-    // Create the toast first, then attach an action using `update`.
-    // This avoids a TDZ crash when passing `dismiss` into the JSX before it's initialized.
-    const tinst = toast({
-      title: t(
-        "creatorDashboard.voice.deleteConfirmation.title",
-        "Delete Recording?",
-      ),
-      description: t(
-        "creatorDashboard.voice.deleteConfirmation.description",
-        "This action cannot be undone.",
-      ),
-      variant: "destructive",
-    });
-
-    tinst.update({
-      action: (
-        <DeleteVoiceRecordingToastAction
-          uiId={id}
-          serverId={sid}
-          dismiss={tinst.dismiss}
-        />
-      ),
-    });
+  const confirmDeleteRecording = async () => {
+    const { uiId, serverId } = deleteVoiceModal;
+    if (!serverId) {
+      toast({ title: t("creatorDashboard.voice.deleteFailedTitle", "Delete failed"), description: t("creatorDashboard.voice.deleteFailedDesc", "Missing recording id."), variant: "destructive" });
+      setDeleteVoiceModal({ open: false, uiId: null, serverId: null });
+      return;
+    }
+    try {
+      setIsDeletingVoice(true);
+      await base44.delete(`/voice/recordings/${encodeURIComponent(String(serverId))}`);
+      setVoiceLibrary((prev) =>
+        prev.filter((r) => r.id !== uiId && String(r?.server_recording_id || r?.id) !== String(serverId)),
+      );
+      setDeleteVoiceModal({ open: false, uiId: null, serverId: null });
+      toast({ title: t("creatorDashboard.voice.deleteSuccess", "Recording deleted") });
+    } catch (err: any) {
+      toast({
+        title: t("creatorDashboard.voice.deleteFailedTitle", "Delete failed"),
+        description: typeof err?.message === "string" ? err.message : t("creatorDashboard.voice.deleteFailedDesc", "Failed to delete recording."),
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeletingVoice(false);
+    }
   };
 
   const createVoiceProfile = async (recording) => {
@@ -12823,6 +12728,7 @@ export default function CreatorDashboard() {
           {activeSection === "jobs" && renderJobsSection()}
           {activeSection === "approvals" && renderApprovals()}
           {activeSection === "archive" && renderCampaignArchive()}
+          {activeSection === "contracts" && renderContracts()}
           {activeSection === "earnings" && renderEarnings()}
           {activeSection === "settings" && renderSettings()}
           {activeSection === "agency-connection" && renderAgencyConnection()}
@@ -13401,6 +13307,46 @@ export default function CreatorDashboard() {
         </DialogContent>
       </Dialog>
 
+      {/* Delete Voice Recording Modal */}
+      <Dialog open={deleteVoiceModal.open} onOpenChange={(open) => !isDeletingVoice && setDeleteVoiceModal((prev) => ({ ...prev, open }))}>
+        <DialogContent className="max-w-sm rounded-2xl p-0 overflow-hidden">
+          <div className="p-6">
+            <div className="flex items-center justify-center w-14 h-14 rounded-full bg-red-50 mx-auto mb-5">
+              <Trash2 className="w-7 h-7 text-red-500" />
+            </div>
+            <DialogHeader className="text-center space-y-2 mb-6">
+              <DialogTitle className="text-xl font-bold text-gray-900 text-center">
+                {t("creatorDashboard.voice.deleteConfirmation.title", "Delete Recording?")}
+              </DialogTitle>
+              <DialogDescription className="text-gray-500 text-sm text-center leading-relaxed">
+                {t("creatorDashboard.voice.deleteConfirmation.description", "This action cannot be undone. The recording will be permanently removed.")}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                className="flex-1 h-11 rounded-xl border-2 border-gray-200 font-semibold"
+                disabled={isDeletingVoice}
+                onClick={() => setDeleteVoiceModal({ open: false, uiId: null, serverId: null })}
+              >
+                {t("common.cancel", "Cancel")}
+              </Button>
+              <Button
+                className="flex-1 h-11 rounded-xl bg-red-500 hover:bg-red-600 text-white font-semibold shadow-sm"
+                disabled={isDeletingVoice}
+                onClick={confirmDeleteRecording}
+              >
+                {isDeletingVoice ? (
+                  <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Deleting…</>
+                ) : (
+                  t("creatorDashboard.voice.deleteConfirmation.action", "Delete")
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       {/* Revoke License Modal */}
       <Dialog open={showRevokeModal} onOpenChange={setShowRevokeModal}>
         <DialogContent className="max-w-2xl">
@@ -13596,44 +13542,6 @@ export default function CreatorDashboard() {
                         {section.bestFor}
                       </p>
                     </div>
-
-                    <Card className="p-4 bg-gray-50 border border-gray-200">
-                      <h4 className="font-bold text-gray-900 mb-3">
-                        {t("creatorDashboard.uploadModal.requirementsTitle")}
-                      </h4>
-                      <div className="space-y-2 text-sm text-gray-700">
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>{t("creatorDashboard.uploadModal.resolution")}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>{t("creatorDashboard.uploadModal.faceVisible")}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>
-                            {t("creatorDashboard.uploadModal.goodLighting")}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>{t("creatorDashboard.uploadModal.recentPhoto")}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>{t("creatorDashboard.uploadModal.noFilters")}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <CheckSquare className="w-4 h-4 text-green-600" />
-                          <p>
-                            {t(
-                              "creatorDashboard.uploadModal.professionalQuality",
-                            )}
-                          </p>
-                        </div>
-                      </div>
-                    </Card>
 
                     <div className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-[#32C8D1] transition-colors">
                       <input


### PR DESCRIPTION
**Title:** Fix/polish: creator dashboard, brand contract hub, 
**Description:**

**Creator Dashboard**
- Billing plan no longer flashes "Free" on refresh — 3-layer cache (localStorage seed → React Query → background revalidation)
- Voice recording delete replaced destructive toast with a proper confirmation modal
- Content tab: mock Nike/Glossier/Tesla data removed, replaced with Coming Soon screen
- Licenses & Contracts tab was blank — `renderContracts()` was missing from the section render switch
- Requirements Checklist removed from likeness image upload modal

**Brand Contract Hub (Creator Contracts tab)**
- Creator name was showing "Unknown Creator" — now reads from `offer.target_name`
- Resend creates a fresh DocuSeal submission (`force_new_submission` flag) so brand always gets a new unsigned URL
- Download button checks `signed_document_url` and `meta` fields in priority order
- Status labels: "Sign Required" (opened), "Awaiting Creator" (partially\_signed/signed), "Completed"


**Backend**
- `send_offer_contract` accepts `force_new_submission: bool` to always create a fresh DocuSeal submission
- `resolve_agency_talent` replaced with `resolve_creator_id_for_assignment` — uses `creator_id` as canonical identity, independent connected creators (no `agency_users` row) now assign correctly
- Assigned talent name in agency offer detail falls back to `creators.full_name` for independent creators
