### PR TITLE
fix(billing): recover from stale Stripe customer IDs on checkout for …

### DIFF
--- a/likelee-server/src/billing.rs
+++ b/likelee-server/src/billing.rs
@@ -854,6 +854,17 @@ async fn get_brand_checkout_row(
         .ok_or((StatusCode::NOT_FOUND, "brand_profile_not_found".to_string()))
 }
 
+/// Verify a stored Stripe customer ID still exists in the current Stripe account.
+/// Returns true if valid, false if stale/deleted/not found.
+async fn stripe_customer_exists(client: &stripe_sdk::Client, customer_id: &str) -> bool {
+    let Ok(cid) = customer_id.trim().parse::<stripe_sdk::CustomerId>() else {
+        return false;
+    };
+    stripe_sdk::Customer::retrieve(client, &cid, &[])
+        .await
+        .is_ok()
+}
+
 async fn ensure_brand_customer(
     state: &AppState,
     brand_id: &str,
@@ -861,11 +872,31 @@ async fn ensure_brand_customer(
     company_name: &str,
     existing_customer: &str,
 ) -> Result<String, (StatusCode, String)> {
+    let client = stripe_sdk::Client::new(state.stripe_secret_key.clone());
+
+    // If we have a stored customer ID, verify it still exists in Stripe.
+    // It may be stale if the Stripe account was reset, switched between test/live mode,
+    // or the customer was manually deleted.
     if !existing_customer.trim().is_empty() {
-        return Ok(existing_customer.to_string());
+        if stripe_customer_exists(&client, existing_customer).await {
+            return Ok(existing_customer.to_string());
+        }
+        warn!(
+            brand_id = %brand_id,
+            stale_customer_id = %existing_customer,
+            "Stored Stripe customer ID is stale or invalid; creating a new customer"
+        );
+        // Clear the stale ID from the DB
+        let _ = state
+            .pg
+            .from("brands")
+            .eq("id", brand_id)
+            .update(json!({ "stripe_customer_id": null }).to_string())
+            .execute()
+            .await;
     }
 
-    let client = stripe_sdk::Client::new(state.stripe_secret_key.clone());
+    // Create a new Stripe customer
     let mut params = stripe_sdk::CreateCustomer::new();
     if !email.trim().is_empty() {
         params.email = Some(email);
@@ -1246,9 +1277,25 @@ async fn get_or_create_agency_billing_context(
         .unwrap_or(false);
 
     let client = stripe_sdk::Client::new(state.stripe_secret_key.clone());
-    let customer_id = if !existing_customer.trim().is_empty() {
+    let customer_id = if !existing_customer.trim().is_empty()
+        && stripe_customer_exists(&client, &existing_customer).await
+    {
         existing_customer
     } else {
+        if !existing_customer.trim().is_empty() {
+            warn!(
+                agency_id = %agency_id,
+                stale_customer_id = %existing_customer,
+                "Stored Stripe customer ID is stale or invalid; creating a new customer"
+            );
+            let _ = state
+                .pg
+                .from("agencies")
+                .eq("id", agency_id)
+                .update(json!({ "stripe_customer_id": null }).to_string())
+                .execute()
+                .await;
+        }
         let mut params = stripe_sdk::CreateCustomer::new();
         if !email.trim().is_empty() {
             params.email = Some(email.as_str());
@@ -2856,9 +2903,25 @@ pub async fn create_creator_subscription_checkout(
             return Err((StatusCode::FORBIDDEN, "trial_already_used".to_string()));
         }
     }
-    let customer_id = if !existing_customer.is_empty() {
+    let customer_id = if !existing_customer.is_empty()
+        && stripe_customer_exists(&client, &existing_customer).await
+    {
         existing_customer
     } else {
+        if !existing_customer.is_empty() {
+            warn!(
+                creator_id = %creator_id,
+                stale_customer_id = %existing_customer,
+                "Stored Stripe customer ID is stale or invalid; creating a new customer"
+            );
+            let _ = state
+                .pg
+                .from("creators")
+                .eq("id", &creator_id)
+                .update(json!({ "stripe_customer_id": null }).to_string())
+                .execute()
+                .await;
+        }
         let mut params = stripe_sdk::CreateCustomer::new();
         if let Some(email) = creator_row
             .get("email")

--- a/likelee-server/src/billing.rs
+++ b/likelee-server/src/billing.rs
@@ -865,6 +865,46 @@ async fn stripe_customer_exists(client: &stripe_sdk::Client, customer_id: &str) 
         .is_ok()
 }
 
+/// Clear a stale stripe_customer_id from the given table row.
+/// Logs a warning if the DB update fails so the issue is visible in logs.
+async fn clear_stale_customer_id(
+    state: &AppState,
+    table: &str,
+    id_column: &str,
+    id_value: &str,
+    stale_customer_id: &str,
+) {
+    match state
+        .pg
+        .from(table)
+        .eq(id_column, id_value)
+        .update(json!({ "stripe_customer_id": null }).to_string())
+        .execute()
+        .await
+    {
+        Ok(resp) if !resp.status().is_success() => {
+            let body = resp.text().await.unwrap_or_default();
+            warn!(
+                table = %table,
+                id = %id_value,
+                stale_customer_id = %stale_customer_id,
+                status = %body,
+                "failed to clear stale stripe_customer_id from DB — stale ID may persist"
+            );
+        }
+        Err(e) => {
+            warn!(
+                table = %table,
+                id = %id_value,
+                stale_customer_id = %stale_customer_id,
+                error = %e,
+                "transport error clearing stale stripe_customer_id from DB — stale ID may persist"
+            );
+        }
+        _ => {}
+    }
+}
+
 async fn ensure_brand_customer(
     state: &AppState,
     brand_id: &str,
@@ -886,14 +926,7 @@ async fn ensure_brand_customer(
             stale_customer_id = %existing_customer,
             "Stored Stripe customer ID is stale or invalid; creating a new customer"
         );
-        // Clear the stale ID from the DB
-        let _ = state
-            .pg
-            .from("brands")
-            .eq("id", brand_id)
-            .update(json!({ "stripe_customer_id": null }).to_string())
-            .execute()
-            .await;
+        clear_stale_customer_id(state, "brands", "id", brand_id, existing_customer).await;
     }
 
     // Create a new Stripe customer
@@ -1288,13 +1321,7 @@ async fn get_or_create_agency_billing_context(
                 stale_customer_id = %existing_customer,
                 "Stored Stripe customer ID is stale or invalid; creating a new customer"
             );
-            let _ = state
-                .pg
-                .from("agencies")
-                .eq("id", agency_id)
-                .update(json!({ "stripe_customer_id": null }).to_string())
-                .execute()
-                .await;
+            clear_stale_customer_id(state, "agencies", "id", agency_id, &existing_customer).await;
         }
         let mut params = stripe_sdk::CreateCustomer::new();
         if !email.trim().is_empty() {
@@ -2903,24 +2930,18 @@ pub async fn create_creator_subscription_checkout(
             return Err((StatusCode::FORBIDDEN, "trial_already_used".to_string()));
         }
     }
-    let customer_id = if !existing_customer.is_empty()
+    let customer_id = if !existing_customer.trim().is_empty()
         && stripe_customer_exists(&client, &existing_customer).await
     {
         existing_customer
     } else {
-        if !existing_customer.is_empty() {
+        if !existing_customer.trim().is_empty() {
             warn!(
                 creator_id = %creator_id,
                 stale_customer_id = %existing_customer,
                 "Stored Stripe customer ID is stale or invalid; creating a new customer"
             );
-            let _ = state
-                .pg
-                .from("creators")
-                .eq("id", &creator_id)
-                .update(json!({ "stripe_customer_id": null }).to_string())
-                .execute()
-                .await;
+            clear_stale_customer_id(&state, "creators", "id", &creator_id, &existing_customer).await;
         }
         let mut params = stripe_sdk::CreateCustomer::new();
         if let Some(email) = creator_row

--- a/likelee-server/src/billing.rs
+++ b/likelee-server/src/billing.rs
@@ -2941,7 +2941,8 @@ pub async fn create_creator_subscription_checkout(
                 stale_customer_id = %existing_customer,
                 "Stored Stripe customer ID is stale or invalid; creating a new customer"
             );
-            clear_stale_customer_id(&state, "creators", "id", &creator_id, &existing_customer).await;
+            clear_stale_customer_id(&state, "creators", "id", &creator_id, &existing_customer)
+                .await;
         }
         let mut params = stripe_sdk::CreateCustomer::new();
         if let Some(email) = creator_row


### PR DESCRIPTION
## fix(billing): recover from stale Stripe customer IDs on checkout

**Problem**

Existing users (brands, agencies, creators) were hitting a `No such customer: 'cus_xxx'` error when trying to subscribe. The stored `stripe_customer_id` in the DB was pointing to a customer that no longer existed in Stripe — caused by a Stripe test environment reset that wiped all test customers while the DB retained the old IDs. New users were unaffected since they always get a fresh customer created.

**What was fixed**

Added a shared `stripe_customer_exists()` helper in `billing.rs` that verifies a stored customer ID against the Stripe API before using it. If the customer is stale or deleted, the ID is cleared from the DB and a new Stripe customer is created transparently. Applied to all three checkout paths: brand, agency, and creator.

**Subscription renewal verification**

As part of investigating the root cause, we verified the full subscription lifecycle using Stripe Test Clocks:
- Trial end → invoice created (Draft) → clock advanced → invoice finalized → `invoice.paid` webhook → DB updated correctly (`plan_tier`, `subscription_status`, `subscription_current_period_end`)
- Renewal cycle works identically — advancing the clock past `current_period_end` triggers the full webhook sequence and DB sync as expected

**How to test**

1. Create a brand account and subscribe via the app
2. Manually set `stripe_customer_id` to a fake value (e.g. `cus_invalid123`) in the `brands` table
3. Try to subscribe again — should succeed without error, and the DB should have a new valid `stripe_customer_id`
4. For renewal: use Stripe Test Clocks — create a clock, subscribe a customer under it, advance past the trial end, then advance past `current_period_end` — verify `subscription_current_period_end` advances in the `brands` table after each cycle