### PR TITLE
fix: flow fixes — translations, asset refresh, LR stubs, logo upload, deliverable modal

### DIFF
--- a/likelee-ui/src/components/agency/BrandConnectionsView.tsx
+++ b/likelee-ui/src/components/agency/BrandConnectionsView.tsx
@@ -541,7 +541,6 @@ const BrandConnectionsView = ({
       );
       return refreshed;
     },
-    refetchInterval: 5000,
   });
 
   const offerDeliverablesQuery = useQuery({
@@ -553,7 +552,6 @@ const BrandConnectionsView = ({
       );
       return Array.isArray(resp?.deliverables) ? resp.deliverables : [];
     },
-    refetchInterval: 5000,
   });
 
   const rosterQuery = useQuery({

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -58,7 +58,12 @@ export const LicensingRequestsTab = ({
     queryFn: async () => {
       const resp = await getAgencyLicensingRequests();
       // Ensure we always return an array even if backend returns an object or null
-      return Array.isArray(resp) ? resp : (resp as any)?.data || [];
+      const rows = Array.isArray(resp) ? resp : (resp as any)?.data || [];
+      // Filter out campaign-offer billing stubs — they are internal accounting
+      // records and have nothing to do with actual licensing requests.
+      return rows.filter(
+        (r: any) => String(r?.context_type || "").toLowerCase() !== "campaign",
+      );
     },
   });
 
@@ -652,8 +657,7 @@ export const LicensingRequestsTab = ({
                   </Button>
                 </div>
               ) : group.submission_id ||
-                !group.brand_id ? // Agency-initiated via SubmissionWizard — no brand actions needed,
-              // the agency is waiting on the client to sign. Show nothing.
+                !group.brand_id ? // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
               null : null}
             </Card>
           ))}

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -657,8 +657,8 @@ export const LicensingRequestsTab = ({
                   </Button>
                 </div>
               ) : group.submission_id ||
-                !group.brand_id ? // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
-              null : null}
+                !group.brand_id ? null : null // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
+              }
             </Card>
           ))}
         </div>

--- a/likelee-ui/src/locales/common/de.json
+++ b/likelee-ui/src/locales/common/de.json
@@ -1546,7 +1546,11 @@
     },
     "organization": "Organization",
     "unknown": "Unknown",
-    "noResults": "No Results"
+    "noResults": "No Results",
+    "new": "Neu",
+    "approved": "Genehmigt",
+    "close": "Schließen",
+    "agency": "Agentur"
   },
   "licensingSettingsPage": {
     "title": "Lizenzeinstellungen",

--- a/likelee-ui/src/locales/common/en.json
+++ b/likelee-ui/src/locales/common/en.json
@@ -965,7 +965,11 @@
       "constraintViolation": "Invalid data. Please check your input and try again."
     },
     "unknown": "Unknown",
-    "noResults": "No Results"
+    "noResults": "No Results",
+    "new": "New",
+    "approved": "Approved",
+    "close": "Close",
+    "agency": "Agency"
   },
   "faces.realFutures.title": "Real Faces. Real Futures.",
   "faces.realFutures.line1": "Brands and studios are already generating AI campaigns — most use unlicensed or synthetic faces.",

--- a/likelee-ui/src/locales/common/es.json
+++ b/likelee-ui/src/locales/common/es.json
@@ -1291,7 +1291,11 @@
     },
     "organization": "Organization",
     "unknown": "Unknown",
-    "noResults": "No Results"
+    "noResults": "No Results",
+    "new": "Nuevo",
+    "approved": "Aprobado",
+    "close": "Cerrar",
+    "agency": "Agencia"
   },
   "licensingSettingsPage": {
     "title": "Configuración de Licencias",

--- a/likelee-ui/src/locales/common/fr.json
+++ b/likelee-ui/src/locales/common/fr.json
@@ -1646,7 +1646,11 @@
     "profilePhotoOptional": "Profile Photo (optional)",
     "agencyOptional": "Agency (if applicable)",
     "unknown": "Unknown",
-    "noResults": "No Results"
+    "noResults": "No Results",
+    "new": "Nouveau",
+    "approved": "Approuvé",
+    "close": "Fermer",
+    "agency": "Agence"
   },
   "licensingSettingsPage": {
     "title": "Paramètres de Licence",

--- a/likelee-ui/src/pages/BrandCampaignDashboard.tsx
+++ b/likelee-ui/src/pages/BrandCampaignDashboard.tsx
@@ -4849,20 +4849,28 @@ export default function BrandCampaignDashboard({
                             return (
                               <Card
                                 key={deliverableId || idx}
-                                className={`p-6 border-2 border-gray-200 rounded-none hover:border-gray-300 transition-colors shadow-none ${
-                                  isPaid ? "cursor-zoom-in" : "cursor-default"
-                                }`}
-                                onClick={() => {
-                                  setPreviewItems(selectedCampaignDeliverables);
-                                  setPreviewIndex(idx);
-                                  setPreviewImage({
-                                    ...deliverable,
-                                    payment_status: deliverable?.payment_status,
-                                  });
-                                }}
+                                className="p-6 border-2 border-gray-200 rounded-none hover:border-gray-300 transition-colors shadow-none"
                               >
                                 <div className="flex items-start gap-6">
-                                  <div className="w-48 h-32 bg-gray-100 rounded-none flex items-center justify-center overflow-hidden border border-gray-200">
+                                  <div
+                                    className={`w-48 h-32 bg-gray-100 rounded-none flex items-center justify-center overflow-hidden border border-gray-200 ${
+                                      isPaid
+                                        ? "cursor-zoom-in"
+                                        : "cursor-default"
+                                    }`}
+                                    onClick={() => {
+                                      if (!isPaid) return;
+                                      setPreviewItems(
+                                        selectedCampaignDeliverables,
+                                      );
+                                      setPreviewIndex(idx);
+                                      setPreviewImage({
+                                        ...deliverable,
+                                        payment_status:
+                                          deliverable?.payment_status,
+                                      });
+                                    }}
+                                  >
                                     {String(
                                       deliverable?.asset_type || "",
                                     ).startsWith("image") &&

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -2574,14 +2574,31 @@ export default function BrandDashboard() {
         (resp as any)?.url ||
         (resp as any)?.file_url;
       if (!publicUrl) throw new Error("No URL returned from upload");
-      setBrand({ ...brand, logo: publicUrl });
-      // Persist immediately so the logo is saved even without clicking Save Profile
-      await updateBrandProfile({
-        company_name: brand?.name,
-        industry: brand?.industry,
-        website: brand?.website,
+
+      // Persist to backend
+      const updatedProfile = await updateBrandProfile({
         logo_url: publicUrl,
       });
+      const nextProfile =
+        updatedProfile && typeof updatedProfile === "object"
+          ? updatedProfile
+          : {};
+
+      // Update local brand state
+      const nextBrand = {
+        ...(brand ?? {}),
+        logo: (nextProfile as any)?.logo_url ?? publicUrl,
+      };
+      setBrand(nextBrand);
+
+      // Update both React Query and IndexedDB caches so the useEffect
+      // doesn't overwrite the new logo with the stale cached value
+      queryClient.setQueryData(["brand-profile", user?.id], nextProfile);
+      await setCachedQuery(["brand-profile", user?.id], nextProfile);
+      await queryClient.invalidateQueries({
+        queryKey: ["brand-profile", user?.id],
+      });
+
       toast({ title: "Success", description: "Logo uploaded successfully!" });
     } catch (err: any) {
       toast({

--- a/likelee-ui/src/pages/BrandDashboard.tsx
+++ b/likelee-ui/src/pages/BrandDashboard.tsx
@@ -30,6 +30,7 @@ import {
   listBrandStorageFilesPaged,
   listBrandStorageFoldersPaged,
   getBrandStorageFileSignedUrl,
+  uploadBrandStorageFile,
 } from "@/api/functions";
 import {
   listGenerations,
@@ -2559,15 +2560,37 @@ export default function BrandDashboard() {
     },
   ];
 
-  const handleLogoUpload = (e) => {
+  const handleLogoUpload = async (e) => {
     const file = e.target.files[0];
-    if (file) {
-      setUploadingLogo(true);
-      setTimeout(() => {
-        setBrand({ ...brand, logo: URL.createObjectURL(file) });
-        setUploadingLogo(false);
-        toast({ title: "Success", description: "Logo uploaded! (Demo mode)" });
-      }, 1000);
+    if (!file) return;
+    setUploadingLogo(true);
+    try {
+      const resp = await uploadBrandStorageFile({
+        file,
+        visibility: "public",
+      });
+      const publicUrl =
+        (resp as any)?.public_url ||
+        (resp as any)?.url ||
+        (resp as any)?.file_url;
+      if (!publicUrl) throw new Error("No URL returned from upload");
+      setBrand({ ...brand, logo: publicUrl });
+      // Persist immediately so the logo is saved even without clicking Save Profile
+      await updateBrandProfile({
+        company_name: brand?.name,
+        industry: brand?.industry,
+        website: brand?.website,
+        logo_url: publicUrl,
+      });
+      toast({ title: "Success", description: "Logo uploaded successfully!" });
+    } catch (err: any) {
+      toast({
+        title: "Upload failed",
+        description: err?.message || "Could not upload logo. Please try again.",
+        variant: "destructive" as any,
+      });
+    } finally {
+      setUploadingLogo(false);
     }
   };
 


### PR DESCRIPTION
## Summary

This PR addresses 5 UX and data-integrity bugs found across the brand and agency dashboards.

### 1. Missing translation keys (`common.new`, `common.approved`)

**Problem:** Raw translation keys like `common.new` were rendering as literal strings in the UI instead of their translated values (e.g. on deliverable status badges in the Brand Dashboard).

**Fix:** Added the missing `new`, `approved`, `close`, and `agency` keys under the `common` namespace object in all 4 locale files (`en`, `es`, `de`, `fr`). The keys existed elsewhere in the files but not under the `common` object where the code was looking.

### 2. Asset Requests constant refresh ("Loading requests..." loop)

**Problem:** The `offerContractsQuery` and `offerDeliverablesQuery` in `BrandConnectionsView.tsx` both had `refetchInterval: 5000`, causing them to re-fetch every 5 seconds. This produced a constant "Loading requests..." flash that was disruptive to the UX.

**Fix:** Removed `refetchInterval: 5000` from both queries. Data is now fetched on demand (on mount and on explicit invalidation) rather than on a polling loop.

### 3. Blank Licensing Request card appearing under LR tab when Campaign Offers are created

**Problem:** When a brand creates a campaign offer targeting an agency, the server creates an internal billing stub in the `licensing_requests` table (with `context_type: "campaign"`) for accounting purposes. This stub has no `license_fee`, `regions`, `deadline`, or other LR-specific fields, so it appeared as a blank card in the agency's Licensing Requests tab. Brand offers have nothing to do with actual licensing requests.

**Fix:** Added a frontend filter in `LicensingRequestsTab.tsx` to exclude any record where `context_type === "campaign"`. The backend already has this filter in the PostgREST query, but this adds a safety net on the client side.

### 4. Brand logo upload not persisting

**Problem:** The `handleLogoUpload` function in `BrandDashboard.tsx` was only creating a local `URL.createObjectURL()` blob URL and setting it in component state — it never uploaded the file to storage or saved the URL to the backend. Additionally, even after fixing the upload, the `useIndexedDbQuery` (5-minute cache) was serving a stale profile from IndexedDB, and the `useEffect` that syncs `brand.logo` from the query data was overwriting the newly uploaded logo URL with the old cached value.

**Fix:**
- Replaced the fake demo-mode timeout with a real `uploadBrandStorageFile` call (uploads to Supabase storage with `visibility: "public"`).
- Immediately calls `updateBrandProfile({ logo_url })` to persist the URL to the `brands` table.
- Updates both the React Query cache (`queryClient.setQueryData`) and the IndexedDB cache (`setCachedQuery`) with the returned profile — the same pattern used by `handleSaveProfile` — so the `useEffect` sees the new `logo_url` and doesn't overwrite it with the stale cached value.

### 5. Deliverable card opens image modal on any click (should only open on image click)

**Problem:** In `BrandCampaignDashboard.tsx`, the deliverable `<Card>` component had an `onClick` handler that opened the image preview modal regardless of where on the card the user clicked — including buttons, text, and other interactive elements.

**Fix:** Removed the `onClick` from the `<Card>` and moved it to only the image/video thumbnail `<div>`. The modal now only opens when the user directly clicks the media thumbnail, not the rest of the card.