### PR TITLE
Offers payrelease

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -68,10 +68,22 @@ Tokens are obtained via Supabase Auth (client-side login). The backend validates
 
 These endpoints are agency-only and require the `manage_billing` permission. They are only meaningful after `escrow_status = "released"` (i.e. after the brand has approved at least one deliverable).
 
-| Method | Path                                                        | Description                                                                 |
-| ------ | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
-| GET    | `/api/agency/campaign-offers/:offer_id/transfer-status`     | Live Stripe account health + transfer row status for every recipient        |
-| POST   | `/api/agency/campaign-offers/:offer_id/retry-transfers`     | Retry all failed Stripe transfers for an offer                              |
+| Method | Path                                                              | Description                                                                 |
+| ------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| GET    | `/api/agency/campaign-offers/:offer_id/stripe-readiness`          | Pre-flight Stripe connectivity check for agency + all assigned talents      |
+| GET    | `/api/agency/campaign-offers/:offer_id/transfer-status`           | Live Stripe account health + transfer row status for every recipient        |
+| POST   | `/api/agency/campaign-offers/:offer_id/retry-transfers`           | Retry all failed Stripe transfers for an offer                              |
+
+#### Stripe Readiness Response
+
+Called before sending a contract. Returns per-party connectivity status and two aggregate flags:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agency` | object | Agency party with `connected`, `transfers_enabled`, `details_submitted` |
+| `talents` | array | One entry per assigned talent, same fields |
+| `all_connected` | bool | `false` → hard block, contract cannot be sent |
+| `all_transfers_enabled` | bool | `false` (but `all_connected = true`) → soft warning, can send |
 
 #### Transfer Status Response Fields (per recipient)
 

--- a/docs/guides/DEVELOPER_QUICK_REFERENCE.md
+++ b/docs/guides/DEVELOPER_QUICK_REFERENCE.md
@@ -209,7 +209,7 @@ Before sending a DocuSeal contract, the agency UI checks Stripe readiness for al
 | Hard block | Agency OR any talent has no Stripe account connected | Contract cannot be sent |
 | Soft warning | All connected but some `transfers_enabled = false` | Can send with warning; retry transfers after onboarding |
 
-This prevents the escrow from getting stuck in `releasing` for new offers going forward.
+**Why the brand is never exposed to Stripe issues:** The brand's obligation ends when they pay and approve. Whether the agency or talent can receive a Stripe transfer is an internal operational matter between the platform and the payee — surfacing it to the brand would be confusing and damaging to trust. The readiness gate enforces this at the contract send step: by the time a brand is approving deliverables, all parties are guaranteed to have at least a connected Stripe account. The only remaining edge case (`transfers_enabled = false`) was explicitly shown to the agency before they sent the contract, and is resolved independently via the retry button — no brand involvement needed.
 
 ### API Endpoints
 

--- a/docs/guides/DEVELOPER_QUICK_REFERENCE.md
+++ b/docs/guides/DEVELOPER_QUICK_REFERENCE.md
@@ -213,11 +213,20 @@ Before sending a DocuSeal contract, the agency UI checks Stripe readiness for al
 
 ### API Endpoints
 
+#### Agency Offer Endpoints
+
 | Method | Path | Permission Required |
 |--------|------|---------------------|
 | `GET` | `/api/agency/campaign-offers/:offer_id/stripe-readiness` | `manage_billing` |
 | `GET` | `/api/agency/campaign-offers/:offer_id/transfer-status` | `manage_billing` |
 | `POST` | `/api/agency/campaign-offers/:offer_id/retry-transfers` | `manage_billing` |
+
+#### Independent Creator Offer Endpoints
+
+| Method | Path | Auth |
+|--------|------|------|
+| `GET` | `/api/talent/campaign-offers/transfer-status` | Creator session |
+| `POST` | `/api/talent/campaign-offers/:offer_id/retry-transfer` | Creator session (owns offer) |
 
 ### DB Changes (migration `2026-04-22_campaign_offer_transfer_retry.sql`)
 
@@ -234,6 +243,8 @@ New RPCs:
 
 ### Frontend
 
+#### Agency Deliverables View
+
 The **Payout Status** panel in `AgencyDeliverablesView` renders automatically when `offer.escrow_status === "released"` and the offer card is expanded. It shows:
 - Per-recipient row: name, type, amount, Stripe health, transfer status badge
 - Human-readable failure reasons mapped from Stripe error codes
@@ -241,6 +252,23 @@ The **Payout Status** panel in `AgencyDeliverablesView` renders automatically wh
 - **Retry failed** button (only when at least one transfer has `status: failed`)
 
 The **Stripe Readiness Gate** in `BrandConnectionsView` fires when the agency clicks "Send" on a contract. It calls `/stripe-readiness` and shows a polished modal with per-party status before allowing the DocuSeal submission to be created.
+
+#### Creator Dashboard
+
+The **Payout Status** panel in `CreatorDashboard` shows all independent creator offers (`target_type === "creator"`) where escrow has been released. Features:
+
+- **Automatic display** when creator has any independent offers with `escrow_status = "released"`
+- **Visual status indicators:**
+  - ✅ **"Paid"** (green) — `transfer_status = "created"` — funds in Stripe account
+  - ⚠️ **"Failed"** (amber) — `transfer_status = "failed"` — shows **"Claim payment"** button
+  - 🔄 **"Retrying"** (blue) — `transfer_status = "pending_retry"` — retry in progress
+  - 🕐 **"Pending"** (gray) — other states
+- **Self-service retry:** "Claim payment" button calls `POST /api/talent/campaign-offers/:offer_id/retry-transfer`
+- **Stripe readiness gate:** Before submitting deliverables, checks if Stripe account is connected:
+  - **Hard block** if not connected → forces creator to Payouts settings
+  - **Soft warning** if `transfers_enabled = false` → warns but allows submission
+
+**Key difference from agency flow:** Independent creators can only retry their own offers. Agency talent splits are handled by the agency, not self-service.
 
 ### Stripe Error Code Mapping (Frontend)
 
@@ -251,3 +279,181 @@ The **Stripe Readiness Gate** in `BrandConnectionsView` fires when the agency cl
 | `payouts_not_allowed` | Payouts not allowed on this Stripe account |
 | `balance_insufficient` | Platform balance insufficient — contact support |
 | No Stripe account | No Stripe account connected. Ask them to complete Stripe onboarding |
+
+---
+
+## Independent Creator Offer Payment Flow
+
+### Overview
+
+Independent creator offers (`target_type = "creator"`) follow a simplified payment flow compared to agency offers. When a brand approves a deliverable, the full offer amount is transferred directly to the creator's Stripe account. No talent splits, no agency intermediary.
+
+### Stripe Readiness Gates
+
+**Two prevention points** ensure creators can receive payment before they submit work:
+
+#### 1. Deliverable Submission Gate (Backend)
+
+When a creator submits a deliverable (final or draft), the backend checks:
+
+```rust
+// In submit_offer_deliverable() and submit_draft_deliverables()
+if is_creator_like(&user.role) && target_type == "creator" {
+    let stripe_account = get_creator_stripe_account(&state, &creator_id).await;
+    if stripe_account.is_empty() {
+        return Err(402 PAYMENT_REQUIRED, "stripe_account_required: Connect your Stripe account...");
+    }
+}
+```
+
+**Result:** Creator cannot submit deliverables until Stripe is connected.
+
+#### 2. Deliverable Submission Gate (Frontend)
+
+Before opening the deliverable submission modal, `CreatorDashboard` checks `payoutAccountStatus`:
+
+```typescript
+if (!payoutAccountStatus?.connected) {
+  // Hard block: show modal forcing user to Payouts
+  setStripeGateModalConfig({
+    severity: "block",
+    title: "Connect Stripe to submit deliverables",
+    description: "You need to connect your Stripe account before submitting deliverables...",
+    actions: [{ label: "Go to Payouts", onClick: () => setShowPayoutSettings(true) }]
+  });
+  return;
+}
+
+if (payoutAccountStatus?.connected && !payoutAccountStatus?.transfers_enabled) {
+  // Soft warning: warn but allow submission
+  setStripeGateModalConfig({
+    severity: "warning",
+    title: "Stripe transfers not fully enabled",
+    description: "Complete your Stripe onboarding to ensure you get paid on time. You can still submit now.",
+    actions: [
+      { label: "Submit anyway", onClick: () => openDeliverableModal() },
+      { label: "Go to Payouts", onClick: () => setShowPayoutSettings(true) }
+    ]
+  });
+  return;
+}
+```
+
+**Result:** Creator is warned/blocked before wasting time on deliverables they can't get paid for.
+
+### Self-Service Transfer Retry
+
+When a transfer fails (e.g., `transfers_enabled` was false at approval time), creators can retry from their dashboard.
+
+#### Retry Endpoint: `POST /api/talent/campaign-offers/:offer_id/retry-transfer`
+
+**Guards:**
+1. User must be a creator
+2. Offer must belong to this creator (`target_type = "creator"`, `target_id = creator_id`)
+3. Escrow must be `"released"` (brand already approved)
+4. A failed transfer row must exist (`status = "failed"`)
+
+**Flow:**
+1. Verify offer ownership and escrow status
+2. Find failed transfer row for this creator
+3. Get creator's **current** Stripe account (may have been fixed since failure)
+4. Mark transfer as `"pending_retry"` via RPC
+5. Execute Stripe transfer via `execute_and_record_stripe_transfer()`
+6. Return success/failure to frontend
+
+**Key insight:** Uses the **current** Stripe account, so creators can fix their setup then retry.
+
+#### Frontend Retry Flow
+
+In `CreatorDashboard`, the **Payout Status** panel shows failed transfers with a "Claim payment" button:
+
+```typescript
+const retryCreatorTransfer = async (offerId: string) => {
+  try {
+    const resp = await base44.post(`/api/talent/campaign-offers/${offerId}/retry-transfer`);
+    if (resp?.status === "ok") {
+      // Show success modal
+      setStripeGateModalConfig({
+        severity: "info",
+        title: "Transfer succeeded",
+        description: "Funds are on their way to your Stripe account.",
+        actions: [{ label: "Done", onClick: () => setStripeGateModalOpen(false) }]
+      });
+      await refreshCreatorTransfers();
+    }
+  } catch (err) {
+    // Show error modal with "Go to Payouts" action
+  }
+};
+```
+
+**One retry at a time:** `retryingTransferOfferId` state prevents concurrent retries.
+
+### Transfer Status Display
+
+The `campaign_offer_transfers` table includes a `target_type` field to distinguish:
+- **`"creator"`** = independent offer (creator can self-service retry)
+- **`"agency"`** = talent split from agency offer (agency handles retry)
+
+Frontend filters by `target_type === "creator"` to show only independent offers in the creator's Payout Status panel.
+
+### Data Flow Summary
+
+**Prevention Flow (Deliverable Submission):**
+```
+Creator clicks "Submit Deliverable"
+  → Frontend checks payoutAccountStatus
+    → If !connected: Block with modal
+    → If !transfers_enabled: Warn but allow
+  → Backend checks Stripe account on submission
+    → If empty: Return 402 PAYMENT_REQUIRED
+  → Deliverable submitted successfully
+```
+
+**Recovery Flow (Failed Transfer Retry):**
+```
+Creator sees "Failed" transfer in Payout Status panel
+  → Clicks "Claim payment" button
+  → Frontend calls POST /api/talent/campaign-offers/:offer_id/retry-transfer
+    → Backend verifies:
+      - Offer belongs to creator
+      - Escrow is released
+      - Failed transfer exists
+    → Fetches current Stripe account
+    → Marks transfer as pending_retry
+    → Executes Stripe transfer
+      → Success: Returns transfer_id
+      → Failure: Returns error message
+  → Frontend shows modal with result
+    → Success: "Funds are on their way"
+    → Failure: "Go to Payouts to fix Stripe setup"
+```
+
+### Key Design Decisions
+
+1. **Only for independent creator offers** — Agency talent splits are handled by the agency, not self-service
+2. **Escrow must be released** — Can't retry if brand hasn't approved yet
+3. **Uses current Stripe account** — Allows creators to fix their Stripe setup then retry
+4. **Idempotent retry** — If no failed transfer exists, returns `nothing_to_retry: true`
+5. **One retry at a time** — `retryingTransferOfferId` state prevents concurrent retries
+6. **Reuses existing transfer infrastructure** — Calls `execute_and_record_stripe_transfer()` and `record_campaign_offer_transfer` RPC
+
+### Files Involved
+
+**Backend:**
+- `likelee-server/src/brand_campaigns.rs`:
+  - `submit_offer_deliverable()` — Stripe readiness gate
+  - `submit_draft_deliverables()` — Stripe readiness gate
+  - `get_creator_transfer_status()` — Fetch creator's transfer status
+  - `retry_creator_transfer()` — Self-service retry endpoint
+
+**Frontend:**
+- `likelee-ui/src/pages/CreatorDashboard.tsx`:
+  - Payout Status panel rendering
+  - Stripe readiness gate modal
+  - `retryCreatorTransfer()` function
+  - `fetchCreatorTransfers()` polling
+
+**Database:**
+- `supabase/migrations/2026-04-22_campaign_offer_transfer_retry.sql` — Transfer retry columns and RPCs
+- `campaign_offer_transfers.target_type` — Distinguishes independent vs agency offers

--- a/docs/guides/DEVELOPER_QUICK_REFERENCE.md
+++ b/docs/guides/DEVELOPER_QUICK_REFERENCE.md
@@ -159,15 +159,29 @@ likelee-ui/
 
 ---
 
-## Campaign Offer Transfer Retry System
+## Campaign Offer Transfer & Escrow System
 
 ### Overview
 
-When a brand approves a deliverable, escrow is released and Stripe transfers are attempted per recipient (agency + assigned talents). Transfers can fail silently if a recipient's Stripe account is not fully onboarded. The retry system allows agencies to recover from these failures without any manual platform intervention.
+When a brand approves a deliverable, escrow is released and Stripe transfers are attempted per recipient (agency + assigned talents). Transfers can fail if a recipient's Stripe account is not fully onboarded. The system is designed to be resilient — individual transfer failures never block the escrow release or other recipients' transfers. Failed transfers are retryable from the agency Deliverables tab.
 
-### Key Principle
+### Key Principles
 
 **Escrow release is always permanent after brand approval.** It represents the brand's obligation being fulfilled. Transfer failures are an operational concern — funds remain on the platform's Stripe balance until a retry succeeds.
+
+**Transfers are best-effort and independent.** A failed agency transfer does not block talent transfers, and a failed talent transfer does not block others. Every recipient is attempted regardless of what happens to others.
+
+**Approving 1 deliverable triggers escrow release.** The threshold is `approved_count >= 1` — the first brand-approved deliverable unlocks the escrow and initiates all transfers.
+
+### Escrow State Machine
+
+```
+holding    → releasing  (atomic claim on first approval)
+releasing  → released   (after all transfers attempted — always, even if some fail)
+released   → released   (permanent — idempotent)
+```
+
+**Recovery from stuck `releasing`:** If a previous release attempt was interrupted (e.g. server crash mid-transfer), the next deliverable approval detects failed transfer rows and automatically retries the full release. No manual SQL intervention needed for new offers.
 
 ### Transfer Status Flow
 
@@ -186,10 +200,22 @@ The retry endpoint enforces two hard guards:
 1. `escrow_status` must be `"released"` — prevents premature transfers
 2. Only rows with `status = "failed"` are processed — never re-transfers succeeded rows
 
-### New API Endpoints
+### Contract Send Gate (Stripe Readiness)
+
+Before sending a DocuSeal contract, the agency UI checks Stripe readiness for all parties via `GET /api/agency/campaign-offers/:offer_id/stripe-readiness`. Two-tier result:
+
+| Gate | Condition | Action |
+|------|-----------|--------|
+| Hard block | Agency OR any talent has no Stripe account connected | Contract cannot be sent |
+| Soft warning | All connected but some `transfers_enabled = false` | Can send with warning; retry transfers after onboarding |
+
+This prevents the escrow from getting stuck in `releasing` for new offers going forward.
+
+### API Endpoints
 
 | Method | Path | Permission Required |
 |--------|------|---------------------|
+| `GET` | `/api/agency/campaign-offers/:offer_id/stripe-readiness` | `manage_billing` |
 | `GET` | `/api/agency/campaign-offers/:offer_id/transfer-status` | `manage_billing` |
 | `POST` | `/api/agency/campaign-offers/:offer_id/retry-transfers` | `manage_billing` |
 
@@ -213,6 +239,8 @@ The **Payout Status** panel in `AgencyDeliverablesView` renders automatically wh
 - Human-readable failure reasons mapped from Stripe error codes
 - **Refresh** button to re-poll
 - **Retry failed** button (only when at least one transfer has `status: failed`)
+
+The **Stripe Readiness Gate** in `BrandConnectionsView` fires when the agency clicks "Send" on a contract. It calls `/stripe-readiness` and shows a polished modal with per-party status before allowing the DocuSeal submission to be created.
 
 ### Stripe Error Code Mapping (Frontend)
 

--- a/docs/guides/DEVELOPER_QUICK_REFERENCE.md
+++ b/docs/guides/DEVELOPER_QUICK_REFERENCE.md
@@ -181,7 +181,7 @@ releasing  → released   (after all transfers attempted — always, even if som
 released   → released   (permanent — idempotent)
 ```
 
-**Recovery from stuck `releasing`:** If a previous release attempt was interrupted (e.g. server crash mid-transfer), the next deliverable approval detects failed transfer rows and automatically retries the full release. No manual SQL intervention needed for new offers.
+**Recovery from stuck `releasing`:** If a previous release attempt was interrupted before our fix (offer stuck in `releasing` with failed transfers), the next deliverable approval detects the failed transfer rows and automatically retries the full release. This only applies to pre-existing stuck offers — for all new offers, `escrow_status` is always set to `"released"` immediately after the first approval regardless of transfer outcomes, and failed transfers are recovered via the manual retry button in the agency Deliverables tab.
 
 ### Transfer Status Flow
 

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -11184,7 +11184,8 @@ pub async fn retry_creator_transfer(
     if escrow_status != "released" {
         return Err((
             StatusCode::BAD_REQUEST,
-            "escrow_not_released: The brand has not yet approved a deliverable for this offer.".to_string(),
+            "escrow_not_released: The brand has not yet approved a deliverable for this offer."
+                .to_string(),
         ));
     }
 

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -8413,8 +8413,7 @@ async fn try_release_campaign_offer_escrow(
                 Ok(t) => t,
                 Err(_) => return false,
             };
-            let rows: Vec<serde_json::Value> =
-                serde_json::from_str(&text).unwrap_or_default();
+            let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
             !rows.is_empty()
         }
         .await;
@@ -9840,8 +9839,7 @@ pub async fn get_offer_stripe_readiness(
     Path(offer_id): Path<String>,
 ) -> Result<Json<OfferStripeReadinessResponse>, (StatusCode, String)> {
     // Agency-only — must have billing visibility to see payout readiness
-    let access =
-        team::require_agency_permission(&state, &user, Permission::ManageBilling).await?;
+    let access = team::require_agency_permission(&state, &user, Permission::ManageBilling).await?;
     let agency_id = access.organization_id.clone();
 
     // Verify the offer belongs to this agency
@@ -10139,8 +10137,7 @@ pub async fn get_offer_stripe_readiness(
         })
         .collect();
 
-    let talent_parties: Vec<StripeReadinessParty> =
-        futures::future::join_all(talent_futures).await;
+    let talent_parties: Vec<StripeReadinessParty> = futures::future::join_all(talent_futures).await;
 
     // Compute aggregate flags
     let all_connected = ag_connected && talent_parties.iter().all(|p| p.connected);

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -6936,9 +6936,11 @@ pub async fn upload_offer_deliverable(
 
     let file_name = format!("{}_{}_{}.{}", offer_id, user.id, Uuid::new_v4(), ext);
     let path = format!("offer-deliverables/{}/{}", user.id, file_name);
+    // Store in the private bucket — deliverables are served exclusively through the
+    // authenticated /api/.../file endpoint which enforces payment and access gates.
     let storage_url = format!(
         "{}/storage/v1/object/{}/{}",
-        state.supabase_url, state.supabase_bucket_public, path
+        state.supabase_url, state.supabase_bucket_private, path
     );
 
     let client = Client::new();
@@ -6963,13 +6965,11 @@ pub async fn upload_offer_deliverable(
         ));
     }
 
-    let public_url = format!(
-        "{}/storage/v1/object/public/{}/{}",
-        state.supabase_url, state.supabase_bucket_public, path
-    );
+    // Return the storage path (not a public URL) — the frontend uses the secure
+    // /api/campaign-offers/:offer_id/deliverables/:id/file endpoint to display assets.
     Ok(Json(json!({
         "status": "ok",
-        "public_url": public_url,
+        "public_url": path,
         "file_name": file_name,
         "content_type": content_type,
     })))
@@ -7337,19 +7337,18 @@ pub async fn list_offer_deliverables(
     }
     let mut rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
 
-    // Normalize asset_url to consistently return the secure file endpoint
-    // for private deliverables instead of the storage path
+    // Always replace asset_url with the secure authenticated file endpoint.
+    // Deliverables are stored in the private bucket and must never be served
+    // via a direct public URL — all access goes through the backend which
+    // enforces payment gates, role checks, and download controls.
     for row in rows.iter_mut() {
         if let Some(obj) = row.as_object_mut() {
             if let Some(id) = obj.get("id").and_then(|v| v.as_str()) {
-                // Replace asset_url with the secure file endpoint URL
                 let secure_url =
                     format!("/api/campaign-offers/{}/deliverables/{}/file", offer_id, id);
                 obj.insert("asset_url".to_string(), json!(secure_url));
             }
-
-            // If the brand hasn't paid yet, keep deliverables visible but mark them as locked
-            // for approval/download. Preview is allowed to support review workflows.
+            // If the brand hasn't paid yet, mark deliverables as locked
             if user.role == "brand" && payment_status != "paid" {
                 let meta = obj.get("meta").cloned().unwrap_or_else(|| json!({}));
                 let mut meta_obj = meta.as_object().cloned().unwrap_or_default();

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -6,7 +6,6 @@ use crate::{
         brand_allows_campaign_collaboration, brand_campaign_limit, get_brand_plan_tier, PlanTier,
     },
     errors::sanitize_db_error,
-    pricing_defaults::should_default_visibility_on,
     services::docuseal::{DocuSealClient, Submitter},
     storage::{
         canonical_object_path, delete_object, download_object, insert_asset_record,
@@ -2439,28 +2438,12 @@ pub async fn list_offer_options(
         return Err(sanitize_db_error(status.as_u16(), text));
     }
     let rows: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap_or_default();
+    // Connected creators are always shown regardless of their public visibility settings.
+    // The brand-creator connection itself is the authorization — a creator who has connected
+    // with this brand should always appear in the offer collaborator list even if their
+    // public profile is set to private.
     let items: Vec<serde_json::Value> = rows
         .into_iter()
-        .filter(|r| {
-            let public_profile_visible = r.get("public_profile_visible").and_then(|v| v.as_bool());
-            let visibility = r
-                .get("visibility")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .trim()
-                .to_lowercase();
-            match public_profile_visible {
-                Some(true) => true,
-                Some(false) => should_default_visibility_on(r),
-                None => {
-                    visibility.is_empty()
-                        || visibility == "public"
-                        || visibility == "brands"
-                        || visibility == "visible_to_brands"
-                        || visibility == "true"
-                }
-            }
-        })
         .map(|r| {
             let monthly = r
                 .get("base_weekly_price_cents")

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -6538,6 +6538,32 @@ pub async fn submit_offer_deliverable(
         }
     }
 
+    // Stripe readiness gate for independent creator offers.
+    // Creators must have a connected Stripe account before submitting deliverables.
+    // This ensures the escrow transfer will succeed when the brand approves.
+    // We check connectivity (account exists) as a hard block, and warn on transfers_enabled = false.
+    if is_creator_like(&user.role) {
+        let target_type = _offer
+            .get("target_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_lowercase();
+        if target_type == "creator" {
+            let resolved_creator = resolve_effective_creator_id(&state, &user).await;
+            if !resolved_creator.is_empty() {
+                let stripe_account = get_creator_stripe_account(&state, &resolved_creator)
+                    .await
+                    .unwrap_or_default();
+                if stripe_account.is_empty() {
+                    return Err((
+                        StatusCode::PAYMENT_REQUIRED,
+                        "stripe_account_required: Connect your Stripe account in Payouts before submitting deliverables. This ensures you get paid when the brand approves your work.".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
     let offer_brand_id = _offer
         .get("brand_id")
         .and_then(|v| v.as_str())
@@ -7751,6 +7777,29 @@ pub async fn submit_draft_deliverables(
         // Additional restriction: unpaid deliverables may only be submitted after the offer is signed.
         if !offer_status_is_signed(&_offer) {
             return Err((StatusCode::BAD_REQUEST, "offer_not_signed".to_string()));
+        }
+    }
+
+    // Stripe readiness gate for independent creator offers (same as submit_offer_deliverable).
+    if is_creator_like(&user.role) {
+        let target_type = _offer
+            .get("target_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_lowercase();
+        if target_type == "creator" {
+            let resolved_creator = resolve_effective_creator_id(&state, &user).await;
+            if !resolved_creator.is_empty() {
+                let stripe_account = get_creator_stripe_account(&state, &resolved_creator)
+                    .await
+                    .unwrap_or_default();
+                if stripe_account.is_empty() {
+                    return Err((
+                        StatusCode::PAYMENT_REQUIRED,
+                        "stripe_account_required: Connect your Stripe account in Payouts before submitting deliverables. This ensures you get paid when the brand approves your work.".to_string(),
+                    ));
+                }
+            }
         }
     }
 
@@ -10930,6 +10979,9 @@ pub struct CreatorTransferRow {
     pub stripe_transfer_id: Option<String>,
     pub escrow_status: String,
     pub paid_at: Option<String>,
+    /// "creator" = independent offer (creator can self-service retry)
+    /// "agency"  = talent split from agency offer (agency handles retry)
+    pub target_type: String,
 }
 
 pub async fn get_creator_transfer_status(
@@ -10978,11 +11030,12 @@ pub async fn get_creator_transfer_status(
         .into_iter()
         .collect();
 
-    // Fetch offer metadata in one query
+    // Fetch offer metadata in one query — include target_type to distinguish
+    // independent creator offers from agency talent-split offers
     let offers_resp = state
         .pg
         .from("campaign_offers")
-        .select("id,offer_title,escrow_status,paid_at,brands(company_name),brand_campaigns(name)")
+        .select("id,offer_title,escrow_status,paid_at,target_type,brands(company_name),brand_campaigns(name)")
         .in_(
             "id",
             offer_ids.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
@@ -11071,8 +11124,220 @@ pub async fn get_creator_transfer_status(
                 .get("paid_at")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
+            target_type: offer
+                .get("target_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("agency")
+                .to_string(),
         });
     }
 
     Ok(Json(json!({ "transfers": result })))
+}
+
+// =============================================================================
+// POST /api/talent/campaign-offers/:offer_id/retry-transfer
+//
+// Self-service retry for independent creator offers where the Stripe transfer
+// failed (e.g. transfers_enabled was false at the time of escrow release).
+//
+// Guards:
+//   - Creator must own the offer (target_type=creator, target_id=creator_id)
+//   - escrow_status must be "released" (brand already approved)
+//   - A failed transfer row must exist for this creator on this offer
+// =============================================================================
+
+pub async fn retry_creator_transfer(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(offer_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if !is_creator_like(&user.role) {
+        return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
+    }
+
+    let creator_id = resolve_effective_creator_id(&state, &user).await;
+    if creator_id.is_empty() {
+        return Err((StatusCode::UNAUTHORIZED, "creator_not_found".to_string()));
+    }
+
+    // Verify the offer belongs to this creator
+    let offer_resp = state
+        .pg
+        .from("campaign_offers")
+        .select("id,target_type,target_id,escrow_status,payment_status,budget_snapshot")
+        .eq("id", &offer_id)
+        .eq("target_type", "creator")
+        .eq("target_id", &creator_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !offer_resp.status().is_success() {
+        return Err(sanitize_db_error(
+            offer_resp.status().as_u16(),
+            offer_resp.text().await.unwrap_or_default(),
+        ));
+    }
+    let offer_text = offer_resp.text().await.unwrap_or_else(|_| "[]".into());
+    let offer_rows: Vec<serde_json::Value> = serde_json::from_str(&offer_text).unwrap_or_default();
+    let offer = offer_rows
+        .first()
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "offer_not_found".to_string()))?;
+
+    // Hard gate: escrow must be released (brand approved)
+    let escrow_status = offer
+        .get("escrow_status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("holding");
+    if escrow_status != "released" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "escrow_not_released: The brand has not yet approved a deliverable for this offer.".to_string(),
+        ));
+    }
+
+    // Find the failed transfer row for this creator
+    let transfer_resp = state
+        .pg
+        .from("campaign_offer_transfers")
+        .select("id,amount_cents,currency,status,retry_count")
+        .eq("offer_id", &offer_id)
+        .eq("recipient_type", "creator")
+        .eq("recipient_id", &creator_id)
+        .eq("status", "failed")
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !transfer_resp.status().is_success() {
+        return Err(sanitize_db_error(
+            transfer_resp.status().as_u16(),
+            transfer_resp.text().await.unwrap_or_default(),
+        ));
+    }
+    let transfer_text = transfer_resp.text().await.unwrap_or_else(|_| "[]".into());
+    let transfer_rows: Vec<serde_json::Value> =
+        serde_json::from_str(&transfer_text).unwrap_or_default();
+
+    if transfer_rows.is_empty() {
+        return Ok(Json(json!({
+            "status": "ok",
+            "nothing_to_retry": true,
+            "message": "No failed transfer found for this offer."
+        })));
+    }
+
+    let transfer = &transfer_rows[0];
+    let amount_cents = transfer
+        .get("amount_cents")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    if amount_cents <= 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "invalid_transfer_amount".to_string(),
+        ));
+    }
+
+    // Resolve the creator's current Stripe account (may have been updated since original failure)
+    let stripe_account_id = get_creator_stripe_account(&state, &creator_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("stripe_account_not_connected: {}", e),
+            )
+        })?;
+
+    // Resolve currency from the transfer row, fall back to budget_snapshot
+    let currency = transfer
+        .get("currency")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            offer
+                .get("budget_snapshot")
+                .and_then(|v| v.get("currency_code"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| "USD".to_string());
+
+    let currency_enum = stripe_sdk::Currency::from_str(&currency.to_lowercase()).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("unsupported_currency: {}", currency),
+        )
+    })?;
+
+    // Mark as pending_retry before attempting
+    let _ = state
+        .pg
+        .rpc(
+            "mark_transfer_pending_retry",
+            json!({
+                "p_offer_id": offer_id,
+                "p_recipient_type": "creator",
+                "p_recipient_id": creator_id,
+            })
+            .to_string(),
+        )
+        .execute()
+        .await;
+
+    let client = stripe_sdk::Client::new(state.stripe_secret_key.clone());
+    let metadata = std::collections::HashMap::from([
+        ("offer_id".to_string(), offer_id.clone()),
+        ("creator_id".to_string(), creator_id.clone()),
+        ("type".to_string(), "creator_earnings_retry".to_string()),
+    ]);
+
+    match crate::payouts::execute_and_record_stripe_transfer(
+        &state,
+        &client,
+        &currency,
+        currency_enum,
+        "creator",
+        &creator_id,
+        &stripe_account_id,
+        amount_cents,
+        metadata,
+        "record_campaign_offer_transfer",
+        "p_offer_id",
+        &offer_id,
+    )
+    .await
+    {
+        Ok(transfer_id) => {
+            tracing::info!(
+                offer_id = %offer_id,
+                creator_id = %creator_id,
+                transfer_id = %transfer_id,
+                "creator self-service transfer retry succeeded"
+            );
+            Ok(Json(json!({
+                "status": "ok",
+                "transfer_id": transfer_id,
+                "message": "Transfer succeeded. Funds are on their way to your Stripe account."
+            })))
+        }
+        Err(e) => {
+            tracing::warn!(
+                offer_id = %offer_id,
+                creator_id = %creator_id,
+                error = %e,
+                "creator self-service transfer retry failed"
+            );
+            Err((
+                StatusCode::BAD_GATEWAY,
+                format!("transfer_failed: {}. Please ensure your Stripe account has completed onboarding and try again.", e),
+            ))
+        }
+    }
 }

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -9712,6 +9712,368 @@ pub async fn ensure_campaign_billing_stub(
 }
 
 // =============================================================================
+// GET /api/agency/campaign-offers/:offer_id/stripe-readiness
+//
+// Pre-flight check called by the agency UI before sending a DocuSeal contract.
+// Returns Stripe connectivity + transfer-capability status for:
+//   - the agency itself
+//   - every talent currently assigned to the offer
+//
+// Two-tier result:
+//   all_connected = false  → HARD BLOCK: at least one party has no Stripe account
+//   all_connected = true,
+//   all_transfers_enabled = false → SOFT WARNING: everyone connected but some
+//                                   transfers not yet enabled (can still send)
+//
+// Stripe API calls are made in parallel (tokio::join!) to keep latency low.
+// Only the owning agency can call this endpoint.
+// =============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct StripeReadinessParty {
+    /// "agency" | "creator"
+    pub party_type: String,
+    pub id: String,
+    pub name: String,
+    pub connected: bool,
+    pub transfers_enabled: bool,
+    pub details_submitted: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OfferStripeReadinessResponse {
+    pub offer_id: String,
+    pub agency: StripeReadinessParty,
+    pub talents: Vec<StripeReadinessParty>,
+    /// true only when agency AND every talent have a connected Stripe account
+    pub all_connected: bool,
+    /// true only when all_connected AND every party has transfers_enabled
+    pub all_transfers_enabled: bool,
+}
+
+pub async fn get_offer_stripe_readiness(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(offer_id): Path<String>,
+) -> Result<Json<OfferStripeReadinessResponse>, (StatusCode, String)> {
+    // Agency-only — must have billing visibility to see payout readiness
+    let access =
+        team::require_agency_permission(&state, &user, Permission::ManageBilling).await?;
+    let agency_id = access.organization_id.clone();
+
+    // Verify the offer belongs to this agency
+    let offer_resp = state
+        .pg
+        .from("campaign_offers")
+        .select("id,target_type,target_id")
+        .eq("id", &offer_id)
+        .eq("target_type", "agency")
+        .eq("target_id", &agency_id)
+        .limit(1)
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if !offer_resp.status().is_success() {
+        return Err(sanitize_db_error(
+            offer_resp.status().as_u16(),
+            offer_resp.text().await.unwrap_or_default(),
+        ));
+    }
+    let offer_text = offer_resp.text().await.unwrap_or_else(|_| "[]".into());
+    let offer_rows: Vec<serde_json::Value> = serde_json::from_str(&offer_text).unwrap_or_default();
+    if offer_rows.is_empty() {
+        return Err((StatusCode::NOT_FOUND, "offer_not_found".to_string()));
+    }
+
+    // Load all assigned talents for this offer
+    let assignments_resp = state
+        .pg
+        .from("offer_talent_assignments")
+        .select("creator_id,talent_id")
+        .eq("offer_id", &offer_id)
+        .eq("agency_id", &agency_id)
+        .eq("status", "assigned")
+        .execute()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let assignments_text = assignments_resp
+        .text()
+        .await
+        .unwrap_or_else(|_| "[]".into());
+    let assignment_rows: Vec<serde_json::Value> =
+        serde_json::from_str(&assignments_text).unwrap_or_default();
+
+    // Collect unique creator_ids from assignments
+    let mut creator_ids: Vec<String> = assignment_rows
+        .iter()
+        .filter_map(|r| {
+            r.get("creator_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .collect();
+    creator_ids.sort();
+    creator_ids.dedup();
+
+    // Resolve talent names — try agency_users first (has stage_name / full_legal_name),
+    // then fall back to creators.full_name for connected creators who have no agency_users row.
+    let mut name_by_creator_id: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    if !creator_ids.is_empty() {
+        let creator_refs: Vec<&str> = creator_ids.iter().map(|s| s.as_str()).collect();
+
+        // 1) agency_users — preferred source (has stage_name / full_legal_name)
+        if let Ok(au_resp) = state
+            .pg
+            .from("agency_users")
+            .select("creator_id,full_legal_name,stage_name")
+            .eq("agency_id", &agency_id)
+            .in_("creator_id", creator_refs.clone())
+            .execute()
+            .await
+        {
+            if au_resp.status().is_success() {
+                let au_text = au_resp.text().await.unwrap_or_else(|_| "[]".into());
+                let au_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&au_text).unwrap_or_default();
+                for row in &au_rows {
+                    let cid = row
+                        .get("creator_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if cid.is_empty() {
+                        continue;
+                    }
+                    let name = row
+                        .get("full_legal_name")
+                        .or_else(|| row.get("stage_name"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "Talent".to_string());
+                    name_by_creator_id.insert(cid, name);
+                }
+            }
+        }
+
+        // 2) creators table — fallback for connected creators without an agency_users row,
+        //    and also the source for stripe_connect_account_id (fetched together to save a round-trip).
+        //    We only need names for creator_ids not already resolved above.
+        let missing_name_ids: Vec<&str> = creator_refs
+            .iter()
+            .copied()
+            .filter(|id| !name_by_creator_id.contains_key(*id))
+            .collect();
+
+        if !missing_name_ids.is_empty() {
+            if let Ok(cr_name_resp) = state
+                .pg
+                .from("creators")
+                .select("id,full_name,email")
+                .in_("id", missing_name_ids)
+                .execute()
+                .await
+            {
+                if cr_name_resp.status().is_success() {
+                    let cr_name_text = cr_name_resp.text().await.unwrap_or_else(|_| "[]".into());
+                    let cr_name_rows: Vec<serde_json::Value> =
+                        serde_json::from_str(&cr_name_text).unwrap_or_default();
+                    for row in &cr_name_rows {
+                        let cid = row
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .trim()
+                            .to_string();
+                        if cid.is_empty() {
+                            continue;
+                        }
+                        // Prefer full_name, fall back to email prefix, then "Creator"
+                        let name = row
+                            .get("full_name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .or_else(|| {
+                                row.get("email")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.trim().to_string())
+                                    .filter(|s| !s.is_empty())
+                            })
+                            .unwrap_or_else(|| "Creator".to_string());
+                        name_by_creator_id.insert(cid, name);
+                    }
+                }
+            }
+        }
+    }
+
+    // Resolve Stripe account IDs for all creators in one DB round-trip
+    let mut stripe_account_by_creator_id: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    if !creator_ids.is_empty() {
+        let creator_refs: Vec<&str> = creator_ids.iter().map(|s| s.as_str()).collect();
+        if let Ok(cr_resp) = state
+            .pg
+            .from("creators")
+            .select("id,stripe_connect_account_id")
+            .in_("id", creator_refs)
+            .execute()
+            .await
+        {
+            if cr_resp.status().is_success() {
+                let cr_text = cr_resp.text().await.unwrap_or_else(|_| "[]".into());
+                let cr_rows: Vec<serde_json::Value> =
+                    serde_json::from_str(&cr_text).unwrap_or_default();
+                for row in &cr_rows {
+                    let cid = row
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    let acct = row
+                        .get("stripe_connect_account_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !cid.is_empty() {
+                        stripe_account_by_creator_id.insert(cid, acct);
+                    }
+                }
+            }
+        }
+    }
+
+    // Resolve agency name + Stripe account
+    let agency_stripe_account = get_agency_stripe_account(&state, &agency_id)
+        .await
+        .unwrap_or_default();
+    let agency_name = {
+        let resp = state
+            .pg
+            .from("agencies")
+            .select("agency_name")
+            .eq("id", &agency_id)
+            .limit(1)
+            .execute()
+            .await;
+        if let Ok(r) = resp {
+            let t = r.text().await.unwrap_or_else(|_| "[]".into());
+            let rows: Vec<serde_json::Value> = serde_json::from_str(&t).unwrap_or_default();
+            rows.first()
+                .and_then(|r| r.get("agency_name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("Agency")
+                .to_string()
+        } else {
+            "Agency".to_string()
+        }
+    };
+
+    // -------------------------------------------------------------------------
+    // Fire all Stripe account health checks in parallel.
+    // We build a flat list of (id, account_id) pairs, check them concurrently,
+    // then reassemble the results.
+    // -------------------------------------------------------------------------
+    let stripe_client = stripe_sdk::Client::new(state.stripe_secret_key.clone());
+
+    // Inline helper — same logic as the one inside get_offer_transfer_status
+    async fn check_stripe_health(
+        client: &stripe_sdk::Client,
+        account_id: &str,
+    ) -> (bool, bool, bool) {
+        // Returns (connected, transfers_enabled, details_submitted)
+        if account_id.is_empty() {
+            return (false, false, false);
+        }
+        match account_id.parse::<stripe_sdk::AccountId>() {
+            Ok(aid) => match stripe_sdk::Account::retrieve(client, &aid, &[]).await {
+                Ok(acct) => {
+                    let transfers_enabled = acct
+                        .capabilities
+                        .as_ref()
+                        .and_then(|c| c.transfers.as_ref())
+                        .map(|s| s == &stripe_sdk::CapabilityStatus::Active)
+                        .unwrap_or(false);
+                    let details_submitted = acct.details_submitted.unwrap_or(false);
+                    (true, transfers_enabled, details_submitted)
+                }
+                // Account exists in DB but Stripe returned an error — treat as
+                // connected (account ID is present) but not transfer-ready.
+                Err(_) => (true, false, false),
+            },
+            // Malformed account ID stored in DB — treat as not connected.
+            Err(_) => (false, false, false),
+        }
+    }
+
+    // Agency health check
+    let (ag_connected, ag_transfers, ag_details) =
+        check_stripe_health(&stripe_client, &agency_stripe_account).await;
+
+    let agency_party = StripeReadinessParty {
+        party_type: "agency".to_string(),
+        id: agency_id.clone(),
+        name: agency_name,
+        connected: ag_connected,
+        transfers_enabled: ag_transfers,
+        details_submitted: ag_details,
+    };
+
+    // Per-talent health checks — run concurrently
+    let talent_futures: Vec<_> = creator_ids
+        .iter()
+        .map(|cid| {
+            let acct = stripe_account_by_creator_id
+                .get(cid)
+                .cloned()
+                .unwrap_or_default();
+            let name = name_by_creator_id
+                .get(cid)
+                .cloned()
+                .unwrap_or_else(|| "Talent".to_string());
+            let cid = cid.clone();
+            let client = stripe_client.clone();
+            async move {
+                let (connected, transfers_enabled, details_submitted) =
+                    check_stripe_health(&client, &acct).await;
+                StripeReadinessParty {
+                    party_type: "creator".to_string(),
+                    id: cid,
+                    name,
+                    connected,
+                    transfers_enabled,
+                    details_submitted,
+                }
+            }
+        })
+        .collect();
+
+    let talent_parties: Vec<StripeReadinessParty> =
+        futures::future::join_all(talent_futures).await;
+
+    // Compute aggregate flags
+    let all_connected = ag_connected && talent_parties.iter().all(|p| p.connected);
+    let all_transfers_enabled =
+        all_connected && ag_transfers && talent_parties.iter().all(|p| p.transfers_enabled);
+
+    Ok(Json(OfferStripeReadinessResponse {
+        offer_id,
+        agency: agency_party,
+        talents: talent_parties,
+        all_connected,
+        all_transfers_enabled,
+    }))
+}
+
+// =============================================================================
 // GET /api/agency/campaign-offers/:offer_id/transfer-status
 //
 // Returns the Stripe account health + transfer row status for every recipient

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -8377,13 +8377,61 @@ async fn try_release_campaign_offer_escrow(
         });
     }
 
-    // Guard against already-released or in-progress releasing state
-    if escrow_status == "released" || escrow_status == "releasing" {
+    // Guard against already-released or in-progress releasing state.
+    // Exception: if escrow is "releasing" but transfers have failed, it means
+    // a previous attempt was interrupted. Allow recovery by treating it as
+    // "holding" so the release can be retried. A genuinely in-flight "releasing"
+    // (no failed transfers yet) is still protected from race conditions.
+    if escrow_status == "released" {
         return Ok(EscrowReleaseOutcome {
             payment_status: payment_status.to_string(),
             escrow_status: escrow_status.to_string(),
             released_now: false,
         });
+    }
+    if escrow_status == "releasing" {
+        // Check whether any transfer for this offer has failed — if so, the
+        // "releasing" state is stale and we should allow a retry.
+        let has_failed_transfers: bool = async {
+            let resp = match state
+                .pg
+                .from("campaign_offer_transfers")
+                .select("id")
+                .eq("offer_id", offer_id)
+                .eq("status", "failed")
+                .limit(1)
+                .execute()
+                .await
+            {
+                Ok(r) => r,
+                Err(_) => return false,
+            };
+            if !resp.status().is_success() {
+                return false;
+            }
+            let text = match resp.text().await {
+                Ok(t) => t,
+                Err(_) => return false,
+            };
+            let rows: Vec<serde_json::Value> =
+                serde_json::from_str(&text).unwrap_or_default();
+            !rows.is_empty()
+        }
+        .await;
+
+        if !has_failed_transfers {
+            // Genuinely in-flight — protect from concurrent release attempts.
+            return Ok(EscrowReleaseOutcome {
+                payment_status: payment_status.to_string(),
+                escrow_status: escrow_status.to_string(),
+                released_now: false,
+            });
+        }
+        // Has failed transfers — fall through and retry the release.
+        tracing::info!(
+            offer_id = %offer_id,
+            "Escrow is in 'releasing' state with failed transfers; retrying release"
+        );
     }
 
     // Escrow releases when at least ONE deliverable is approved.
@@ -8735,7 +8783,10 @@ async fn try_release_campaign_offer_escrow(
         });
     }
 
-    // Execute transfers BEFORE marking as released. If transfers fail, escrow stays in "releasing" state.
+    // Execute all transfers best-effort. Individual failures are recorded in
+    // campaign_offer_transfers and retryable via the retry-transfers endpoint.
+    // The escrow is marked "released" regardless — it signals that the brand
+    // has approved and funds should flow, not that all transfers succeeded.
     release_campaign_offer_transfers(state, offer_id, agency_id, billing_request_id).await?;
 
     // Only mark as "released" AFTER transfers succeed
@@ -8809,35 +8860,59 @@ async fn release_campaign_offer_transfers(
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
+    // ── Agency transfer ───────────────────────────────────────────────────────
+    // Best-effort: a failed agency transfer is recorded and retryable but must
+    // NOT abort the talent transfers. Funds are held in escrow until retried.
     if agency_amount_cents > 0 {
-        let agency_account_id = get_agency_stripe_account(state, agency_id)
-            .await
-            .map_err(|e| format!("Failed to get agency Stripe account: {}", e))?;
+        match get_agency_stripe_account(state, agency_id).await {
+            Err(e) => {
+                tracing::warn!(
+                    offer_id = %offer_id,
+                    agency_id = %agency_id,
+                    error = %e,
+                    "Skipping agency transfer — Stripe account not found; retryable"
+                );
+            }
+            Ok(agency_account_id) => {
+                let metadata = std::collections::HashMap::from([
+                    ("offer_id".to_string(), offer_id.to_string()),
+                    ("agency_id".to_string(), agency_id.to_string()),
+                    ("type".to_string(), "agency_commission".to_string()),
+                ]);
 
-        let metadata = std::collections::HashMap::from([
-            ("offer_id".to_string(), offer_id.to_string()),
-            ("agency_id".to_string(), agency_id.to_string()),
-            ("type".to_string(), "agency_commission".to_string()),
-        ]);
-
-        crate::payouts::execute_and_record_stripe_transfer(
-            state,
-            &client,
-            &currency,
-            currency_enum,
-            "agency",
-            agency_id,
-            &agency_account_id,
-            agency_amount_cents,
-            metadata,
-            "record_campaign_offer_transfer",
-            "p_offer_id",
-            offer_id,
-        )
-        .await
-        .map_err(|e| format!("Stripe transfer to agency failed: {}", e))?;
+                if let Err(e) = crate::payouts::execute_and_record_stripe_transfer(
+                    state,
+                    &client,
+                    &currency,
+                    currency_enum,
+                    "agency",
+                    agency_id,
+                    &agency_account_id,
+                    agency_amount_cents,
+                    metadata,
+                    "record_campaign_offer_transfer",
+                    "p_offer_id",
+                    offer_id,
+                )
+                .await
+                {
+                    // Failure is already recorded in campaign_offer_transfers by
+                    // execute_and_record_stripe_transfer. Log and continue so
+                    // talent transfers are not blocked.
+                    tracing::warn!(
+                        offer_id = %offer_id,
+                        agency_id = %agency_id,
+                        error = %e,
+                        "Agency Stripe transfer failed; recorded as failed, continuing to talent transfers"
+                    );
+                }
+            }
+        }
     }
 
+    // ── Talent transfers ──────────────────────────────────────────────────────
+    // Each talent split is attempted independently. A failure on one talent
+    // does not block others. All failures are recorded and retryable.
     let talent_splits = payout
         .get("talent_splits")
         .and_then(|v| v.as_array())
@@ -8889,7 +8964,7 @@ async fn release_campaign_offer_transfers(
                     creator_id = %creator_id,
                     talent_id = %talent_id,
                     error = %e,
-                    "Skipping talent split — Stripe account not connected"
+                    "Skipping talent split — Stripe account not connected; retryable"
                 );
                 continue;
             }
@@ -8904,7 +8979,7 @@ async fn release_campaign_offer_transfers(
             metadata.insert("talent_id".to_string(), talent_id.to_string());
         }
 
-        crate::payouts::execute_and_record_stripe_transfer(
+        if let Err(e) = crate::payouts::execute_and_record_stripe_transfer(
             state,
             &client,
             &currency,
@@ -8919,7 +8994,15 @@ async fn release_campaign_offer_transfers(
             offer_id,
         )
         .await
-        .map_err(|e| format!("Stripe transfer to talent failed: {}", e))?;
+        {
+            tracing::warn!(
+                offer_id = %offer_id,
+                creator_id = %creator_id,
+                talent_id = %talent_id,
+                error = %e,
+                "Talent Stripe transfer failed; recorded as failed, continuing to next split"
+            );
+        }
     }
 
     Ok(())

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -6505,18 +6505,21 @@ pub async fn submit_offer_deliverable(
 
     // Payment gate: by default do not allow campaign deliverables to be submitted until the offer
     // is paid. Agencies may override this with an explicit confirmation flag.
+    // Creators are always allowed to submit regardless of payment status — the brand cannot
+    // download deliverables until they pay, so there is no risk in allowing early submission.
     let payment_status = _offer
         .get("payment_status")
         .and_then(|v| v.as_str())
         .unwrap_or("unpaid");
     if payment_status != "paid" {
         let confirm_unpaid = payload.confirm_unpaid.unwrap_or(false);
-        if user.role != "agency" || !confirm_unpaid {
+        if (user.role != "agency" || !confirm_unpaid) && !is_creator_like(&user.role) {
             return Err((StatusCode::PAYMENT_REQUIRED, "offer_unpaid".to_string()));
         }
 
         // Additional restriction: unpaid deliverables may only be submitted after the offer is signed.
-        if !offer_status_is_signed(&_offer) {
+        // (Applies to agencies only — creators are always allowed through above.)
+        if !is_creator_like(&user.role) && !offer_status_is_signed(&_offer) {
             return Err((StatusCode::BAD_REQUEST, "offer_not_signed".to_string()));
         }
     }
@@ -6898,7 +6901,9 @@ pub async fn upload_offer_deliverable(
         .get("payment_status")
         .and_then(|v| v.as_str())
         .unwrap_or("unpaid");
-    if payment_status != "paid" && user.role != "agency" {
+    // Creators can upload deliverables regardless of payment status.
+    // The brand cannot download until they pay, so there is no risk.
+    if payment_status != "paid" && user.role != "agency" && !is_creator_like(&user.role) {
         return Err((StatusCode::PAYMENT_REQUIRED, "offer_unpaid".to_string()));
     }
 
@@ -7371,7 +7376,9 @@ pub async fn upload_offer_deliverable_form(
         .get("payment_status")
         .and_then(|v| v.as_str())
         .unwrap_or("unpaid");
-    if payment_status != "paid" && user.role != "agency" {
+    // Creators can upload deliverables regardless of payment status.
+    // The brand cannot download until they pay, so there is no risk.
+    if payment_status != "paid" && user.role != "agency" && !is_creator_like(&user.role) {
         return Err((StatusCode::PAYMENT_REQUIRED, "offer_unpaid".to_string()));
     }
 
@@ -7753,12 +7760,13 @@ pub async fn submit_draft_deliverables(
             .as_ref()
             .and_then(|p| p.confirm_unpaid)
             .unwrap_or(false);
-        if user.role != "agency" || !confirm_unpaid {
+        if (user.role != "agency" || !confirm_unpaid) && !is_creator_like(&user.role) {
             return Err((StatusCode::PAYMENT_REQUIRED, "offer_unpaid".to_string()));
         }
 
         // Additional restriction: unpaid deliverables may only be submitted after the offer is signed.
-        if !offer_status_is_signed(&_offer) {
+        // (Applies to agencies only — creators are always allowed through above.)
+        if !is_creator_like(&user.role) && !offer_status_is_signed(&_offer) {
             return Err((StatusCode::BAD_REQUEST, "offer_not_signed".to_string()));
         }
     }

--- a/likelee-server/src/brand_campaigns.rs
+++ b/likelee-server/src/brand_campaigns.rs
@@ -4595,6 +4595,77 @@ pub async fn download_offer_contract_document(
             )
         })?;
 
+    // DocuSeal pre-signed file URLs expire after a few hours. If the stored URL
+    // returns 401/403, fall back to fetching a fresh URL via the submissions API.
+    let upstream = if upstream.status().as_u16() == 401
+        || upstream.status().as_u16() == 403
+        || upstream.status().as_u16() == 404
+    {
+        tracing::info!(
+            contract_id = %contract_id,
+            status = %upstream.status(),
+            "Stored DocuSeal document URL expired; fetching fresh URL via submissions API"
+        );
+        let submission_id = contract
+            .get("docuseal_submission_id")
+            .and_then(|v| v.as_i64())
+            .unwrap_or_default();
+        if submission_id <= 0 || state.docuseal_api_key.trim().is_empty() {
+            return Err((
+                StatusCode::NOT_FOUND,
+                "Signed contract PDF is no longer available. Please contact support.".to_string(),
+            ));
+        }
+        let docuseal = DocuSealClient::new(
+            state.docuseal_api_key.clone(),
+            state.docuseal_api_url.clone(),
+        );
+        let fresh_url = match docuseal.get_submission(submission_id as i32).await {
+            Ok(details) => details
+                .documents
+                .first()
+                .map(|doc| doc.url.trim().to_string())
+                .filter(|u| !u.is_empty()),
+            Err(e) => {
+                tracing::warn!(contract_id = %contract_id, error = %e, "Failed to refresh DocuSeal document URL");
+                None
+            }
+        };
+        let fresh_url = fresh_url.ok_or((
+            StatusCode::NOT_FOUND,
+            "Signed contract PDF is no longer available from DocuSeal.".to_string(),
+        ))?;
+
+        // Persist the fresh URL so subsequent downloads don't need to re-fetch
+        let _ = state
+            .pg
+            .from("campaign_offer_contracts")
+            .eq("id", &contract_id)
+            .update(
+                json!({
+                    "signed_document_url": fresh_url,
+                    "updated_at": chrono::Utc::now().to_rfc3339(),
+                })
+                .to_string(),
+            )
+            .execute()
+            .await;
+
+        Client::new()
+            .get(&fresh_url)
+            .header("X-Auth-Token", state.docuseal_api_key.clone())
+            .send()
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    format!("Failed to fetch refreshed contract PDF: {e}"),
+                )
+            })?
+    } else {
+        upstream
+    };
+
     if !upstream.status().is_success() {
         let upstream_status = upstream.status();
         let upstream_body = upstream.text().await.unwrap_or_default();

--- a/likelee-server/src/router.rs
+++ b/likelee-server/src/router.rs
@@ -1142,6 +1142,10 @@ pub fn build_router(state: AppState) -> Router {
             post(crate::brand_campaigns::comment_offer_deliverable),
         )
         .route(
+            "/api/agency/campaign-offers/:offer_id/stripe-readiness",
+            get(crate::brand_campaigns::get_offer_stripe_readiness),
+        )
+        .route(
             "/api/agency/campaign-offers/:offer_id/transfer-status",
             get(crate::brand_campaigns::get_offer_transfer_status),
         )

--- a/likelee-server/src/router.rs
+++ b/likelee-server/src/router.rs
@@ -1166,6 +1166,10 @@ pub fn build_router(state: AppState) -> Router {
             get(crate::brand_campaigns::get_creator_transfer_status),
         )
         .route(
+            "/api/talent/campaign-offers/:offer_id/retry-transfer",
+            post(crate::brand_campaigns::retry_creator_transfer),
+        )
+        .route(
             "/api/brand/campaigns/:campaign_id/license-requests",
             post(crate::licensing_requests::create_for_brand_campaign),
         )

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -210,7 +210,8 @@ const BrandConnectionsView = ({
 
   // Stripe readiness gate state
   const [stripeGateOpen, setStripeGateOpen] = useState(false);
-  const [stripeGateData, setStripeGateData] = useState<OfferStripeReadiness | null>(null);
+  const [stripeGateData, setStripeGateData] =
+    useState<OfferStripeReadiness | null>(null);
   const [stripeGate, setStripeGate] = useState<ReadinessGate>("ok");
   const [stripeGatePendingOffer, setStripeGatePendingOffer] = useState<{
     offerId: string;
@@ -2812,9 +2813,13 @@ const BrandConnectionsView = ({
                                                         cId,
                                                       )
                                                     }
-                                                    disabled={isBusy || stripeReadinessLoading}
+                                                    disabled={
+                                                      isBusy ||
+                                                      stripeReadinessLoading
+                                                    }
                                                   >
-                                                    {isBusy || stripeReadinessLoading ? (
+                                                    {isBusy ||
+                                                    stripeReadinessLoading ? (
                                                       <Loader2 className="w-4 h-4 animate-spin" />
                                                     ) : (
                                                       <>

--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -49,8 +49,17 @@ import {
   Mail,
   UserX,
   Clock,
+  ExternalLink,
 } from "lucide-react";
 import { CampaignBriefView } from "@/components/campaign-offers/CampaignBriefView";
+import {
+  StripeReadinessGateModal,
+  ContractPrecheckModal,
+  deriveGate,
+  type OfferStripeReadiness,
+  type ReadinessGate,
+  type ContractPrecheckAction,
+} from "@/components/agency/StripeReadinessGateModal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -186,12 +195,28 @@ const BrandConnectionsView = ({
   });
 
   const [sendPrecheckOpen, setSendPrecheckOpen] = useState(false);
-  const [sendPrecheckTitle, setSendPrecheckTitle] = useState("");
-  const [sendPrecheckBody, setSendPrecheckBody] =
-    useState<React.ReactNode>(null);
-  const [sendPrecheckActions, setSendPrecheckActions] = useState<
-    { label: string; onClick: () => void; variant?: "default" | "outline" }[]
-  >([]);
+  const [sendPrecheckConfig, setSendPrecheckConfig] = useState<{
+    severity: "block" | "warning" | "info";
+    title: string;
+    description: string;
+    body?: React.ReactNode;
+    actions: ContractPrecheckAction[];
+  }>({
+    severity: "warning",
+    title: "",
+    description: "",
+    actions: [],
+  });
+
+  // Stripe readiness gate state
+  const [stripeGateOpen, setStripeGateOpen] = useState(false);
+  const [stripeGateData, setStripeGateData] = useState<OfferStripeReadiness | null>(null);
+  const [stripeGate, setStripeGate] = useState<ReadinessGate>("ok");
+  const [stripeGatePendingOffer, setStripeGatePendingOffer] = useState<{
+    offerId: string;
+    contractId: string;
+  } | null>(null);
+  const [stripeReadinessLoading, setStripeReadinessLoading] = useState(false);
 
   // Load DocuSeal Builder script
   const loadDocuSealBuilder = () => {
@@ -457,17 +482,19 @@ const BrandConnectionsView = ({
     agencyStripeConnected && agencyStripeTransfersEnabled;
 
   const openSendPrecheckModal = (opts: {
+    severity?: "block" | "warning" | "info";
     title: string;
-    body: React.ReactNode;
-    actions: {
-      label: string;
-      onClick: () => void;
-      variant?: "default" | "outline";
-    }[];
+    description: string;
+    body?: React.ReactNode;
+    actions: ContractPrecheckAction[];
   }) => {
-    setSendPrecheckTitle(opts.title);
-    setSendPrecheckBody(opts.body);
-    setSendPrecheckActions(opts.actions);
+    setSendPrecheckConfig({
+      severity: opts.severity ?? "warning",
+      title: opts.title,
+      description: opts.description,
+      body: opts.body,
+      actions: opts.actions,
+    });
     setSendPrecheckOpen(true);
   };
 
@@ -476,22 +503,13 @@ const BrandConnectionsView = ({
 
     if (!hasAssignedTalent) {
       openSendPrecheckModal({
+        severity: "block",
         title: "Assign talents before sending",
-        body: (
-          <div className="space-y-2 text-sm text-gray-600">
-            <p>
-              This offer has no assigned talents. Assign at least 1 talent
-              before sending the contract.
-            </p>
-            <p className="text-xs text-gray-500">
-              Assignments are locked after the contract is sent.
-            </p>
-          </div>
-        ),
+        description:
+          "This offer has no assigned talents. Assign at least 1 talent before sending the contract. Assignments are locked after the contract is sent.",
         actions: [
           {
-            label: "Close",
-            variant: "outline",
+            label: "Got it",
             onClick: () => setSendPrecheckOpen(false),
           },
         ],
@@ -499,79 +517,92 @@ const BrandConnectionsView = ({
       return;
     }
 
-    if (!agencyStripeConnected) {
-      openSendPrecheckModal({
-        title: "Connect Stripe before sending",
-        body: (
-          <div className="space-y-2 text-sm text-gray-600">
-            <p>
-              Connect your agency Stripe account before sending contracts. This
-              ensures payouts and commissions can be transferred correctly when
-              the brand pays.
-            </p>
-          </div>
-        ),
-        actions: [
-          {
-            label: "Go to Payouts",
-            onClick: () => {
-              setSendPrecheckOpen(false);
-              navigate("/AgencyDashboard?tab=payouts");
-            },
-          },
-          {
-            label: "Close",
-            variant: "outline",
-            onClick: () => setSendPrecheckOpen(false),
-          },
-        ],
-      });
-      return;
-    }
+    // ── Stripe readiness gate ──────────────────────────────────────────────
+    // Call the backend to check Stripe connectivity for the agency + all
+    // assigned talents before creating the DocuSeal submission.
+    setStripeReadinessLoading(true);
+    base44
+      .get<OfferStripeReadiness>(
+        `/api/agency/campaign-offers/${encodeURIComponent(offerId)}/stripe-readiness`,
+      )
+      .then((data) => {
+        const gate = deriveGate(data);
+        if (gate === "ok") {
+          // All clear — proceed directly
+          handleSendContract(offerId, contractId);
+          return;
+        }
+        // Show the appropriate gate modal
+        setStripeGateData(data);
+        setStripeGate(gate);
+        setStripeGatePendingOffer({ offerId, contractId });
+        setStripeGateOpen(true);
+      })
+      .catch((err) => {
+        // If the readiness check itself fails (network error, 403, etc.)
+        // fall back to the existing agency-only stripe check so we never
+        // silently skip the gate.
+        console.error("stripe-readiness check failed", err);
 
-    if (agencyStripeConnected && !agencyStripeTransfersEnabled) {
-      openSendPrecheckModal({
-        title: "Stripe transfers not enabled",
-        body: (
-          <div className="space-y-2 text-sm text-gray-600">
-            <p>
-              Your Stripe account is connected, but Stripe reports that{" "}
-              <span className="font-semibold">transfers are not enabled</span>{" "}
-              for this account yet.
-            </p>
-            <p>
-              If you send this contract now, the brand may be able to pay, but
-              transfers to your agency and creators can fail until Stripe
-              enables transfers.
-            </p>
-            <p className="text-xs text-gray-500">
-              Recommendation: finish Stripe onboarding in Payouts. If transfers
-              stay disabled, contact system support for help.
-            </p>
-          </div>
-        ),
-        actions: [
-          {
-            label: "Send anyway",
-            onClick: () => {
-              setSendPrecheckOpen(false);
-              handleSendContract(offerId, contractId);
-            },
-          },
-          {
-            label: "Go to Payouts",
-            variant: "outline",
-            onClick: () => {
-              setSendPrecheckOpen(false);
-              navigate("/AgencyDashboard?tab=payouts");
-            },
-          },
-        ],
-      });
-      return;
-    }
+        if (!agencyStripeConnected) {
+          openSendPrecheckModal({
+            severity: "block",
+            title: "Connect Stripe before sending",
+            description:
+              "Connect your agency Stripe account before sending contracts. This ensures payouts and commissions can be transferred correctly when the brand pays.",
+            actions: [
+              {
+                label: "Go to Payouts",
+                icon: <ExternalLink className="w-4 h-4" />,
+                onClick: () => {
+                  setSendPrecheckOpen(false);
+                  navigate("/AgencyDashboard?tab=payouts");
+                },
+              },
+              {
+                label: "Close",
+                variant: "outline",
+                onClick: () => setSendPrecheckOpen(false),
+              },
+            ],
+          });
+          return;
+        }
 
-    handleSendContract(offerId, contractId);
+        if (agencyStripeConnected && !agencyStripeTransfersEnabled) {
+          openSendPrecheckModal({
+            severity: "warning",
+            title: "Stripe transfers not enabled",
+            description:
+              "Your Stripe account is connected, but transfers are not enabled yet. The brand can still pay, but payouts may fail until Stripe onboarding is complete.",
+            actions: [
+              {
+                label: "Send anyway",
+                onClick: () => {
+                  setSendPrecheckOpen(false);
+                  handleSendContract(offerId, contractId);
+                },
+              },
+              {
+                label: "Go to Payouts",
+                variant: "outline",
+                icon: <ExternalLink className="w-4 h-4" />,
+                onClick: () => {
+                  setSendPrecheckOpen(false);
+                  navigate("/AgencyDashboard?tab=payouts");
+                },
+              },
+            ],
+          });
+          return;
+        }
+
+        // Readiness check failed but agency looks fine locally — proceed
+        handleSendContract(offerId, contractId);
+      })
+      .finally(() => {
+        setStripeReadinessLoading(false);
+      });
   };
 
   const builderSendDisabledReason = useMemo(() => {
@@ -2781,9 +2812,9 @@ const BrandConnectionsView = ({
                                                         cId,
                                                       )
                                                     }
-                                                    disabled={isBusy}
+                                                    disabled={isBusy || stripeReadinessLoading}
                                                   >
-                                                    {isBusy ? (
+                                                    {isBusy || stripeReadinessLoading ? (
                                                       <Loader2 className="w-4 h-4 animate-spin" />
                                                     ) : (
                                                       <>
@@ -3338,28 +3369,36 @@ const BrandConnectionsView = ({
         </DialogContent>
       </Dialog>
 
-      <Dialog open={sendPrecheckOpen} onOpenChange={setSendPrecheckOpen}>
-        <DialogContent className="sm:max-w-[520px]">
-          <DialogHeader>
-            <DialogTitle>{sendPrecheckTitle || "Before you send"}</DialogTitle>
-            <DialogDescription>
-              Please review the information below.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-1">{sendPrecheckBody}</div>
-          <DialogFooter className="gap-2 sm:gap-2">
-            {sendPrecheckActions.map((a, idx) => (
-              <Button
-                key={`${a.label}-${idx}`}
-                variant={a.variant === "outline" ? "outline" : "default"}
-                onClick={a.onClick}
-              >
-                {a.label}
-              </Button>
-            ))}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* Contract pre-check modal (no talents assigned, fallback stripe checks) */}
+      <ContractPrecheckModal
+        open={sendPrecheckOpen}
+        onOpenChange={setSendPrecheckOpen}
+        severity={sendPrecheckConfig.severity}
+        title={sendPrecheckConfig.title}
+        description={sendPrecheckConfig.description}
+        body={sendPrecheckConfig.body}
+        actions={sendPrecheckConfig.actions}
+      />
+
+      {/* Stripe readiness gate — hard block or soft warning before sending contract */}
+      <StripeReadinessGateModal
+        open={stripeGateOpen}
+        gate={stripeGate}
+        readiness={stripeGateData}
+        onClose={() => {
+          setStripeGateOpen(false);
+          setStripeGatePendingOffer(null);
+        }}
+        onSendAnyway={() => {
+          if (stripeGatePendingOffer) {
+            handleSendContract(
+              stripeGatePendingOffer.offerId,
+              stripeGatePendingOffer.contractId,
+            );
+          }
+          setStripeGatePendingOffer(null);
+        }}
+      />
 
       {/* DocuSeal Builder Modal */}
       {builderOpen && builderToken && (
@@ -3393,12 +3432,15 @@ const BrandConnectionsView = ({
                   disabled={
                     !selectedOfferId ||
                     !currentContractId ||
-                    busyIds.has(currentContractId)
+                    busyIds.has(currentContractId) ||
+                    stripeReadinessLoading
                   }
                   title={builderSendDisabledReason || undefined}
                 >
                   <Send className="w-4 h-4 mr-2" />
-                  {busyIds.has(currentContractId) ? "Sending..." : "Send"}
+                  {busyIds.has(currentContractId) || stripeReadinessLoading
+                    ? "Checking..."
+                    : "Send"}
                 </Button>
               </div>
               <Button

--- a/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
+++ b/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
@@ -64,8 +64,8 @@ export interface OfferStripeReadiness {
 // ---------------------------------------------------------------------------
 
 export type ReadinessGate =
-  | "ok"            // all connected + all transfers enabled → no modal needed
-  | "hard_block"    // ≥1 party not connected → cannot send
+  | "ok" // all connected + all transfers enabled → no modal needed
+  | "hard_block" // ≥1 party not connected → cannot send
   | "soft_warning"; // all connected, but ≥1 transfers disabled → can send with warning
 
 export function deriveGate(data: OfferStripeReadiness): ReadinessGate {
@@ -251,10 +251,8 @@ export function StripeReadinessGateModal({
           {/* Explanation */}
           <div className="px-6 pb-2">
             <p className="text-xs text-gray-500 leading-relaxed">
-              Ask{" "}
-              {unconnectedParties.map((p) => p.name).join(", ")}{" "}
-              to go to their{" "}
-              <span className="font-semibold text-gray-700">Payouts</span>{" "}
+              Ask {unconnectedParties.map((p) => p.name).join(", ")} to go to
+              their <span className="font-semibold text-gray-700">Payouts</span>{" "}
               section and complete Stripe onboarding. Once connected, you can
               send this contract.{" "}
               {unconnectedTalents.length > 0 && (
@@ -354,10 +352,14 @@ export function StripeReadinessGateModal({
         {/* Info callout */}
         <div className="mx-6 mb-4 rounded-xl border border-blue-100 bg-blue-50 p-3.5">
           <p className="text-xs text-blue-800 leading-relaxed">
-            <span className="font-semibold">You can still send this contract.</span>{" "}
+            <span className="font-semibold">
+              You can still send this contract.
+            </span>{" "}
             The brand will be able to pay and funds will be held in escrow. Once
             the affected{" "}
-            {transferDisabledParties.length === 1 ? "party completes" : "parties complete"}{" "}
+            {transferDisabledParties.length === 1
+              ? "party completes"
+              : "parties complete"}{" "}
             Stripe onboarding, you can retry the escrow release from the
             Deliverables tab.
           </p>
@@ -455,7 +457,9 @@ export function ContractPrecheckModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[440px] p-0 overflow-hidden gap-0">
         {/* Header band */}
-        <div className={`bg-gradient-to-br ${cfg.gradient} px-6 pt-8 pb-6 text-white`}>
+        <div
+          className={`bg-gradient-to-br ${cfg.gradient} px-6 pt-8 pb-6 text-white`}
+        >
           <div className="w-12 h-12 rounded-2xl bg-white/15 flex items-center justify-center mb-4">
             {cfg.icon}
           </div>
@@ -484,7 +488,13 @@ export function ContractPrecheckModal({
           {actions.map((a, idx) => (
             <Button
               key={`${a.label}-${idx}`}
-              variant={a.variant === "outline" ? "outline" : a.variant === "destructive" ? "destructive" : "default"}
+              variant={
+                a.variant === "outline"
+                  ? "outline"
+                  : a.variant === "destructive"
+                    ? "destructive"
+                    : "default"
+              }
               onClick={a.onClick}
               className={
                 a.variant !== "outline" && a.variant !== "destructive"

--- a/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
+++ b/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
@@ -1,0 +1,432 @@
+/**
+ * StripeReadinessGateModal
+ *
+ * Pre-flight modal shown when an agency clicks "Send Contract".
+ * Enforces a two-tier gate:
+ *
+ *   HARD BLOCK  — at least one party (agency or talent) has no Stripe account
+ *                 connected at all. Contract cannot be sent until resolved.
+ *
+ *   SOFT WARNING — all parties are connected but one or more have
+ *                  transfers_enabled = false (Stripe onboarding incomplete).
+ *                  Agency may still send; transfers can be retried later.
+ *
+ * Also exports ContractPrecheckModal — a polished replacement for the generic
+ * sendPrecheckOpen dialog used for "no talents assigned" and fallback checks.
+ */
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Users,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldX,
+  ArrowRight,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Types (mirror the backend OfferStripeReadinessResponse shape)
+// ---------------------------------------------------------------------------
+
+export interface StripeReadinessParty {
+  party_type: "agency" | "creator";
+  id: string;
+  name: string;
+  connected: boolean;
+  transfers_enabled: boolean;
+  details_submitted: boolean;
+}
+
+export interface OfferStripeReadiness {
+  offer_id: string;
+  agency: StripeReadinessParty;
+  talents: StripeReadinessParty[];
+  all_connected: boolean;
+  all_transfers_enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Gate type derived from readiness data
+// ---------------------------------------------------------------------------
+
+export type ReadinessGate =
+  | "ok"            // all connected + all transfers enabled → no modal needed
+  | "hard_block"    // ≥1 party not connected → cannot send
+  | "soft_warning"; // all connected, but ≥1 transfers disabled → can send with warning
+
+export function deriveGate(data: OfferStripeReadiness): ReadinessGate {
+  if (data.all_connected && data.all_transfers_enabled) return "ok";
+  if (!data.all_connected) return "hard_block";
+  return "soft_warning";
+}
+
+// ---------------------------------------------------------------------------
+// PartyRow — single row in the party list
+// ---------------------------------------------------------------------------
+
+function PartyStatusPill({
+  connected,
+  transfers_enabled,
+}: {
+  connected: boolean;
+  transfers_enabled: boolean;
+}) {
+  if (!connected) {
+    return (
+      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-700 border border-red-200">
+        <ShieldX className="w-3 h-3" />
+        Not connected
+      </span>
+    );
+  }
+  if (!transfers_enabled) {
+    return (
+      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-700 border border-amber-200">
+        <ShieldAlert className="w-3 h-3" />
+        Transfers disabled
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700 border border-emerald-200">
+      <ShieldCheck className="w-3 h-3" />
+      Ready
+    </span>
+  );
+}
+
+function PartyRow({ party }: { party: StripeReadinessParty }) {
+  const roleLabel = party.party_type === "agency" ? "Agency" : "Talent";
+  const initials = party.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="flex items-center gap-3 py-3 border-b border-gray-100 last:border-0">
+      {/* Avatar */}
+      <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center shrink-0 text-xs font-bold text-gray-600">
+        {initials || <Users className="w-4 h-4 text-gray-400" />}
+      </div>
+      {/* Name + role */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-gray-900 truncate leading-tight">
+          {party.name}
+        </p>
+        <p className="text-xs text-gray-400 leading-tight">{roleLabel}</p>
+      </div>
+      {/* Status pill */}
+      <PartyStatusPill
+        connected={party.connected}
+        transfers_enabled={party.transfers_enabled}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StripeReadinessGateModal — hard block or soft warning
+// ---------------------------------------------------------------------------
+
+interface StripeReadinessGateModalProps {
+  open: boolean;
+  gate: ReadinessGate;
+  readiness: OfferStripeReadiness | null;
+  onSendAnyway: () => void;
+  onClose: () => void;
+}
+
+export function StripeReadinessGateModal({
+  open,
+  gate,
+  readiness,
+  onSendAnyway,
+  onClose,
+}: StripeReadinessGateModalProps) {
+  const navigate = useNavigate();
+
+  if (!readiness || gate === "ok") return null;
+
+  const allParties: StripeReadinessParty[] = [
+    readiness.agency,
+    ...readiness.talents,
+  ];
+  const unconnectedParties = allParties.filter((p) => !p.connected);
+  const transferDisabledParties = allParties.filter(
+    (p) => p.connected && !p.transfers_enabled,
+  );
+  const agencyUnconnected = !readiness.agency.connected;
+
+  // ── HARD BLOCK ─────────────────────────────────────────────────────────────
+  if (gate === "hard_block") {
+    return (
+      <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+        <DialogContent className="sm:max-w-[460px] p-0 overflow-hidden gap-0">
+          {/* Header band */}
+          <div className="bg-gradient-to-br from-red-600 to-rose-700 px-6 pt-8 pb-6 text-white">
+            <div className="w-12 h-12 rounded-2xl bg-white/15 flex items-center justify-center mb-4">
+              <ShieldX className="w-6 h-6 text-white" />
+            </div>
+            <DialogHeader>
+              <DialogTitle className="text-xl font-bold text-white leading-snug">
+                Stripe account required
+              </DialogTitle>
+            </DialogHeader>
+            <p className="text-sm text-red-100 mt-1 leading-relaxed">
+              {unconnectedParties.length === 1
+                ? "1 party hasn't connected a Stripe account yet."
+                : `${unconnectedParties.length} parties haven't connected Stripe accounts yet.`}{" "}
+              The contract cannot be sent until this is resolved.
+            </p>
+          </div>
+
+          {/* Party list */}
+          <div className="px-6 py-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+              Payout readiness
+            </p>
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 divide-y divide-gray-100">
+              {allParties.map((p) => (
+                <PartyRow key={p.id} party={p} />
+              ))}
+            </div>
+          </div>
+
+          {/* Explanation */}
+          <div className="px-6 pb-2">
+            <p className="text-xs text-gray-500 leading-relaxed">
+              Ask the{" "}
+              {unconnectedParties.map((p) => p.name).join(", ")}{" "}
+              to go to their{" "}
+              <span className="font-semibold text-gray-700">Payouts</span>{" "}
+              section and complete Stripe onboarding. Once connected, you can
+              send this contract.
+            </p>
+          </div>
+
+          <DialogFooter className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex flex-col-reverse sm:flex-row gap-2">
+            {agencyUnconnected && (
+              <Button
+                variant="outline"
+                className="gap-2 border-gray-300"
+                onClick={() => {
+                  onClose();
+                  navigate("/AgencyDashboard?tab=payouts");
+                }}
+              >
+                <ExternalLink className="w-4 h-4" />
+                Go to Payouts
+              </Button>
+            )}
+            <Button
+              onClick={onClose}
+              className="bg-gray-900 hover:bg-gray-800 text-white gap-2"
+            >
+              Got it
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // ── SOFT WARNING ───────────────────────────────────────────────────────────
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-[460px] p-0 overflow-hidden gap-0">
+        {/* Header band */}
+        <div className="bg-gradient-to-br from-amber-500 to-orange-500 px-6 pt-8 pb-6 text-white">
+          <div className="w-12 h-12 rounded-2xl bg-white/15 flex items-center justify-center mb-4">
+            <ShieldAlert className="w-6 h-6 text-white" />
+          </div>
+          <DialogHeader>
+            <DialogTitle className="text-xl font-bold text-white leading-snug">
+              Transfers not fully enabled
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-amber-100 mt-1 leading-relaxed">
+            All parties have Stripe accounts, but{" "}
+            {transferDisabledParties.length === 1
+              ? "1 account hasn't"
+              : `${transferDisabledParties.length} accounts haven't`}{" "}
+            completed Stripe onboarding yet.
+          </p>
+        </div>
+
+        {/* Party list */}
+        <div className="px-6 py-4">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            Payout readiness
+          </p>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 divide-y divide-gray-100">
+            {allParties.map((p) => (
+              <PartyRow key={p.id} party={p} />
+            ))}
+          </div>
+        </div>
+
+        {/* Info callout */}
+        <div className="mx-6 mb-4 rounded-xl border border-blue-100 bg-blue-50 p-3.5">
+          <p className="text-xs text-blue-800 leading-relaxed">
+            <span className="font-semibold">You can still send this contract.</span>{" "}
+            The brand will be able to pay and funds will be held in escrow. Once
+            the affected{" "}
+            {transferDisabledParties.length === 1 ? "party completes" : "parties complete"}{" "}
+            Stripe onboarding, you can retry the escrow release from the
+            Deliverables tab.
+          </p>
+        </div>
+
+        <DialogFooter className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex flex-col-reverse sm:flex-row gap-2">
+          <Button
+            variant="outline"
+            className="gap-2 border-gray-300"
+            onClick={() => {
+              onClose();
+              navigate("/AgencyDashboard?tab=payouts");
+            }}
+          >
+            <ExternalLink className="w-4 h-4" />
+            Go to Payouts
+          </Button>
+          <Button
+            variant="outline"
+            className="border-gray-300"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onClose();
+              onSendAnyway();
+            }}
+            className="bg-gray-900 hover:bg-gray-800 text-white gap-2"
+          >
+            Send anyway
+            <ArrowRight className="w-4 h-4" />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ContractPrecheckModal — polished replacement for the generic sendPrecheckOpen
+// dialog used for "no talents assigned" and fallback stripe checks.
+// ---------------------------------------------------------------------------
+
+export interface ContractPrecheckAction {
+  label: string;
+  onClick: () => void;
+  variant?: "default" | "outline" | "destructive";
+  icon?: React.ReactNode;
+}
+
+export interface ContractPrecheckModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** "block" = red header, "warning" = amber header, "info" = blue header */
+  severity?: "block" | "warning" | "info";
+  title: string;
+  description: string;
+  /** Optional extra body content rendered below the description */
+  body?: React.ReactNode;
+  actions: ContractPrecheckAction[];
+}
+
+const severityConfig = {
+  block: {
+    gradient: "from-red-600 to-rose-700",
+    icon: <ShieldX className="w-6 h-6 text-white" />,
+    subtextColor: "text-red-100",
+  },
+  warning: {
+    gradient: "from-amber-500 to-orange-500",
+    icon: <AlertTriangle className="w-6 h-6 text-white" />,
+    subtextColor: "text-amber-100",
+  },
+  info: {
+    gradient: "from-blue-600 to-indigo-600",
+    icon: <AlertCircle className="w-6 h-6 text-white" />,
+    subtextColor: "text-blue-100",
+  },
+};
+
+export function ContractPrecheckModal({
+  open,
+  onOpenChange,
+  severity = "warning",
+  title,
+  description,
+  body,
+  actions,
+}: ContractPrecheckModalProps) {
+  const cfg = severityConfig[severity];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px] p-0 overflow-hidden gap-0">
+        {/* Header band */}
+        <div className={`bg-gradient-to-br ${cfg.gradient} px-6 pt-8 pb-6 text-white`}>
+          <div className="w-12 h-12 rounded-2xl bg-white/15 flex items-center justify-center mb-4">
+            {cfg.icon}
+          </div>
+          <DialogHeader>
+            <DialogTitle className="text-xl font-bold text-white leading-snug">
+              {title}
+            </DialogTitle>
+          </DialogHeader>
+          <p className={`text-sm ${cfg.subtextColor} mt-1 leading-relaxed`}>
+            {description}
+          </p>
+        </div>
+
+        {/* Optional extra body */}
+        {body && (
+          <div className="px-6 py-4 text-sm text-gray-600 leading-relaxed">
+            {body}
+          </div>
+        )}
+
+        <DialogFooter
+          className={`px-6 py-4 bg-gray-50 border-t border-gray-100 flex flex-col-reverse sm:flex-row gap-2 ${
+            body ? "" : "mt-0"
+          }`}
+        >
+          {actions.map((a, idx) => (
+            <Button
+              key={`${a.label}-${idx}`}
+              variant={a.variant === "outline" ? "outline" : a.variant === "destructive" ? "destructive" : "default"}
+              onClick={a.onClick}
+              className={
+                a.variant !== "outline" && a.variant !== "destructive"
+                  ? "bg-gray-900 hover:bg-gray-800 text-white gap-2"
+                  : "border-gray-300 gap-2"
+              }
+            >
+              {a.icon}
+              {a.label}
+            </Button>
+          ))}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
+++ b/likelee-ui/src/components/agency/StripeReadinessGateModal.tsx
@@ -29,11 +29,12 @@ import {
   AlertTriangle,
   CheckCircle2,
   ExternalLink,
-  Users,
+  MessageSquare,
   ShieldAlert,
   ShieldCheck,
   ShieldX,
   ArrowRight,
+  Users,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
@@ -108,7 +109,13 @@ function PartyStatusPill({
   );
 }
 
-function PartyRow({ party }: { party: StripeReadinessParty }) {
+function PartyRow({
+  party,
+  onMessage,
+}: {
+  party: StripeReadinessParty;
+  onMessage?: (party: StripeReadinessParty) => void;
+}) {
   const roleLabel = party.party_type === "agency" ? "Agency" : "Talent";
   const initials = party.name
     .split(" ")
@@ -116,6 +123,9 @@ function PartyRow({ party }: { party: StripeReadinessParty }) {
     .join("")
     .slice(0, 2)
     .toUpperCase();
+
+  const canMessage =
+    onMessage && party.party_type === "creator" && !party.connected;
 
   return (
     <div className="flex items-center gap-3 py-3 border-b border-gray-100 last:border-0">
@@ -130,6 +140,16 @@ function PartyRow({ party }: { party: StripeReadinessParty }) {
         </p>
         <p className="text-xs text-gray-400 leading-tight">{roleLabel}</p>
       </div>
+      {/* Message shortcut — only for unconnected talents */}
+      {canMessage && (
+        <button
+          onClick={() => onMessage(party)}
+          className="p-1.5 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 transition-colors shrink-0"
+          title={`Message ${party.name}`}
+        >
+          <MessageSquare className="w-4 h-4" />
+        </button>
+      )}
       {/* Status pill */}
       <PartyStatusPill
         connected={party.connected}
@@ -174,6 +194,19 @@ export function StripeReadinessGateModal({
 
   // ── HARD BLOCK ─────────────────────────────────────────────────────────────
   if (gate === "hard_block") {
+    // Unconnected talents (not the agency) — these are the ones to message
+    const unconnectedTalents = unconnectedParties.filter(
+      (p) => p.party_type === "creator",
+    );
+
+    const handleMessageParty = (party: StripeReadinessParty) => {
+      onClose();
+      // creator_id is stored in party.id — openCreatorId pre-opens the conversation
+      navigate(
+        `/AgencyDashboard?tab=messages&openCreatorId=${encodeURIComponent(party.id)}`,
+      );
+    };
+
     return (
       <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
         <DialogContent className="sm:max-w-[460px] p-0 overflow-hidden gap-0">
@@ -202,7 +235,15 @@ export function StripeReadinessGateModal({
             </p>
             <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 divide-y divide-gray-100">
               {allParties.map((p) => (
-                <PartyRow key={p.id} party={p} />
+                <PartyRow
+                  key={p.id}
+                  party={p}
+                  onMessage={
+                    unconnectedTalents.length > 0
+                      ? handleMessageParty
+                      : undefined
+                  }
+                />
               ))}
             </div>
           </div>
@@ -210,12 +251,19 @@ export function StripeReadinessGateModal({
           {/* Explanation */}
           <div className="px-6 pb-2">
             <p className="text-xs text-gray-500 leading-relaxed">
-              Ask the{" "}
+              Ask{" "}
               {unconnectedParties.map((p) => p.name).join(", ")}{" "}
               to go to their{" "}
               <span className="font-semibold text-gray-700">Payouts</span>{" "}
               section and complete Stripe onboarding. Once connected, you can
-              send this contract.
+              send this contract.{" "}
+              {unconnectedTalents.length > 0 && (
+                <span>
+                  Use the{" "}
+                  <MessageSquare className="w-3 h-3 inline-block -mt-0.5 text-blue-500" />{" "}
+                  icon next to each talent to message them directly.
+                </span>
+              )}
             </p>
           </div>
 
@@ -231,6 +279,29 @@ export function StripeReadinessGateModal({
               >
                 <ExternalLink className="w-4 h-4" />
                 Go to Payouts
+              </Button>
+            )}
+            {unconnectedTalents.length === 1 && (
+              <Button
+                variant="outline"
+                className="gap-2 border-gray-300"
+                onClick={() => handleMessageParty(unconnectedTalents[0])}
+              >
+                <MessageSquare className="w-4 h-4" />
+                Message {unconnectedTalents[0].name}
+              </Button>
+            )}
+            {unconnectedTalents.length > 1 && (
+              <Button
+                variant="outline"
+                className="gap-2 border-gray-300"
+                onClick={() => {
+                  onClose();
+                  navigate("/AgencyDashboard?tab=messages");
+                }}
+              >
+                <MessageSquare className="w-4 h-4" />
+                Go to Messages
               </Button>
             )}
             <Button

--- a/likelee-ui/src/locales/brand/de.json
+++ b/likelee-ui/src/locales/brand/de.json
@@ -1269,7 +1269,7 @@
       "collaborators": "Mitarbeiter",
       "noCollaborators": "Noch keine Mitarbeiter zugewiesen.",
       "deliverablesFeedback": "Deliverables & Feedback",
-      "approvalThresholdWarning": "Wenn mehr als die Hälfte der Deliverables genehmigt wird, wird die Treuhand-Auszahlung einmalig ausgelöst und Downloads für alle Deliverables freigeschaltet. Genehmigungen sind endgültig und können nicht rückgängig gemacht werden.",
+      "approvalThresholdWarning": "Die Genehmigung von 1 Deliverable löst die Treuhand-Auszahlung einmalig aus und schaltet Downloads für alle Deliverables frei. Genehmigungen sind endgültig und können nicht rückgängig gemacht werden.",
       "assetsCount_one": "{{count}} Asset",
       "assetsCount_other": "{{count}} Assets",
       "videoLocked": "Video gesperrt",

--- a/likelee-ui/src/locales/brand/en.json
+++ b/likelee-ui/src/locales/brand/en.json
@@ -1534,7 +1534,7 @@
       "collaborators": "Collaborators",
       "noCollaborators": "No collaborators assigned yet.",
       "deliverablesFeedback": "Deliverables & Feedback",
-      "approvalThresholdWarning": "Approving more than half of deliverables triggers escrow payout (once) and unlocks downloads for all deliverables. Approvals are final and cannot be undone.",
+      "approvalThresholdWarning": "Approving 1 deliverable triggers escrow payout (once) and unlocks downloads for all deliverables. Approvals are final and cannot be undone.",
       "assetsCount_one": "{{count}} asset",
       "assetsCount_other": "{{count}} assets",
       "videoLocked": "Video locked",

--- a/likelee-ui/src/locales/brand/es.json
+++ b/likelee-ui/src/locales/brand/es.json
@@ -1534,7 +1534,7 @@
       "collaborators": "Colaboradores",
       "noCollaborators": "Aún no hay colaboradores asignados.",
       "deliverablesFeedback": "Entregables y comentarios",
-      "approvalThresholdWarning": "Aprobar más de la mitad de los entregables activa el pago en escrow una vez y desbloquea las descargas de todos los entregables. Las aprobaciones son definitivas.",
+      "approvalThresholdWarning": "Aprobar 1 entregable activa el pago en escrow una vez y desbloquea las descargas de todos los entregables. Las aprobaciones son definitivas.",
       "assetsCount_one": "{{count}} asset",
       "assetsCount_other": "{{count}} assets",
       "videoLocked": "Video bloqueado",

--- a/likelee-ui/src/locales/brand/fr.json
+++ b/likelee-ui/src/locales/brand/fr.json
@@ -1595,7 +1595,7 @@
       "collaborators": "Collaborateurs",
       "noCollaborators": "Aucun collaborateur assigné pour le moment.",
       "deliverablesFeedback": "Livrables et feedback",
-      "approvalThresholdWarning": "L'approbation de plus de la moitié des livrables déclenche le paiement escrow une fois et débloque les téléchargements pour tous les livrables. Les approbations sont définitives.",
+      "approvalThresholdWarning": "L'approbation d'un seul livrable déclenche le paiement escrow une fois et débloque les téléchargements pour tous les livrables. Les approbations sont définitives.",
       "assetsCount_one": "{{count}} asset",
       "assetsCount_other": "{{count}} assets",
       "videoLocked": "Vidéo verrouillée",

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -799,6 +799,8 @@ export default function BrandDashboard() {
   const [showCreatorProfile, setShowCreatorProfile] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [showContractModal, setShowContractModal] = useState(false);
+  const [contractPdfBlobUrl, setContractPdfBlobUrl] = useState<string | null>(null);
+  const [contractPdfLoading, setContractPdfLoading] = useState(false);
   const [selectedCampaignContracts, setSelectedCampaignContracts] = useState<
     any[]
   >([]);
@@ -5747,17 +5749,33 @@ export default function BrandDashboard() {
                                       variant="outline"
                                       size="sm"
                                       className="border-gray-200 text-gray-600"
-                                      onClick={() => {
-                                        if (contract?.signed_document_url) {
-                                          window.open(
-                                            contract.signed_document_url,
-                                            "_blank",
-                                          );
-                                        } else {
+                                      onClick={async () => {
+                                        const cOfferId = String(contract?.offer_id || "").trim();
+                                        const cId = String(contract?.id || "").trim();
+                                        if (!cOfferId || !cId) {
                                           toast({
                                             title: "Download Unavailable",
-                                            description:
-                                              "The signed document URL is not available yet.",
+                                            description: "The signed document URL is not available yet.",
+                                            variant: "destructive",
+                                          });
+                                          return;
+                                        }
+                                        try {
+                                          const response = await base44.getRaw(
+                                            `/api/campaign-offers/${encodeURIComponent(cOfferId)}/contracts/${encodeURIComponent(cId)}/download`,
+                                          );
+                                          if (!response.ok) throw new Error("Download failed");
+                                          const blob = await response.blob();
+                                          const url = URL.createObjectURL(blob);
+                                          const a = document.createElement("a");
+                                          a.href = url;
+                                          a.download = `${contract?.title || "signed-contract"}.pdf`;
+                                          a.click();
+                                          URL.revokeObjectURL(url);
+                                        } catch {
+                                          toast({
+                                            title: "Download failed",
+                                            description: "Could not download the signed contract. Please try again.",
                                             variant: "destructive",
                                           });
                                         }
@@ -6039,25 +6057,43 @@ export default function BrandDashboard() {
                               >
                                 <Archive className="h-4 w-4" />
                               </button>
-                              {/* Download — check both signed_document_url and meta.docuseal_document_url */}
+                              {/* Download — route through backend proxy so expired DocuSeal URLs are auto-refreshed */}
                               {(() => {
-                                const docUrl =
-                                  row?.signed_document_url ||
-                                  row?.meta?.docuseal_document_url ||
-                                  row?.meta?.signed_document_url;
-                                return docUrl ? (
-                                  <a
-                                    href={String(docUrl)}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    download
+                                const rowOfferId = String(row?.offer_id || "").trim();
+                                const rowContractId = String(row?.id || "").trim();
+                                const isCompleted = String(row?.docuseal_status || "").toLowerCase() === "completed";
+                                if (!isCompleted || !rowOfferId || !rowContractId) return null;
+                                return (
+                                  <button
+                                    type="button"
                                     title="Download signed contract"
                                     aria-label="Download"
                                     className="text-blue-700 hover:text-blue-800"
+                                    onClick={async () => {
+                                      try {
+                                        const response = await base44.getRaw(
+                                          `/api/campaign-offers/${encodeURIComponent(rowOfferId)}/contracts/${encodeURIComponent(rowContractId)}/download`,
+                                        );
+                                        if (!response.ok) throw new Error("Download failed");
+                                        const blob = await response.blob();
+                                        const url = URL.createObjectURL(blob);
+                                        const a = document.createElement("a");
+                                        a.href = url;
+                                        a.download = `${row?.title || "signed-contract"}.pdf`;
+                                        a.click();
+                                        URL.revokeObjectURL(url);
+                                      } catch {
+                                        toast({
+                                          title: "Download failed",
+                                          description: "Could not download the signed contract. Please try again.",
+                                          variant: "destructive" as any,
+                                        });
+                                      }
+                                    }}
                                   >
                                     <Download className="h-4 w-4" />
-                                  </a>
-                                ) : null;
+                                  </button>
+                                );
                               })()}
                             </div>
                           </td>
@@ -7576,10 +7612,39 @@ export default function BrandDashboard() {
                 variant="outline"
                 className="flex-1 border-2 border-gray-300"
                 onClick={async () => {
-                  await loadCampaignContractsForOffer(
-                    String(campaign.offer_id || ""),
-                  );
+                  const offerId = String(campaign.offer_id || "");
+                  await loadCampaignContractsForOffer(offerId);
                   setShowContractModal(true);
+                  // Fetch PDF via backend proxy so expired DocuSeal URLs are auto-refreshed
+                  setContractPdfBlobUrl(null);
+                  setContractPdfLoading(true);
+                  try {
+                    // contracts are loaded by loadCampaignContractsForOffer — wait briefly then pick first
+                    // We need the contract id; fetch contracts directly here
+                    const contractsResp = await base44.get<{ contracts?: any[] }>(
+                      `/api/campaign-offers/${encodeURIComponent(offerId)}/contracts`,
+                    );
+                    const contracts = Array.isArray(contractsResp?.contracts)
+                      ? contractsResp.contracts
+                      : [];
+                    const firstContract = contracts[0];
+                    const contractId = String(firstContract?.id || "").trim();
+                    if (!contractId) {
+                      setContractPdfLoading(false);
+                      return;
+                    }
+                    const response = await base44.getRaw(
+                      `/api/campaign-offers/${encodeURIComponent(offerId)}/contracts/${encodeURIComponent(contractId)}/download`,
+                    );
+                    if (!response.ok) throw new Error("Download failed");
+                    const blob = await response.blob();
+                    const blobUrl = URL.createObjectURL(blob);
+                    setContractPdfBlobUrl(blobUrl);
+                  } catch {
+                    // leave blobUrl null — modal will show fallback message
+                  } finally {
+                    setContractPdfLoading(false);
+                  }
                 }}
               >
                 <FileText className="w-4 h-4 mr-2" />
@@ -11417,7 +11482,13 @@ export default function BrandDashboard() {
       </Dialog>
 
       {/* View Contract Modal */}
-      <Dialog open={showContractModal} onOpenChange={setShowContractModal}>
+      <Dialog open={showContractModal} onOpenChange={(open) => {
+        setShowContractModal(open);
+        if (!open && contractPdfBlobUrl) {
+          URL.revokeObjectURL(contractPdfBlobUrl);
+          setContractPdfBlobUrl(null);
+        }
+      }}>
         <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-2xl font-bold text-gray-900">
@@ -11489,24 +11560,22 @@ export default function BrandDashboard() {
                     </div>
                   </Card>
                   <Card className="p-4 bg-white border border-gray-200">
-                    {String(
-                      selectedCampaignContracts[0]?.meta
-                        ?.docuseal_document_url ||
-                        selectedCampaignContracts[0]?.file_url ||
-                        "",
-                    ).trim() ? (
+                    {contractPdfLoading ? (
+                      <div className="flex items-center justify-center h-[70vh]">
+                        <div className="flex flex-col items-center gap-3 text-gray-500">
+                          <div className="w-8 h-8 border-2 border-gray-300 border-t-gray-600 rounded-full animate-spin" />
+                          <p className="text-sm">Loading contract...</p>
+                        </div>
+                      </div>
+                    ) : contractPdfBlobUrl ? (
                       <iframe
-                        src={String(
-                          selectedCampaignContracts[0]?.meta
-                            ?.docuseal_document_url ||
-                            selectedCampaignContracts[0]?.file_url,
-                        )}
+                        src={contractPdfBlobUrl}
                         className="w-full h-[70vh] border border-gray-200 rounded"
                         title="Campaign Contract Document"
                       />
                     ) : (
                       <p className="text-sm text-gray-600">
-                        Contract document URL is not available yet.
+                        Contract document is not available yet.
                       </p>
                     )}
                   </Card>
@@ -11514,7 +11583,13 @@ export default function BrandDashboard() {
                     <Button
                       variant="outline"
                       className="border-2 border-gray-300"
-                      onClick={() => setShowContractModal(false)}
+                      onClick={() => {
+                        setShowContractModal(false);
+                        if (contractPdfBlobUrl) {
+                          URL.revokeObjectURL(contractPdfBlobUrl);
+                          setContractPdfBlobUrl(null);
+                        }
+                      }}
                     >
                       {t("common.close", { defaultValue: "Close" })}
                     </Button>

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -799,7 +799,9 @@ export default function BrandDashboard() {
   const [showCreatorProfile, setShowCreatorProfile] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [showContractModal, setShowContractModal] = useState(false);
-  const [contractPdfBlobUrl, setContractPdfBlobUrl] = useState<string | null>(null);
+  const [contractPdfBlobUrl, setContractPdfBlobUrl] = useState<string | null>(
+    null,
+  );
   const [contractPdfLoading, setContractPdfLoading] = useState(false);
   const [selectedCampaignContracts, setSelectedCampaignContracts] = useState<
     any[]
@@ -5750,12 +5752,17 @@ export default function BrandDashboard() {
                                       size="sm"
                                       className="border-gray-200 text-gray-600"
                                       onClick={async () => {
-                                        const cOfferId = String(contract?.offer_id || "").trim();
-                                        const cId = String(contract?.id || "").trim();
+                                        const cOfferId = String(
+                                          contract?.offer_id || "",
+                                        ).trim();
+                                        const cId = String(
+                                          contract?.id || "",
+                                        ).trim();
                                         if (!cOfferId || !cId) {
                                           toast({
                                             title: "Download Unavailable",
-                                            description: "The signed document URL is not available yet.",
+                                            description:
+                                              "The signed document URL is not available yet.",
                                             variant: "destructive",
                                           });
                                           return;
@@ -5764,7 +5771,8 @@ export default function BrandDashboard() {
                                           const response = await base44.getRaw(
                                             `/api/campaign-offers/${encodeURIComponent(cOfferId)}/contracts/${encodeURIComponent(cId)}/download`,
                                           );
-                                          if (!response.ok) throw new Error("Download failed");
+                                          if (!response.ok)
+                                            throw new Error("Download failed");
                                           const blob = await response.blob();
                                           const url = URL.createObjectURL(blob);
                                           const a = document.createElement("a");
@@ -5775,7 +5783,8 @@ export default function BrandDashboard() {
                                         } catch {
                                           toast({
                                             title: "Download failed",
-                                            description: "Could not download the signed contract. Please try again.",
+                                            description:
+                                              "Could not download the signed contract. Please try again.",
                                             variant: "destructive",
                                           });
                                         }
@@ -6059,10 +6068,22 @@ export default function BrandDashboard() {
                               </button>
                               {/* Download — route through backend proxy so expired DocuSeal URLs are auto-refreshed */}
                               {(() => {
-                                const rowOfferId = String(row?.offer_id || "").trim();
-                                const rowContractId = String(row?.id || "").trim();
-                                const isCompleted = String(row?.docuseal_status || "").toLowerCase() === "completed";
-                                if (!isCompleted || !rowOfferId || !rowContractId) return null;
+                                const rowOfferId = String(
+                                  row?.offer_id || "",
+                                ).trim();
+                                const rowContractId = String(
+                                  row?.id || "",
+                                ).trim();
+                                const isCompleted =
+                                  String(
+                                    row?.docuseal_status || "",
+                                  ).toLowerCase() === "completed";
+                                if (
+                                  !isCompleted ||
+                                  !rowOfferId ||
+                                  !rowContractId
+                                )
+                                  return null;
                                 return (
                                   <button
                                     type="button"
@@ -6074,7 +6095,8 @@ export default function BrandDashboard() {
                                         const response = await base44.getRaw(
                                           `/api/campaign-offers/${encodeURIComponent(rowOfferId)}/contracts/${encodeURIComponent(rowContractId)}/download`,
                                         );
-                                        if (!response.ok) throw new Error("Download failed");
+                                        if (!response.ok)
+                                          throw new Error("Download failed");
                                         const blob = await response.blob();
                                         const url = URL.createObjectURL(blob);
                                         const a = document.createElement("a");
@@ -6085,7 +6107,8 @@ export default function BrandDashboard() {
                                       } catch {
                                         toast({
                                           title: "Download failed",
-                                          description: "Could not download the signed contract. Please try again.",
+                                          description:
+                                            "Could not download the signed contract. Please try again.",
                                           variant: "destructive" as any,
                                         });
                                       }
@@ -7621,7 +7644,9 @@ export default function BrandDashboard() {
                   try {
                     // contracts are loaded by loadCampaignContractsForOffer — wait briefly then pick first
                     // We need the contract id; fetch contracts directly here
-                    const contractsResp = await base44.get<{ contracts?: any[] }>(
+                    const contractsResp = await base44.get<{
+                      contracts?: any[];
+                    }>(
                       `/api/campaign-offers/${encodeURIComponent(offerId)}/contracts`,
                     );
                     const contracts = Array.isArray(contractsResp?.contracts)
@@ -11482,13 +11507,16 @@ export default function BrandDashboard() {
       </Dialog>
 
       {/* View Contract Modal */}
-      <Dialog open={showContractModal} onOpenChange={(open) => {
-        setShowContractModal(open);
-        if (!open && contractPdfBlobUrl) {
-          URL.revokeObjectURL(contractPdfBlobUrl);
-          setContractPdfBlobUrl(null);
-        }
-      }}>
+      <Dialog
+        open={showContractModal}
+        onOpenChange={(open) => {
+          setShowContractModal(open);
+          if (!open && contractPdfBlobUrl) {
+            URL.revokeObjectURL(contractPdfBlobUrl);
+            setContractPdfBlobUrl(null);
+          }
+        }}
+      >
         <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-2xl font-bold text-gray-900">

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -165,6 +165,7 @@ import { TrialCountdownBanner } from "@/components/brand/TrialCountdownBanner";
 import { useTeamAccess } from "@/features/team/useTeamAccess";
 import { TeamManagementCard } from "@/features/team/TeamManagementCard";
 import { BrandSettingsBilling } from "@/components/brand-dashboard/settings/BrandSettingsBilling";
+import { UnpaidDeliverableModal } from "@/components/brand/UnpaidDeliverableModal";
 import { currencyFormatter } from "@/lib/utils";
 import {
   LineChart,
@@ -351,6 +352,8 @@ export default function BrandDashboard() {
     amount?: number;
     currency?: string;
   }>({ open: false });
+  const [showUnpaidModal, setShowUnpaidModal] = useState(false);
+  const [unpaidOfferId, setUnpaidOfferId] = useState("");
 
   const billingSuccess = searchParams.get("billing_success") === "1";
   const billingSuccessProcessedRef = useRef(false);
@@ -5132,12 +5135,8 @@ export default function BrandDashboard() {
       return;
     }
     if (!isPaid) {
-      toast({
-        title: "Payment required",
-        description:
-          "Payment has not been received for this offer. Please complete payment to download deliverables.",
-        variant: "destructive" as any,
-      });
+      setUnpaidOfferId(offerId);
+      setShowUnpaidModal(true);
       return;
     }
     try {
@@ -5240,12 +5239,8 @@ export default function BrandDashboard() {
         .trim()
         .toLowerCase() === "paid";
     if (!isPaid) {
-      toast({
-        title: "Payment required",
-        description:
-          "You can’t approve or review deliverables until payment for this offer is completed.",
-        variant: "destructive" as any,
-      });
+      setUnpaidOfferId(offerId);
+      setShowUnpaidModal(true);
       deliverableReviewBusyRef.current.delete(deliverableId);
       return;
     }
@@ -14724,6 +14719,12 @@ export default function BrandDashboard() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <UnpaidDeliverableModal
+        open={showUnpaidModal}
+        onOpenChange={setShowUnpaidModal}
+        offerId={unpaidOfferId}
+      />
     </div>
   );
 }

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -3310,7 +3310,9 @@ export default function CreatorDashboard() {
   const [creatorTransfers, setCreatorTransfers] = useState<any[]>([]);
   const [loadingCreatorTransfers, setLoadingCreatorTransfers] = useState(false);
   // Tracks which offer_id is currently being retried (one at a time)
-  const [retryingTransferOfferId, setRetryingTransferOfferId] = useState<string | null>(null);
+  const [retryingTransferOfferId, setRetryingTransferOfferId] = useState<
+    string | null
+  >(null);
   // Stripe readiness gate modal for deliverable submission
   const [stripeGateModalOpen, setStripeGateModalOpen] = useState(false);
   const [stripeGateModalConfig, setStripeGateModalConfig] = useState<{
@@ -3364,7 +3366,11 @@ export default function CreatorDashboard() {
     if (retryingTransferOfferId) return;
     setRetryingTransferOfferId(offerId);
     try {
-      const resp = await base44.post<{ status: string; transfer_id?: string; message?: string }>(
+      const resp = await base44.post<{
+        status: string;
+        transfer_id?: string;
+        message?: string;
+      }>(
         `/api/talent/campaign-offers/${encodeURIComponent(offerId)}/retry-transfer`,
         {},
       );
@@ -3372,7 +3378,8 @@ export default function CreatorDashboard() {
         setStripeGateModalConfig({
           severity: "info",
           title: "Transfer succeeded",
-          description: resp.message || "Funds are on their way to your Stripe account.",
+          description:
+            resp.message || "Funds are on their way to your Stripe account.",
           actions: [
             {
               label: "Done",
@@ -3388,7 +3395,9 @@ export default function CreatorDashboard() {
       const isNotConnected = msg.includes("stripe_account_not_connected");
       setStripeGateModalConfig({
         severity: "block",
-        title: isNotConnected ? "Stripe account not connected" : "Transfer failed",
+        title: isNotConnected
+          ? "Stripe account not connected"
+          : "Transfer failed",
         description: isNotConnected
           ? "Your Stripe account is not connected. Go to Payouts to complete setup, then try again."
           : "The transfer could not be completed. Ensure your Stripe account has completed onboarding and try again.",
@@ -9554,7 +9563,10 @@ export default function CreatorDashboard() {
                       setStripeGateModalOpen(true);
                       return;
                     }
-                    if (payoutAccountStatus?.connected && !payoutAccountStatus?.transfers_enabled) {
+                    if (
+                      payoutAccountStatus?.connected &&
+                      !payoutAccountStatus?.transfers_enabled
+                    ) {
                       setStripeGateModalConfig({
                         severity: "warning",
                         title: "Stripe transfers not fully enabled",
@@ -9672,11 +9684,17 @@ export default function CreatorDashboard() {
                                     t("brandConnections.sendDeliverable"),
                                 )}
                               </div>
-                              {deliverableBlobUrls[String(deliverable?.id || "")] && (
+                              {deliverableBlobUrls[
+                                String(deliverable?.id || "")
+                              ] && (
                                 <div className="mt-2">
                                   {deliverableIsImage(deliverable) && (
                                     <img
-                                      src={deliverableBlobUrls[String(deliverable?.id || "")]}
+                                      src={
+                                        deliverableBlobUrls[
+                                          String(deliverable?.id || "")
+                                        ]
+                                      }
                                       alt={String(
                                         deliverable?.caption ||
                                           deliverable?.meta?.original_name ||
@@ -9687,7 +9705,11 @@ export default function CreatorDashboard() {
                                   )}
                                   {deliverableIsVideo(deliverable) && (
                                     <video
-                                      src={deliverableBlobUrls[String(deliverable?.id || "")]}
+                                      src={
+                                        deliverableBlobUrls[
+                                          String(deliverable?.id || "")
+                                        ]
+                                      }
                                       controls
                                       className="h-32 w-auto max-w-full rounded border border-gray-200 bg-black"
                                     />
@@ -9732,7 +9754,8 @@ export default function CreatorDashboard() {
                   {independentTransfers.map((transfer: any) => {
                     const isFailed = transfer.transfer_status === "failed";
                     const isCreated = transfer.transfer_status === "created";
-                    const isPendingRetry = transfer.transfer_status === "pending_retry";
+                    const isPendingRetry =
+                      transfer.transfer_status === "pending_retry";
                     return (
                       <div
                         key={transfer.offer_id}
@@ -9761,7 +9784,8 @@ export default function CreatorDashboard() {
                                   )
                                     ? "Stripe account not fully set up — transfers not enabled"
                                     : transfer.failure_reason.length > 100
-                                      ? transfer.failure_reason.slice(0, 100) + "…"
+                                      ? transfer.failure_reason.slice(0, 100) +
+                                        "…"
                                       : transfer.failure_reason}
                                 </p>
                               )}
@@ -9794,10 +9818,15 @@ export default function CreatorDashboard() {
                               <Button
                                 size="sm"
                                 className="h-7 px-3 text-xs bg-gray-900 hover:bg-gray-800 text-white font-semibold rounded-lg gap-1"
-                                disabled={retryingTransferOfferId === transfer.offer_id}
-                                onClick={() => retryCreatorTransfer(transfer.offer_id)}
+                                disabled={
+                                  retryingTransferOfferId === transfer.offer_id
+                                }
+                                onClick={() =>
+                                  retryCreatorTransfer(transfer.offer_id)
+                                }
                               >
-                                {retryingTransferOfferId === transfer.offer_id ? (
+                                {retryingTransferOfferId ===
+                                transfer.offer_id ? (
                                   <>
                                     <Loader2 className="w-3 h-3 animate-spin" />
                                     Retrying…
@@ -11471,22 +11500,27 @@ export default function CreatorDashboard() {
                           </span>
                           {transfer.transfer_status === "failed" &&
                             transfer.target_type === "creator" && (
-                            <Button
-                              size="sm"
-                              className="h-7 px-3 text-xs bg-gray-900 hover:bg-gray-800 text-white font-semibold rounded-lg gap-1"
-                              disabled={retryingTransferOfferId === transfer.offer_id}
-                              onClick={() => retryCreatorTransfer(transfer.offer_id)}
-                            >
-                              {retryingTransferOfferId === transfer.offer_id ? (
-                                <>
-                                  <Loader2 className="w-3 h-3 animate-spin" />
-                                  Retrying…
-                                </>
-                              ) : (
-                                "Claim payment"
-                              )}
-                            </Button>
-                          )}
+                              <Button
+                                size="sm"
+                                className="h-7 px-3 text-xs bg-gray-900 hover:bg-gray-800 text-white font-semibold rounded-lg gap-1"
+                                disabled={
+                                  retryingTransferOfferId === transfer.offer_id
+                                }
+                                onClick={() =>
+                                  retryCreatorTransfer(transfer.offer_id)
+                                }
+                              >
+                                {retryingTransferOfferId ===
+                                transfer.offer_id ? (
+                                  <>
+                                    <Loader2 className="w-3 h-3 animate-spin" />
+                                    Retrying…
+                                  </>
+                                ) : (
+                                  "Claim payment"
+                                )}
+                              </Button>
+                            )}
                         </div>
                       </div>
                     </div>
@@ -13586,9 +13620,7 @@ export default function CreatorDashboard() {
               <Button
                 className="bg-[#32C8D1] hover:bg-[#2AB8C1] text-white"
                 onClick={sendDeliverable}
-                disabled={
-                  offerActionLoading
-                }
+                disabled={offerActionLoading}
               >
                 {offerActionLoading
                   ? t("brandConnections.sending")

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -66,6 +66,10 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import {
+  ContractPrecheckModal,
+  type ContractPrecheckAction,
+} from "@/components/agency/StripeReadinessGateModal";
+import {
   Upload,
   Instagram,
   Mic,
@@ -3254,6 +3258,16 @@ export default function CreatorDashboard() {
   const [requestPayoutAmount, setRequestPayoutAmount] = useState("");
   const [creatorTransfers, setCreatorTransfers] = useState<any[]>([]);
   const [loadingCreatorTransfers, setLoadingCreatorTransfers] = useState(false);
+  // Tracks which offer_id is currently being retried (one at a time)
+  const [retryingTransferOfferId, setRetryingTransferOfferId] = useState<string | null>(null);
+  // Stripe readiness gate modal for deliverable submission
+  const [stripeGateModalOpen, setStripeGateModalOpen] = useState(false);
+  const [stripeGateModalConfig, setStripeGateModalConfig] = useState<{
+    severity: "block" | "warning" | "info";
+    title: string;
+    description: string;
+    actions: ContractPrecheckAction[];
+  }>({ severity: "block", title: "", description: "", actions: [] });
 
   const fetchPayoutStatus = async () => {
     if (!initialized || !authenticated || !user?.id) return;
@@ -3292,6 +3306,59 @@ export default function CreatorDashboard() {
       // best-effort
     } finally {
       setLoadingCreatorTransfers(false);
+    }
+  };
+
+  const retryCreatorTransfer = async (offerId: string) => {
+    if (retryingTransferOfferId) return;
+    setRetryingTransferOfferId(offerId);
+    try {
+      const resp = await base44.post<{ status: string; transfer_id?: string; message?: string }>(
+        `/api/talent/campaign-offers/${encodeURIComponent(offerId)}/retry-transfer`,
+        {},
+      );
+      if (resp?.status === "ok") {
+        setStripeGateModalConfig({
+          severity: "info",
+          title: "Transfer succeeded",
+          description: resp.message || "Funds are on their way to your Stripe account.",
+          actions: [
+            {
+              label: "Done",
+              onClick: () => setStripeGateModalOpen(false),
+            },
+          ],
+        });
+        setStripeGateModalOpen(true);
+        await refreshCreatorTransfers();
+      }
+    } catch (err: any) {
+      const msg = String(err?.message || "");
+      const isNotConnected = msg.includes("stripe_account_not_connected");
+      setStripeGateModalConfig({
+        severity: "block",
+        title: isNotConnected ? "Stripe account not connected" : "Transfer failed",
+        description: isNotConnected
+          ? "Your Stripe account is not connected. Go to Payouts to complete setup, then try again."
+          : "The transfer could not be completed. Ensure your Stripe account has completed onboarding and try again.",
+        actions: [
+          {
+            label: "Go to Payouts",
+            onClick: () => {
+              setStripeGateModalOpen(false);
+              setShowPayoutSettings(true);
+            },
+          },
+          {
+            label: "Close",
+            variant: "outline",
+            onClick: () => setStripeGateModalOpen(false),
+          },
+        ],
+      });
+      setStripeGateModalOpen(true);
+    } finally {
+      setRetryingTransferOfferId(null);
     }
   };
 
@@ -9412,6 +9479,60 @@ export default function CreatorDashboard() {
                 <Button
                   className="bg-[#32C8D1] hover:bg-[#2AB8C1] text-white"
                   onClick={() => {
+                    // Stripe readiness gate for independent creator offers.
+                    if (!payoutAccountStatus?.connected) {
+                      setStripeGateModalConfig({
+                        severity: "block",
+                        title: "Connect Stripe to submit deliverables",
+                        description:
+                          "You need to connect your Stripe account before submitting deliverables. This ensures you get paid when the brand approves your work.",
+                        actions: [
+                          {
+                            label: "Go to Payouts",
+                            onClick: () => {
+                              setStripeGateModalOpen(false);
+                              setShowPayoutSettings(true);
+                            },
+                          },
+                          {
+                            label: "Cancel",
+                            variant: "outline",
+                            onClick: () => setStripeGateModalOpen(false),
+                          },
+                        ],
+                      });
+                      setStripeGateModalOpen(true);
+                      return;
+                    }
+                    if (payoutAccountStatus?.connected && !payoutAccountStatus?.transfers_enabled) {
+                      setStripeGateModalConfig({
+                        severity: "warning",
+                        title: "Stripe transfers not fully enabled",
+                        description:
+                          "Your Stripe account is connected but transfers are not yet enabled. Complete your Stripe onboarding in Payouts to ensure you get paid on time. You can still submit deliverables now.",
+                        actions: [
+                          {
+                            label: "Submit anyway",
+                            onClick: () => {
+                              setStripeGateModalOpen(false);
+                              setSendDeliverableRequestId("");
+                              setSendDeliverableRequestMeta(null);
+                              setSendDeliverableOpen(true);
+                            },
+                          },
+                          {
+                            label: "Go to Payouts",
+                            variant: "outline",
+                            onClick: () => {
+                              setStripeGateModalOpen(false);
+                              setShowPayoutSettings(true);
+                            },
+                          },
+                        ],
+                      });
+                      setStripeGateModalOpen(true);
+                      return;
+                    }
                     setSendDeliverableRequestId("");
                     setSendDeliverableRequestMeta(null);
                     setSendDeliverableOpen(true);
@@ -9532,6 +9653,118 @@ export default function CreatorDashboard() {
                 );
               })}
             </div>
+
+            {/* Payout Status Panel — independent creator offers with released escrow */}
+            {(() => {
+              const independentTransfers = creatorTransfers.filter(
+                (t: any) => t.target_type === "creator",
+              );
+              if (independentTransfers.length === 0) return null;
+              return (
+                <div className="mt-6 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-bold text-gray-900">
+                      Payout Status
+                    </h4>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs text-gray-500 hover:text-gray-700"
+                      onClick={refreshCreatorTransfers}
+                      disabled={loadingCreatorTransfers}
+                    >
+                      <RefreshCw
+                        className={`w-3 h-3 mr-1 ${loadingCreatorTransfers ? "animate-spin" : ""}`}
+                      />
+                      Refresh
+                    </Button>
+                  </div>
+                  {independentTransfers.map((transfer: any) => {
+                    const isFailed = transfer.transfer_status === "failed";
+                    const isCreated = transfer.transfer_status === "created";
+                    const isPendingRetry = transfer.transfer_status === "pending_retry";
+                    return (
+                      <div
+                        key={transfer.offer_id}
+                        className="p-4 rounded-xl border border-gray-200 bg-gray-50/50"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex items-start gap-3 min-w-0">
+                            {isCreated ? (
+                              <CheckCircle2 className="w-4 h-4 text-emerald-500 mt-0.5 flex-shrink-0" />
+                            ) : isFailed || isPendingRetry ? (
+                              <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+                            ) : (
+                              <Clock className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+                            )}
+                            <div className="min-w-0">
+                              <p className="text-sm font-semibold text-gray-900 truncate">
+                                {transfer.offer_title}
+                              </p>
+                              <p className="text-xs text-gray-400">
+                                {transfer.brand_name}
+                              </p>
+                              {isFailed && transfer.failure_reason && (
+                                <p className="text-[11px] text-amber-700 mt-1 leading-snug">
+                                  {transfer.failure_reason.includes(
+                                    "insufficient_capabilities_for_transfer",
+                                  )
+                                    ? "Stripe account not fully set up — transfers not enabled"
+                                    : transfer.failure_reason.length > 100
+                                      ? transfer.failure_reason.slice(0, 100) + "…"
+                                      : transfer.failure_reason}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            <span className="text-sm font-bold text-gray-900">
+                              ${((transfer.amount_cents ?? 0) / 100).toFixed(2)}
+                            </span>
+                            <span
+                              className={`text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full border ${
+                                isCreated
+                                  ? "bg-emerald-50 text-emerald-700 border-emerald-200"
+                                  : isFailed
+                                    ? "bg-amber-50 text-amber-700 border-amber-200"
+                                    : isPendingRetry
+                                      ? "bg-blue-50 text-blue-700 border-blue-200"
+                                      : "bg-gray-50 text-gray-500 border-gray-200"
+                              }`}
+                            >
+                              {isCreated
+                                ? "Paid"
+                                : isFailed
+                                  ? "Failed"
+                                  : isPendingRetry
+                                    ? "Retrying"
+                                    : "Pending"}
+                            </span>
+                            {isFailed && (
+                              <Button
+                                size="sm"
+                                className="h-7 px-3 text-xs bg-gray-900 hover:bg-gray-800 text-white font-semibold rounded-lg gap-1"
+                                disabled={retryingTransferOfferId === transfer.offer_id}
+                                onClick={() => retryCreatorTransfer(transfer.offer_id)}
+                              >
+                                {retryingTransferOfferId === transfer.offer_id ? (
+                                  <>
+                                    <Loader2 className="w-3 h-3 animate-spin" />
+                                    Retrying…
+                                  </>
+                                ) : (
+                                  "Claim payment"
+                                )}
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })()}
           </Card>
         )}
 
@@ -11186,6 +11419,24 @@ export default function CreatorDashboard() {
                           >
                             {statusLabel}
                           </span>
+                          {transfer.transfer_status === "failed" &&
+                            transfer.target_type === "creator" && (
+                            <Button
+                              size="sm"
+                              className="h-7 px-3 text-xs bg-gray-900 hover:bg-gray-800 text-white font-semibold rounded-lg gap-1"
+                              disabled={retryingTransferOfferId === transfer.offer_id}
+                              onClick={() => retryCreatorTransfer(transfer.offer_id)}
+                            >
+                              {retryingTransferOfferId === transfer.offer_id ? (
+                                <>
+                                  <Loader2 className="w-3 h-3 animate-spin" />
+                                  Retrying…
+                                </>
+                              ) : (
+                                "Claim payment"
+                              )}
+                            </Button>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -13011,6 +13262,16 @@ export default function CreatorDashboard() {
           {activeSection === "brand-connection" && renderBrandConnection()}
           {activeSection === "talent-portal" && renderTalentPortal()}
         </div>
+
+        {/* Stripe readiness gate modal — deliverable submission + retry transfer feedback */}
+        <ContractPrecheckModal
+          open={stripeGateModalOpen}
+          onOpenChange={setStripeGateModalOpen}
+          severity={stripeGateModalConfig.severity}
+          title={stripeGateModalConfig.title}
+          description={stripeGateModalConfig.description}
+          actions={stripeGateModalConfig.actions}
+        />
 
         <Dialog
           open={sendDeliverableOpen}

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -2067,17 +2067,10 @@ export default function CreatorDashboard() {
       (offer: any) => String(offer?.id || "") === sendDeliverableOfferId,
     );
     const selectedOfferBrandId = String(selectedOffer?.brand_id || "");
-    const isPaid =
-      String(selectedOffer?.payment_status || "").toLowerCase() === "paid";
 
-    if (selectedOffer && !isPaid && !sendDeliverableRequestId) {
-      toast({
-        title: "Payment required",
-        description:
-          "The brand must complete the payment for this offer before deliverables can be uploaded.",
-        variant: "destructive",
-      });
-      return;
+    if (selectedOffer && !sendDeliverableRequestId) {
+      // Payment status is no longer a gate — creators can submit deliverables
+      // regardless of payment status. The brand cannot download until they pay.
     }
     if (!selectedOffer) {
       toast({
@@ -13333,21 +13326,6 @@ export default function CreatorDashboard() {
                 </div>
               )}
               {(() => {
-                const selectedOffer = brandOffers.find(
-                  (o) => String(o.id) === sendDeliverableOfferId,
-                );
-                const isPaid =
-                  String(selectedOffer?.payment_status || "").toLowerCase() ===
-                  "paid";
-                if (sendDeliverableOfferId && !isPaid) {
-                  return (
-                    <div className="flex items-center gap-2 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
-                      <span className="text-amber-700 text-sm font-semibold">
-                        {t("brandConnections.awaitingPayment")}
-                      </span>
-                    </div>
-                  );
-                }
                 return null;
               })()}
               <div className="space-y-2">
@@ -13552,18 +13530,7 @@ export default function CreatorDashboard() {
                 className="bg-[#32C8D1] hover:bg-[#2AB8C1] text-white"
                 onClick={sendDeliverable}
                 disabled={
-                  offerActionLoading ||
-                  (sendDeliverableOfferId &&
-                    (() => {
-                      const selectedOffer = brandOffers.find(
-                        (o) => String(o.id) === sendDeliverableOfferId,
-                      );
-                      return (
-                        String(
-                          selectedOffer?.payment_status || "",
-                        ).toLowerCase() !== "paid"
-                      );
-                    })())
+                  offerActionLoading
                 }
               >
                 {offerActionLoading

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -557,6 +557,44 @@ export default function CreatorDashboard() {
     }
     return new URL(normalizedPath, normalizedBase).toString();
   };
+
+  // Fetch a list of deliverables with auth and cache as blob URLs.
+  // All deliverables are stored in the private bucket and served via the authenticated
+  // /api/.../file endpoint — plain <img src> won't work without this.
+  const fetchDeliverableBlobUrls = async (deliverables: any[]) => {
+    const session = supabase
+      ? await supabase.auth.getSession()
+      : { data: { session: null } };
+    const token = session.data.session?.access_token;
+    await Promise.all(
+      deliverables.map(async (d: any) => {
+        const id = String(d?.id || "");
+        const rawUrl = String(d?.asset_url || "");
+        if (!id || !rawUrl || deliverableBlobFetching.current.has(id)) return;
+        deliverableBlobFetching.current.add(id);
+        try {
+          const normalizedBase = API_BASE_ABS.endsWith("/")
+            ? API_BASE_ABS
+            : `${API_BASE_ABS}/`;
+          const normalizedPath = rawUrl.startsWith("/")
+            ? rawUrl.slice(1)
+            : rawUrl;
+          const fullUrl = rawUrl.startsWith("http")
+            ? rawUrl
+            : new URL(normalizedPath, normalizedBase).toString();
+          const res = await fetch(fullUrl, {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+          });
+          if (!res.ok) return;
+          const blob = await res.blob();
+          const blobUrl = URL.createObjectURL(blob);
+          setDeliverableBlobUrls((prev) => ({ ...prev, [id]: blobUrl }));
+        } catch {
+          // silently ignore
+        }
+      }),
+    );
+  };
   const [activeSection, setActiveSection] = useState("dashboard");
   const [settingsTab, setSettingsTab] = useState("profile"); // 'profile' | 'rules' | 'billing'
 
@@ -646,6 +684,12 @@ export default function CreatorDashboard() {
   const [deliverableUrlByOffer, setDeliverableUrlByOffer] = useState<
     Record<string, string>
   >({});
+  // deliverable_id → authenticated blob URL for <img>/<video> display
+  const [deliverableBlobUrls, setDeliverableBlobUrls] = useState<
+    Record<string, string>
+  >({});
+  const deliverableBlobFetching = useRef<Set<string>>(new Set());
+
   const [creatorContractHubRows, setCreatorContractHubRows] = useState<any[]>(
     [],
   );
@@ -1932,6 +1976,20 @@ export default function CreatorDashboard() {
     setBrandOffers(Array.isArray(offers) ? offers : []);
     setJobInvites(Array.isArray(jobInvitesRes) ? jobInvitesRes : []);
   };
+
+  // Fetch blob URLs whenever offerDeliverablesById changes
+  useEffect(() => {
+    const all = Object.values(offerDeliverablesById).flat();
+    if (all.length > 0) void fetchDeliverableBlobUrls(all);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [offerDeliverablesById]);
+
+  // Fetch blob URLs whenever selectedOfferDeliverables changes
+  useEffect(() => {
+    if (selectedOfferDeliverables.length > 0)
+      void fetchDeliverableBlobUrls(selectedOfferDeliverables);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedOfferDeliverables]);
 
   const onRespond = async (id: string, action: "accept" | "decline") => {
     try {
@@ -8367,9 +8425,8 @@ export default function CreatorDashboard() {
                             )}
                           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4">
                             {requestDeliverables.map((deliverable: any) => {
-                              const assetUrl = String(
-                                deliverable?.asset_url || "",
-                              );
+                              const id = String(deliverable?.id || "");
+                              const assetUrl = deliverableBlobUrls[id] || "";
                               const caption =
                                 String(deliverable?.caption || "").trim() ||
                                 String(
@@ -9615,11 +9672,11 @@ export default function CreatorDashboard() {
                                     t("brandConnections.sendDeliverable"),
                                 )}
                               </div>
-                              {deliverable?.asset_url && (
+                              {deliverableBlobUrls[String(deliverable?.id || "")] && (
                                 <div className="mt-2">
                                   {deliverableIsImage(deliverable) && (
                                     <img
-                                      src={String(deliverable.asset_url)}
+                                      src={deliverableBlobUrls[String(deliverable?.id || "")]}
                                       alt={String(
                                         deliverable?.caption ||
                                           deliverable?.meta?.original_name ||
@@ -9630,7 +9687,7 @@ export default function CreatorDashboard() {
                                   )}
                                   {deliverableIsVideo(deliverable) && (
                                     <video
-                                      src={String(deliverable.asset_url)}
+                                      src={deliverableBlobUrls[String(deliverable?.id || "")]}
                                       controls
                                       className="h-32 w-auto max-w-full rounded border border-gray-200 bg-black"
                                     />


### PR DESCRIPTION
## PR Description

### Campaign Offer Escrow & Payout Reliability

**The real root cause**

The escrow release modal never appeared after a brand approved a deliverable. Tracing the issue back to its origin: contracts were being sent to brands and signed without any check that the agency or assigned talents had connected their Stripe accounts. This meant that when the brand paid and later approved a deliverable, the Stripe transfer to the agency failed with `insufficient_capabilities_for_transfer` — the account existed but transfers were not enabled. Because the transfer loop was fail-fast, this single failure aborted the entire release, talent transfers were never attempted, and the offer was left permanently stuck in `escrow_status = "releasing"`. Every subsequent approval attempt hit the unconditional `releasing` guard and silently returned `released_now: false` — no modal, no error, no recovery.

---

**Fix 1 — Prevent the problem at source: Stripe readiness gate before contract send**

A new `GET /api/agency/campaign-offers/:offer_id/stripe-readiness` endpoint checks Stripe connectivity for the agency and every assigned talent before the DocuSeal submission is created. The agency UI enforces this at the moment the "Send" button is clicked:

- **Hard block** — any party has no Stripe account connected → contract cannot be sent, modal lists who is missing with a direct "Message talent" shortcut
- **Soft warning** — all connected but some have `transfers_enabled = false` → can still send with a warning explaining the escrow retry path

Name resolution uses `agency_users` first, then falls back to `creators.full_name` for connected creators without an agency roster row. Stripe health checks run in parallel for all parties.

**Fix 2 — Make the transfer loop resilient: best-effort transfers**

`release_campaign_offer_transfers` is rewritten so agency and talent transfers are each attempted independently. A failure on one recipient is logged and recorded in `campaign_offer_transfers` but never aborts the others. `escrow_status` is set to `"released"` after all attempts regardless of individual outcomes — it is the authorization signal that the brand has approved, not a guarantee that every transfer succeeded. Failed transfers remain retryable from the agency Deliverables tab.

**Fix 3 — Auto-recover stuck `releasing` state**

The `releasing` guard in `try_release_campaign_offer_escrow` now checks `campaign_offer_transfers` for failed rows. If found, it falls through and retries the full release. If no failed rows exist, the race condition protection is preserved. Existing stuck offers recover automatically on the next deliverable approval after resetting `escrow_status` to `holding`.

**Fix 4 — Correct UI copy**

`approvalThresholdWarning` updated in all four locales (en, fr, es, de) from "more than half of deliverables" to "1 deliverable" to match the actual backend threshold.

---

**Testing**

- Contract send with unconnected talent → hard block modal, message shortcut works
- Contract send with transfers-disabled accounts → soft warning, "Send anyway" proceeds
- Existing stuck offer → reset to `holding`, approve 1 deliverable → escrow modal appears, all transfers attempted, failed ones retryable
- Fresh offer, all Stripe ready → approve 1 deliverable → modal appears, all transfers created
- Fresh offer, agency transfers disabled → modal appears, agency transfer recorded as failed, talent transfers succeed

**Cargo build:** clean.