### PR TITLE
Fix/nginx upload size limit and error handling

### DIFF
--- a/deploy/ec2/nginx.conf
+++ b/deploy/ec2/nginx.conf
@@ -57,6 +57,15 @@ http {
     # Forward real IP headers (if behind another proxy, adjust as needed)
     real_ip_header X-Forwarded-For;
 
+    # Custom error page for 413 Payload Too Large - return user-friendly JSON
+    error_page 413 = @error_413;
+
+    # Custom error handler for 413 errors
+    location @error_413 {
+      default_type application/json;
+      return 413 '{"error":"Payload Too Large","message":"The file you are trying to upload exceeds the 20MB limit. Please choose a smaller file."}';
+    }
+
     location /api/ {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;

--- a/deploy/ec2/nginx.http.conf
+++ b/deploy/ec2/nginx.http.conf
@@ -15,6 +15,14 @@ http {
   gzip_proxied any;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
+  # Allow file uploads up to 25 MB (application limit is 20 MB; extra headroom
+  # for multipart overhead and metadata). Without this nginx defaults to 1 MB
+  # and returns 413 before the request reaches the backend or Supabase.
+  client_max_body_size 25M;
+
+  # Custom error page for 413 Payload Too Large - return user-friendly JSON
+  error_page 413 = @error_413;
+
   upstream ui_upstream { server ui:8080; }
   upstream api_upstream { server server:8787; }
 
@@ -22,6 +30,15 @@ http {
   server {
     listen 80;
     server_name likelee.ai;
+
+    # Custom error page for 413 Payload Too Large - return user-friendly JSON
+    error_page 413 = @error_413;
+
+    # Custom error handler for 413 errors
+    location @error_413 {
+      default_type application/json;
+      return 413 '{"error":"Payload Too Large","message":"The file you are trying to upload exceeds the 20MB limit. Please choose a smaller file."}';
+    }
 
     location ^~ /.well-known/acme-challenge/ {
       root /var/www/certbot;
@@ -52,6 +69,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      client_max_body_size 25M;
       proxy_pass http://api_upstream;
     }
 

--- a/deploy/ec2/nginx.staging.conf
+++ b/deploy/ec2/nginx.staging.conf
@@ -18,6 +18,14 @@ http {
   # Docker DNS resolver for dynamic container IP resolution
   resolver 127.0.0.11 valid=10s;
 
+  # Allow file uploads up to 25 MB (application limit is 20 MB; extra headroom
+  # for multipart overhead and metadata). Without this nginx defaults to 1 MB
+  # and returns 413 before the request reaches the backend or Supabase.
+  client_max_body_size 25M;
+
+  # Custom error page for 413 Payload Too Large - return user-friendly JSON
+  error_page 413 = @error_413;
+
   server {
     listen 80;
     server_name likelee.rustcameroon.com;
@@ -28,7 +36,14 @@ http {
       return 200 "ok\n";
     }
 
+    # Custom error handler for 413 errors
+    location @error_413 {
+      default_type application/json;
+      return 413 '{"error":"Payload Too Large","message":"The file you are trying to upload exceeds the 20MB limit. Please choose a smaller file."}';
+    }
+
     location /api/ {
+      client_max_body_size 25M;
       set $api_backend http://server:8787;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Add client_max_body_size 25M to nginx.staging.conf (was missing, causing 1MB default limit)
- Add client_max_body_size 25M to nginx.http.conf for consistency
- Configure custom 413 error responses returning user-friendly JSON instead of raw nginx messages
- Ensures uploads up to 20MB (app limit) work correctly with 25MB nginx headroom for multipart overhead

Fixes issue where staging environment rejected uploads due to missing size limit configuration."