### PR TITLE
fix: agency licensing visibility, creator PDF upload, and duplicate brand offer cards

### DIFF
--- a/likelee-server/src/campaigns/legacy.rs
+++ b/likelee-server/src/campaigns/legacy.rs
@@ -5999,28 +5999,49 @@ pub async fn upload_offer_asset_request_file(
     State(state): State<AppState>,
     user: AuthUser,
     Path(OfferPath { offer_id }): Path<OfferPath>,
-    headers: HeaderMap,
-    body: axum::body::Bytes,
+    mut multipart: axum::extract::Multipart,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     if user.role != "agency" {
         return Err((StatusCode::FORBIDDEN, "Forbidden".to_string()));
     }
     let _offer = ensure_offer_access(&state, &user, &offer_id).await?;
-    if body.is_empty() {
+
+    let mut file_data = Vec::new();
+    let mut content_type = "application/pdf".to_string();
+
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        error!(error = %e, "Failed to get next field from multipart");
+        (StatusCode::BAD_REQUEST, e.to_string())
+    })? {
+        let name = field.name().unwrap_or("").to_string();
+        if name == "file" {
+            content_type = field
+                .content_type()
+                .unwrap_or("application/pdf")
+                .to_string();
+            file_data = field
+                .bytes()
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "Failed to read bytes from multipart field");
+                    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+                })?
+                .to_vec();
+        }
+    }
+
+    if file_data.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "missing file bytes".to_string()));
     }
     const MAX_FILE_SIZE: usize = 25_000_000;
-    if body.len() > MAX_FILE_SIZE {
+    if file_data.len() > MAX_FILE_SIZE {
         return Err((
             StatusCode::PAYLOAD_TOO_LARGE,
             "file too large (max 25MB)".to_string(),
         ));
     }
-    let content_type = headers
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/pdf");
-    let ext = if content_type == "application/pdf" {
+
+    let ext = if content_type.contains("pdf") {
         "pdf"
     } else {
         "bin"
@@ -6039,8 +6060,8 @@ pub async fn upload_offer_asset_request_file(
             format!("Bearer {}", state.supabase_service_key),
         )
         .header("apikey", state.supabase_service_key.clone())
-        .header("content-type", content_type)
-        .body(body)
+        .header("content-type", &content_type)
+        .body(file_data)
         .send()
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;

--- a/likelee-server/src/catalogs/handlers.rs
+++ b/likelee-server/src/catalogs/handlers.rs
@@ -235,8 +235,10 @@ pub async fn list_eligible_requests(
 
         if is_eligible {
             let today = chrono::Utc::now().date_naive();
-            let end_date_str = row.get("license_end_date").and_then(|v| v.as_str())
-                                  .or_else(|| row.get("deadline").and_then(|v| v.as_str()));
+            let end_date_str = row
+                .get("license_end_date")
+                .and_then(|v| v.as_str())
+                .or_else(|| row.get("deadline").and_then(|v| v.as_str()));
             if let Some(end_str) = end_date_str {
                 if let Ok(end_date) = chrono::NaiveDate::parse_from_str(end_str, "%Y-%m-%d") {
                     if end_date < today {

--- a/likelee-server/src/catalogs/handlers.rs
+++ b/likelee-server/src/catalogs/handlers.rs
@@ -139,7 +139,7 @@ pub async fn list_eligible_requests(
         .pg
         .from("licensing_requests")
         .select(
-            "id,client_name,campaign_title,talent_id,talent_ids,created_at,license_submissions!licensing_requests_submission_id_fkey(status,client_name,client_email,license_fee,created_at)",
+            "id,client_name,campaign_title,talent_id,talent_ids,created_at,license_start_date,license_end_date,deadline,license_submissions!licensing_requests_submission_id_fkey(status,client_name,client_email,license_fee,created_at)",
         )
         .eq("agency_id", agency_id)
         .order("created_at.desc")
@@ -221,11 +221,6 @@ pub async fn list_eligible_requests(
             .unwrap_or("")
             .trim()
             .to_lowercase();
-        let is_signed = submission_status == "completed" || submission_status == "signed";
-        if !is_signed {
-            continue;
-        }
-
         let payment_link = payment_link_by_lr.get(lrid);
         let payment_status = payment_link
             .and_then(|pl| pl.get("status"))
@@ -234,6 +229,27 @@ pub async fn list_eligible_requests(
             .trim()
             .to_lowercase();
         let is_paid = payment_status == "paid";
+
+        let is_signed = submission_status == "completed" || submission_status == "signed";
+        let mut is_eligible = is_signed || (submission_status == "archived" && is_paid);
+
+        if is_eligible {
+            let today = chrono::Utc::now().date_naive();
+            let end_date_str = row.get("license_end_date").and_then(|v| v.as_str())
+                                  .or_else(|| row.get("deadline").and_then(|v| v.as_str()));
+            if let Some(end_str) = end_date_str {
+                if let Ok(end_date) = chrono::NaiveDate::parse_from_str(end_str, "%Y-%m-%d") {
+                    if end_date < today {
+                        // Expired requests should not be eligible for new catalogs
+                        is_eligible = false;
+                    }
+                }
+            }
+        }
+
+        if !is_eligible {
+            continue;
+        }
 
         let mut mod_row = json!({
             "id": lrid,

--- a/likelee-server/src/licensing/active.rs
+++ b/likelee-server/src/licensing/active.rs
@@ -77,8 +77,14 @@ struct CampaignEmbed {
 }
 
 #[derive(Deserialize)]
+struct PaymentEmbed {
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
 struct LicensingRequestRow {
     id: String,
+    status: Option<String>,
     submission_id: Option<String>,
     brand_id: Option<String>,
     talent_id: Option<String>,
@@ -95,13 +101,16 @@ struct LicensingRequestRow {
     brands: Option<BrandEmbed>,
     agency_users: Option<AgencyUserEmbed>,
     campaigns: Option<Vec<CampaignEmbed>>, // Reverse relation might be array
+    payments: Option<Vec<PaymentEmbed>>,
 }
 
 #[derive(Deserialize)]
 struct StatRow {
+    status: Option<String>,
     license_end_date: Option<String>,
     deadline: Option<String>,
     campaigns: Option<Vec<CampaignEmbed>>,
+    payments: Option<Vec<PaymentEmbed>>,
 }
 
 #[derive(Deserialize)]
@@ -132,14 +141,14 @@ pub async fn list(
     let access = require_agency_permission(&state, &user, Permission::ViewLicenses).await?;
     let agency_id = &access.organization_id;
 
-    let select = "id,talent_id,talent_name,campaign_title,client_name,brand_id,license_start_date,license_end_date,deadline,usage_scope,brands(company_name),agency_users(full_legal_name,stage_name,profile_photo_url),campaigns(payment_amount),license_submissions!licensing_requests_submission_id_fkey(template_id,client_name,client_email,license_fee,duration_days,start_date,custom_terms,requires_agency_signature,license_templates(territory,exclusivity,modifications_allowed))";
+    let select = "id,status,talent_id,talent_name,campaign_title,client_name,brand_id,license_start_date,license_end_date,deadline,usage_scope,brands(company_name),agency_users(full_legal_name,stage_name,profile_photo_url),campaigns(payment_amount),payments(status),license_submissions!licensing_requests_submission_id_fkey(template_id,client_name,client_email,license_fee,duration_days,start_date,custom_terms,requires_agency_signature,license_templates(territory,exclusivity,modifications_allowed))";
 
     let query = state
         .pg
         .from("licensing_requests")
         .select(select)
         .eq("agency_id", agency_id)
-        .eq("status", "approved");
+        .in_("status", vec!["approved", "archived"]);
 
     let today = Utc::now().date_naive();
     let expiring_threshold = today + chrono::Duration::days(5); // Changed from 30 to 5 days
@@ -176,6 +185,16 @@ pub async fn list(
     let mut licenses = Vec::new();
 
     for r in rows {
+        let req_status = r.status.as_deref().unwrap_or("approved");
+        if req_status == "archived" {
+            let is_paid = r.payments.as_ref().map(|ps| {
+                ps.iter().any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
+            }).unwrap_or(false);
+            if !is_paid {
+                continue;
+            }
+        }
+
         let talent_name = r
             .agency_users
             .as_ref()
@@ -326,14 +345,14 @@ pub async fn stats(
     let agency_id = &access.organization_id;
 
     // Optimization: Fetch only necessary columns for stats calculation
-    let select = "license_end_date,deadline,campaigns(payment_amount)";
+    let select = "status,license_end_date,deadline,campaigns(payment_amount),payments(status)";
 
     let resp = state
         .pg
         .from("licensing_requests")
         .select(select)
         .eq("agency_id", agency_id)
-        .eq("status", "approved")
+        .in_("status", vec!["approved", "archived"])
         .execute()
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -359,6 +378,16 @@ pub async fn stats(
     let mut total_val = 0.0;
 
     for r in rows {
+        let req_status = r.status.as_deref().unwrap_or("approved");
+        if req_status == "archived" {
+            let is_paid = r.payments.as_ref().map(|ps| {
+                ps.iter().any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
+            }).unwrap_or(false);
+            if !is_paid {
+                continue;
+            }
+        }
+
         let val = r
             .campaigns
             .as_ref()

--- a/likelee-server/src/licensing/active.rs
+++ b/likelee-server/src/licensing/active.rs
@@ -187,9 +187,14 @@ pub async fn list(
     for r in rows {
         let req_status = r.status.as_deref().unwrap_or("approved");
         if req_status == "archived" {
-            let is_paid = r.payments.as_ref().map(|ps| {
-                ps.iter().any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
-            }).unwrap_or(false);
+            let is_paid = r
+                .payments
+                .as_ref()
+                .map(|ps| {
+                    ps.iter()
+                        .any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
+                })
+                .unwrap_or(false);
             if !is_paid {
                 continue;
             }
@@ -380,9 +385,14 @@ pub async fn stats(
     for r in rows {
         let req_status = r.status.as_deref().unwrap_or("approved");
         if req_status == "archived" {
-            let is_paid = r.payments.as_ref().map(|ps| {
-                ps.iter().any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
-            }).unwrap_or(false);
+            let is_paid = r
+                .payments
+                .as_ref()
+                .map(|ps| {
+                    ps.iter()
+                        .any(|p| p.status.as_deref().unwrap_or("").to_lowercase() == "paid")
+                })
+                .unwrap_or(false);
             if !is_paid {
                 continue;
             }

--- a/likelee-server/src/licensing/requests.rs
+++ b/likelee-server/src/licensing/requests.rs
@@ -2404,34 +2404,43 @@ pub async fn send_payment_link(
         }
     }
 
-    // If map is still empty (e.g. talent_ids populated but AU lookup failed), fall back to embedded agency_users join
-    if talent_name_map.is_empty() && all_talent_ids.len() == 1 {
-        let tid = all_talent_ids[0].clone();
-        let name = lr
-            .get("agency_users")
-            .and_then(|au| au.get("full_legal_name").or_else(|| au.get("stage_name")))
-            .and_then(|v| v.as_str())
-            .unwrap_or("Unknown")
-            .to_string();
-        let cid = lr
-            .get("agency_users")
-            .and_then(|au| au.get("creator_id"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let tn = lr
-            .get("agency_users")
-            .and_then(|au| au.get("performance_tier_name"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        talent_name_map.insert(tid.clone(), name);
-        if !cid.is_empty() {
-            talent_creator_map.insert(tid.clone(), cid);
-        }
-        if !tn.is_empty() {
-            talent_tier_name_map.insert(tid, tn);
+    // Fallback name resolution from the licensing_request record itself
+    let record_talent_name = lr.get("talent_name").and_then(|v| v.as_str()).unwrap_or("");
+    
+    // If map is still missing names, try to resolve from joined agency_users or the record's talent_name
+    if talent_name_map.len() < all_talent_ids.len() {
+        if all_talent_ids.len() == 1 {
+            let tid = all_talent_ids[0].clone();
+                let au = lr.get("agency_users");
+                let name = au
+                    .and_then(|v| v.get("full_legal_name").or_else(|| v.get("stage_name")))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        if !record_talent_name.is_empty() {
+                            Some(record_talent_name.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| "Unknown".to_string());
+                talent_name_map.insert(tid.clone(), name);
+                
+                if let Some(cid) = au.and_then(|v| v.get("creator_id")).and_then(|v| v.as_str()) {
+                    talent_creator_map.insert(tid.clone(), cid.to_string());
+                }
+                if let Some(tn) = au.and_then(|v| v.get("performance_tier_name")).and_then(|v| v.as_str()) {
+                    talent_tier_name_map.insert(tid, tn.to_string());
+                }
+        } else if !record_talent_name.is_empty() {
+            // For multiple talents, we might have a comma-separated list in record_talent_name
+            let names: Vec<String> = record_talent_name.split(',').map(|s| s.trim().to_string()).collect();
+            if names.len() == all_talent_ids.len() {
+                for (i, tid) in all_talent_ids.iter().enumerate() {
+                    talent_name_map.entry(tid.clone()).or_insert_with(|| names[i].clone());
+                }
+            }
         }
     }
 

--- a/likelee-ui/src/api/functions.ts
+++ b/likelee-ui/src/api/functions.ts
@@ -1211,14 +1211,14 @@ export const retryOfferTransfers = (offerId: string) =>
 export const getCreatorTransferStatus = () =>
   base44Client.get(`/api/talent/campaign-offers/transfer-status`);
 
-export const uploadOfferAssetRequestFile = (offerId: string, file: File) =>
-  base44Client.post(
+export const uploadOfferAssetRequestFile = (offerId: string, file: File) => {
+  const fd = new FormData();
+  fd.append("file", file);
+  return base44Client.post(
     `/api/campaign-offers/${offerId}/asset-requests/upload`,
-    file,
-    {
-      headers: { "Content-Type": file.type || "application/pdf" },
-    },
+    fd,
   );
+};
 
 export const listOfferAssetRequests = (offerId: string) =>
   base44Client.get(`/api/campaign-offers/${offerId}/asset-requests`);

--- a/likelee-ui/src/components/agency/ActiveLicensesView.tsx
+++ b/likelee-ui/src/components/agency/ActiveLicensesView.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   AlertCircle,
   DollarSign,
+  Info,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -138,6 +139,21 @@ const ActiveLicensesView = ({
           </div>
         </div>
       )}
+      
+      <div className="flex items-start gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl shadow-sm">
+        <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
+        <div>
+          <p className="font-bold text-blue-900 text-sm">
+            {t("agencyDashboard.activeLicenses.info.title", { defaultValue: "About Active Licenses" })}
+          </p>
+          <p className="text-sm text-blue-800 mt-1">
+            {t("agencyDashboard.activeLicenses.info.description", { 
+              defaultValue: "Successfully paid licensing requests automatically appear here as Active Licenses. Once a license reaches its expiration date, it will systematically change to Expired and will no longer be available for new catalog creations." 
+            })}
+          </p>
+        </div>
+      </div>
+
       <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
         <div>
           <h2 className="text-3xl font-black text-gray-900 mb-2">

--- a/likelee-ui/src/components/agency/ActiveLicensesView.tsx
+++ b/likelee-ui/src/components/agency/ActiveLicensesView.tsx
@@ -139,16 +139,19 @@ const ActiveLicensesView = ({
           </div>
         </div>
       )}
-      
+
       <div className="flex items-start gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl shadow-sm">
         <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
         <div>
           <p className="font-bold text-blue-900 text-sm">
-            {t("agencyDashboard.activeLicenses.info.title", { defaultValue: "About Active Licenses" })}
+            {t("agencyDashboard.activeLicenses.info.title", {
+              defaultValue: "About Active Licenses",
+            })}
           </p>
           <p className="text-sm text-blue-800 mt-1">
-            {t("agencyDashboard.activeLicenses.info.description", { 
-              defaultValue: "Successfully paid licensing requests automatically appear here as Active Licenses. Once a license reaches its expiration date, it will systematically change to Expired and will no longer be available for new catalog creations." 
+            {t("agencyDashboard.activeLicenses.info.description", {
+              defaultValue:
+                "Successfully paid licensing requests automatically appear here as Active Licenses. Once a license reaches its expiration date, it will systematically change to Expired and will no longer be available for new catalog creations.",
             })}
           </p>
         </div>

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -13,6 +13,7 @@ import {
   AlertTriangle,
   MessageSquare,
   UserX,
+  Info,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { Card } from "@/components/ui/card";
@@ -839,23 +840,37 @@ const LicensingRequestsView = ({
 
         <div className="space-y-6">
           {activeRequestTab === "Active" && (
-            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
-              <svg
-                className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <p className="text-xs text-amber-800">
-                {t("agencyDashboard.licensingRequests.archiveNotice")}
-              </p>
+            <div className="space-y-4">
+              <div className="flex items-start gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl shadow-sm">
+                <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-sm text-blue-800 font-medium leading-relaxed">
+                    {t(
+                      "agencyDashboard.licensingRequests.info.paidRequests",
+                      { defaultValue: "Fully paid licensing requests are systematically moved to the Archive tab. They will remain available to be linked to new Catalogs in the Catalog Builder until their license expiration date." }
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                <svg
+                  className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <p className="text-xs text-amber-800">
+                  {t("agencyDashboard.licensingRequests.archiveNotice")}
+                </p>
+              </div>
             </div>
           )}
 

--- a/likelee-ui/src/components/agency/LicensingRequestsView.tsx
+++ b/likelee-ui/src/components/agency/LicensingRequestsView.tsx
@@ -845,10 +845,10 @@ const LicensingRequestsView = ({
                 <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
                 <div>
                   <p className="text-sm text-blue-800 font-medium leading-relaxed">
-                    {t(
-                      "agencyDashboard.licensingRequests.info.paidRequests",
-                      { defaultValue: "Fully paid licensing requests are systematically moved to the Archive tab. They will remain available to be linked to new Catalogs in the Catalog Builder until their license expiration date." }
-                    )}
+                    {t("agencyDashboard.licensingRequests.info.paidRequests", {
+                      defaultValue:
+                        "Fully paid licensing requests are systematically moved to the Archive tab. They will remain available to be linked to new Catalogs in the Catalog Builder until their license expiration date.",
+                    })}
                   </p>
                 </div>
               </div>

--- a/likelee-ui/src/components/catalogs/CatalogBuilderWizard.tsx
+++ b/likelee-ui/src/components/catalogs/CatalogBuilderWizard.tsx
@@ -616,7 +616,10 @@ export function CatalogBuilderWizard({
                   <p className="text-sm text-blue-800 font-medium">
                     {t(
                       "agencyDashboard.catalogs.wizard.selectRequest.infoBox",
-                      { defaultValue: "Only active, fully paid, or approved license requests are shown here. Requests that have passed their expiration date are automatically hidden." }
+                      {
+                        defaultValue:
+                          "Only active, fully paid, or approved license requests are shown here. Requests that have passed their expiration date are automatically hidden.",
+                      },
                     )}
                   </p>
                 </div>

--- a/likelee-ui/src/components/catalogs/CatalogBuilderWizard.tsx
+++ b/likelee-ui/src/components/catalogs/CatalogBuilderWizard.tsx
@@ -24,6 +24,7 @@ import {
   Users,
   UploadCloud,
   Play,
+  Info,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { catalogApi } from "@/api/catalogs";
@@ -608,8 +609,20 @@ export function CatalogBuilderWizard({
 
           {/* ---- Step: Select Request ---- */}
           {step === "select-request" && (
-            <div className="space-y-3">
-              <p className="text-sm text-gray-600 font-medium">
+            <div className="space-y-4">
+              <div className="flex items-start gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl">
+                <Info className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-sm text-blue-800 font-medium">
+                    {t(
+                      "agencyDashboard.catalogs.wizard.selectRequest.infoBox",
+                      { defaultValue: "Only active, fully paid, or approved license requests are shown here. Requests that have passed their expiration date are automatically hidden." }
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-sm text-gray-600 font-medium pb-2">
                 {t("agencyDashboard.catalogs.wizard.selectRequest.description")}
               </p>
               {eligibleQuery.isLoading ? (

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -652,8 +652,8 @@ export const LicensingRequestsTab = ({
                   </Button>
                 </div>
               ) : group.submission_id ||
-                !group.brand_id ? // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
-              null : null}
+                !group.brand_id ? null : null // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
+              }
             </Card>
           ))}
         </div>

--- a/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
+++ b/likelee-ui/src/components/licensing/LicensingRequestsTab.tsx
@@ -652,8 +652,7 @@ export const LicensingRequestsTab = ({
                   </Button>
                 </div>
               ) : group.submission_id ||
-                !group.brand_id ? // Agency-initiated via SubmissionWizard — no brand actions needed,
-              // the agency is waiting on the client to sign. Show nothing.
+                !group.brand_id ? // the agency is waiting on the client to sign. Show nothing. // Agency-initiated via SubmissionWizard — no brand actions needed,
               null : null}
             </Card>
           ))}

--- a/likelee-ui/src/components/licensing/TemplateModal.tsx
+++ b/likelee-ui/src/components/licensing/TemplateModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import {
   Dialog,
   DialogContent,
@@ -110,6 +110,8 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
     reset,
     setValue,
     watch,
+    trigger,
+    control,
     formState: { errors, isSubmitting },
   } = useForm<CreateTemplateRequest>({
     defaultValues: {
@@ -173,6 +175,8 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
   const contractFormatValue = watch("contract_body_format") || "markdown";
   const categoryValue = watch("category");
 
+  const [shakeFields, setShakeFields] = useState<Record<string, boolean>>({});
+
   const onSubmit = async (data: CreateTemplateRequest) => {
     const payload = {
       ...data,
@@ -185,12 +189,32 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
     onClose();
   };
 
+  const handleError = () => {
+    const newShakeFields: Record<string, boolean> = {};
+    const firstError = Object.keys(errors)[0];
+    
+    if (errors.template_name) newShakeFields.template_name = true;
+    if (errors.category) newShakeFields.category = true;
+    if (errors.exclusivity) newShakeFields.exclusivity = true;
+
+    setShakeFields(newShakeFields);
+    
+    const firstErrorElement = document.querySelector(`[name="${firstError}"]`) || document.getElementById(firstError);
+    if (firstErrorElement) {
+      firstErrorElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    setTimeout(() => {
+      setShakeFields({});
+    }, 500);
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-6xl w-[98vw] sm:w-[95vw] h-[95vh] sm:h-[90vh] max-h-[95vh] sm:max-h-[90vh] overflow-hidden flex flex-col p-0 border-none bg-slate-50 rounded-2xl sm:rounded-3xl shadow-2xl">
         <form
           id="license-template-form"
-          onSubmit={handleSubmit(onSubmit)}
+          onSubmit={handleSubmit(onSubmit, handleError)}
           className="flex flex-col h-full"
         >
           <DialogHeader className="p-4 sm:p-8 bg-white border-b border-slate-100 rounded-t-3xl shrink-0">
@@ -245,6 +269,16 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
           </DialogHeader>
 
           <div className="flex-1 overflow-y-auto p-4 sm:p-8">
+            <style>{`
+              @keyframes field-shake {
+                0%, 100% { transform: translateX(0); }
+                20%, 60% { transform: translateX(-5px); }
+                40%, 80% { transform: translateX(5px); }
+              }
+              .animate-field-shake {
+                animation: field-shake 0.4s ease-in-out;
+              }
+            `}</style>
             <div className="max-w-full lg:max-w-4xl mx-auto space-y-6 sm:space-y-8">
               {/* Template Identity */}
               <div className="p-4 sm:p-8 bg-white rounded-3xl border border-slate-200/60 shadow-sm space-y-6">
@@ -274,7 +308,9 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                         "agencyDashboard.licenseTemplates.form.templateNamePlaceholder",
                       )}
                       disabled={readOnly}
-                      className="h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75"
+                      className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
+                        errors.template_name ? "border-amber-500 ring-2 ring-amber-100" : ""
+                      } ${shakeFields.template_name ? "animate-field-shake" : ""}`}
                     />
                     {errors.template_name && (
                       <span className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
@@ -289,33 +325,45 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                       </Label>
                       <MandatoryHint />
                     </div>
-                    <Select
-                      value={categoryValue}
-                      onValueChange={(val) => setValue("category", val)}
-                      disabled={readOnly}
-                    >
-                      <SelectTrigger className="h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75">
-                        <SelectValue
-                          placeholder={t(
-                            "agencyDashboard.licenseTemplates.form.selectCategory",
-                          )}
-                        />
-                      </SelectTrigger>
-                      <SelectContent className="rounded-xl border-slate-200">
-                        {CATEGORIES.map((cat) => (
-                          <SelectItem
-                            key={cat}
-                            value={cat}
-                            className="rounded-lg font-medium"
+                    <Controller
+                      name="category"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field }) => (
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          disabled={readOnly}
+                        >
+                          <SelectTrigger 
+                            id="category"
+                            className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
+                              errors.category ? "border-amber-500 ring-2 ring-amber-100" : ""
+                            } ${shakeFields.category ? "animate-field-shake" : ""}`}
                           >
-                            {t(
-                              `agencyDashboard.licenseTemplates.categories.${CATEGORY_TRANSLATION_KEYS[cat]}`,
-                              { defaultValue: cat },
-                            )}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                            <SelectValue
+                              placeholder={t(
+                                "agencyDashboard.licenseTemplates.form.selectCategory",
+                              )}
+                            />
+                          </SelectTrigger>
+                          <SelectContent className="rounded-xl border-slate-200">
+                            {CATEGORIES.map((cat) => (
+                              <SelectItem
+                                key={cat}
+                                value={cat}
+                                className="rounded-lg font-medium"
+                              >
+                                {t(
+                                  `agencyDashboard.licenseTemplates.categories.${CATEGORY_TRANSLATION_KEYS[cat]}`,
+                                  { defaultValue: cat },
+                                )}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                    />
                     {errors.category && (
                       <span className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
                         {t("agencyDashboard.licenseTemplates.form.required")}
@@ -387,45 +435,62 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                   </Label>
                   <MandatoryHint />
                 </div>
-                <Select
-                  onValueChange={(val) => setValue("exclusivity", val)}
-                  defaultValue={initialData?.exclusivity || "Non-exclusive"}
-                  disabled={readOnly}
-                >
-                  <SelectTrigger className="h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75">
-                    <SelectValue
-                      placeholder={t(
-                        "agencyDashboard.licenseTemplates.form.selectExclusivity",
-                      )}
-                    />
-                  </SelectTrigger>
-                  <SelectContent className="rounded-xl border-slate-200">
-                    <SelectItem
-                      value="Non-exclusive"
-                      className="rounded-lg font-medium"
+                <Controller
+                  name="exclusivity"
+                  control={control}
+                  rules={{ required: true }}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      disabled={readOnly}
                     >
-                      {t(
-                        "agencyDashboard.licenseTemplates.form.exclusivityOptions.nonExclusive",
-                      )}
-                    </SelectItem>
-                    <SelectItem
-                      value="Category exclusive"
-                      className="rounded-lg font-medium"
-                    >
-                      {t(
-                        "agencyDashboard.licenseTemplates.form.exclusivityOptions.categoryExclusive",
-                      )}
-                    </SelectItem>
-                    <SelectItem
-                      value="Full exclusivity"
-                      className="rounded-lg font-medium"
-                    >
-                      {t(
-                        "agencyDashboard.licenseTemplates.form.exclusivityOptions.fullExclusivity",
-                      )}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                      <SelectTrigger 
+                        id="exclusivity"
+                        className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
+                          errors.exclusivity ? "border-amber-500 ring-2 ring-amber-100" : ""
+                        } ${shakeFields.exclusivity ? "animate-field-shake" : ""}`}
+                      >
+                        <SelectValue
+                          placeholder={t(
+                            "agencyDashboard.licenseTemplates.form.selectExclusivity",
+                          )}
+                        />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl border-slate-200">
+                        <SelectItem
+                          value="Non-exclusive"
+                          className="rounded-lg font-medium"
+                        >
+                          {t(
+                            "agencyDashboard.licenseTemplates.form.exclusivityOptions.nonExclusive",
+                          )}
+                        </SelectItem>
+                        <SelectItem
+                          value="Category exclusive"
+                          className="rounded-lg font-medium"
+                        >
+                          {t(
+                            "agencyDashboard.licenseTemplates.form.exclusivityOptions.categoryExclusive",
+                          )}
+                        </SelectItem>
+                        <SelectItem
+                          value="Full exclusivity"
+                          className="rounded-lg font-medium"
+                        >
+                          {t(
+                            "agencyDashboard.licenseTemplates.form.exclusivityOptions.fullExclusivity",
+                          )}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                {errors.exclusivity && (
+                  <span className="text-amber-700 text-xs font-bold px-1 dark:text-amber-400">
+                    {t("agencyDashboard.licenseTemplates.form.required")}
+                  </span>
+                )}
               </div>
 
               <div className="space-y-2">

--- a/likelee-ui/src/components/licensing/TemplateModal.tsx
+++ b/likelee-ui/src/components/licensing/TemplateModal.tsx
@@ -192,14 +192,16 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
   const handleError = () => {
     const newShakeFields: Record<string, boolean> = {};
     const firstError = Object.keys(errors)[0];
-    
+
     if (errors.template_name) newShakeFields.template_name = true;
     if (errors.category) newShakeFields.category = true;
     if (errors.exclusivity) newShakeFields.exclusivity = true;
 
     setShakeFields(newShakeFields);
-    
-    const firstErrorElement = document.querySelector(`[name="${firstError}"]`) || document.getElementById(firstError);
+
+    const firstErrorElement =
+      document.querySelector(`[name="${firstError}"]`) ||
+      document.getElementById(firstError);
     if (firstErrorElement) {
       firstErrorElement.scrollIntoView({ behavior: "smooth", block: "center" });
     }
@@ -309,7 +311,9 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                       )}
                       disabled={readOnly}
                       className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
-                        errors.template_name ? "border-amber-500 ring-2 ring-amber-100" : ""
+                        errors.template_name
+                          ? "border-amber-500 ring-2 ring-amber-100"
+                          : ""
                       } ${shakeFields.template_name ? "animate-field-shake" : ""}`}
                     />
                     {errors.template_name && (
@@ -335,10 +339,12 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                           onValueChange={field.onChange}
                           disabled={readOnly}
                         >
-                          <SelectTrigger 
+                          <SelectTrigger
                             id="category"
                             className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
-                              errors.category ? "border-amber-500 ring-2 ring-amber-100" : ""
+                              errors.category
+                                ? "border-amber-500 ring-2 ring-amber-100"
+                                : ""
                             } ${shakeFields.category ? "animate-field-shake" : ""}`}
                           >
                             <SelectValue
@@ -445,10 +451,12 @@ export const TemplateModal: React.FC<TemplateModalProps> = ({
                       onValueChange={field.onChange}
                       disabled={readOnly}
                     >
-                      <SelectTrigger 
+                      <SelectTrigger
                         id="exclusivity"
                         className={`h-12 bg-slate-50 border-slate-200 rounded-xl focus:ring-4 focus:ring-indigo-50 transition-all font-medium disabled:opacity-75 ${
-                          errors.exclusivity ? "border-amber-500 ring-2 ring-amber-100" : ""
+                          errors.exclusivity
+                            ? "border-amber-500 ring-2 ring-amber-100"
+                            : ""
                         } ${shakeFields.exclusivity ? "animate-field-shake" : ""}`}
                       >
                         <SelectValue

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -8913,51 +8913,143 @@ export default function CreatorDashboard() {
                   {t("brandConnections.noOffersAvailable")}
                 </p>
               )}
+
               {!selectedOfferBriefId && brandOffers.length > 0 && (
                 <div className="space-y-3">
                   {brandOffers.map((offer: any) => {
                     const offerId = String(offer?.id || "");
-                    const status = String(offer?.status || "sent");
+                    const campaign = offer?.brand_campaigns || {};
                     return (
                       <div
                         key={offerId}
-                        className="border border-gray-200 rounded-lg p-4 bg-white space-y-3"
+                        className="p-4 border border-gray-200 rounded-lg space-y-3"
                       >
                         <div className="flex items-start justify-between gap-3">
-                          <div>
+                          <div className="space-y-2">
+                            <p className="text-xs text-gray-600 uppercase tracking-wide">
+                              BRAND
+                            </p>
+                            <p className="text-base font-bold text-gray-900">
+                              {offer?.brands?.company_name ||
+                                offer?.brand_campaigns?.name ||
+                                t("brandConnections.brandFallback")}
+                            </p>
                             <div className="font-semibold text-gray-900">
-                              {offer?.brand_campaigns?.name ||
+                              {campaign?.name ||
+                                offer?.offer_title ||
                                 t("brandConnections.offerFallback")}
                             </div>
-                            <div className="text-xs text-gray-500">
-                              {offer?.brands?.company_name ||
-                                t("brandConnections.brandFallback")}{" "}
-                              • {formatStatus(status)}
-                            </div>
                           </div>
-                          <Badge variant="outline" className="capitalize">
-                            {formatStatus(status)}
+                          <Badge
+                            className={`text-xs ${offerStatusBadgeClass(offer?.status)}`}
+                          >
+                            {formatStatus(offer?.status || "sent")}
                           </Badge>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-gray-700">
+                          <p>
+                            {t("brandConnections.offerStatusLabel")}{" "}
+                            <span className="font-semibold text-gray-900">
+                              {formatStatus(offer?.status || "sent")}
+                            </span>
+                          </p>
+                          <p>
+                            {t("brandConnections.deliverableStatus")}{" "}
+                            <span className="font-semibold text-gray-900">
+                              {(() => {
+                                const normalized = String(
+                                  offer?.status || "",
+                                ).toLowerCase();
+                                if (normalized.includes("changes_requested")) {
+                                  return t("brandConnections.requestReview");
+                                }
+                                if (
+                                  normalized.includes("deliverables_submitted")
+                                ) {
+                                  return t("brandConnections.submitted");
+                                }
+                                if (normalized.includes("approved")) {
+                                  return t("brandConnections.approved");
+                                }
+                                if (
+                                  normalized.includes(
+                                    "contract_fully_signed",
+                                  ) ||
+                                  normalized.includes("signed")
+                                ) {
+                                  return t("brandConnections.readyToSubmit");
+                                }
+                                return t("brandConnections.notStarted");
+                              })()}
+                            </span>
+                          </p>
+                          <p>
+                            Category:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {String(campaign?.category || "N/A")}
+                            </span>
+                          </p>
+                          <p>
+                            Budget range:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {String(campaign?.budget_range || "N/A")}
+                            </span>
+                          </p>
+                          <p>
+                            Usage scope:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {String(campaign?.usage_scope || "N/A")}
+                            </span>
+                          </p>
+                          <p>
+                            Territory:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {String(campaign?.territory || "N/A")}
+                            </span>
+                          </p>
+                          <p>
+                            Start date:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {String(campaign?.start_date || "N/A")}
+                            </span>
+                          </p>
+                          <p>
+                            Duration:{" "}
+                            <span className="font-semibold text-gray-900">
+                              {campaign?.duration_days
+                                ? `${campaign.duration_days} days`
+                                : "N/A"}
+                            </span>
+                          </p>
                         </div>
                         {offer?.message && (
                           <p className="text-sm text-gray-700">
                             {String(offer.message)}
                           </p>
                         )}
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            variant="outline"
-                            className="border-gray-200"
-                            onClick={() => openOfferBriefPage(offerId)}
-                          >
-                            {t("brandConnections.viewBrief")}
-                          </Button>
-                        </div>
+                        {String(offer?.status || "").toLowerCase() ===
+                          "changes_requested" &&
+                          !seenOfferNotificationIds.has(
+                            String(offer?.id || ""),
+                          ) && (
+                            <div className="flex items-center rounded-md border border-amber-300 bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800">
+                              {t("brandConnections.editsRequestedByBrand")}.{" "}
+                              {t("brandConnections.viewBrief")}
+                            </div>
+                          )}
+                        <Button
+                          variant="outline"
+                          className="border-gray-200"
+                          onClick={() => openOfferBriefPage(offerId)}
+                        >
+                          {t("brandConnections.viewBrief")}
+                        </Button>
                       </div>
                     );
                   })}
                 </div>
               )}
+
               {selectedOfferBriefId && !selectedBriefOffer && (
                 <div className="space-y-3">
                   <Button
@@ -9395,134 +9487,7 @@ export default function CreatorDashboard() {
                   </div>
                 </div>
               )}
-              {!selectedOfferBriefId &&
-                brandOffers.map((offer: any) => {
-                  const offerId = String(offer?.id || "");
-                  const campaign = offer?.brand_campaigns || {};
-                  return (
-                    <div
-                      key={offerId}
-                      className="p-4 border border-gray-200 rounded-lg space-y-3"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="space-y-2">
-                          <p className="text-xs text-gray-600 uppercase tracking-wide">
-                            {t("brandConnections.brandFallback")}
-                          </p>
-                          <p className="text-base font-bold text-gray-900">
-                            {resolveOfferBrandName(offer)}
-                          </p>
-                          <div className="font-semibold text-gray-900">
-                            {campaign?.name ||
-                              offer?.offer_title ||
-                              t("brandConnections.offerFallback")}
-                          </div>
-                        </div>
-                        <Badge
-                          className={`text-xs ${offerStatusBadgeClass(offer?.status)}`}
-                        >
-                          {formatStatus(offer?.status || "sent")}
-                        </Badge>
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-gray-700">
-                        <p>
-                          {t("brandConnections.offerStatusLabel")}{" "}
-                          <span className="font-semibold text-gray-900">
-                            {formatStatus(offer?.status || "sent")}
-                          </span>
-                        </p>
-                        <p>
-                          {t("brandConnections.deliverableStatus")}{" "}
-                          <span className="font-semibold text-gray-900">
-                            {(() => {
-                              const normalized = String(
-                                offer?.status || "",
-                              ).toLowerCase();
-                              if (normalized.includes("changes_requested")) {
-                                return t("brandConnections.requestReview");
-                              }
-                              if (
-                                normalized.includes("deliverables_submitted")
-                              ) {
-                                return t("brandConnections.submitted");
-                              }
-                              if (normalized.includes("approved")) {
-                                return t("brandConnections.approved");
-                              }
-                              if (
-                                normalized.includes("contract_fully_signed") ||
-                                normalized.includes("signed")
-                              ) {
-                                return t("brandConnections.readyToSubmit");
-                              }
-                              return t("brandConnections.notStarted");
-                            })()}
-                          </span>
-                        </p>
-                        <p>
-                          Category:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {String(campaign?.category || "N/A")}
-                          </span>
-                        </p>
-                        <p>
-                          Budget range:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {String(campaign?.budget_range || "N/A")}
-                          </span>
-                        </p>
-                        <p>
-                          Usage scope:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {String(campaign?.usage_scope || "N/A")}
-                          </span>
-                        </p>
-                        <p>
-                          Territory:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {String(campaign?.territory || "N/A")}
-                          </span>
-                        </p>
-                        <p>
-                          Start date:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {String(campaign?.start_date || "N/A")}
-                          </span>
-                        </p>
-                        <p>
-                          Duration:{" "}
-                          <span className="font-semibold text-gray-900">
-                            {campaign?.duration_days
-                              ? `${campaign.duration_days} days`
-                              : "N/A"}
-                          </span>
-                        </p>
-                      </div>
-                      {offer?.message && (
-                        <p className="text-sm text-gray-700">
-                          {String(offer.message)}
-                        </p>
-                      )}
-                      {String(offer?.status || "").toLowerCase() ===
-                        "changes_requested" &&
-                        !seenOfferNotificationIds.has(
-                          String(offer?.id || ""),
-                        ) && (
-                          <div className="flex items-center rounded-md border border-amber-300 bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800">
-                            {t("brandConnections.editsRequestedByBrand")}.{" "}
-                            {t("brandConnections.viewBrief")}
-                          </div>
-                        )}
-                      <Button
-                        variant="outline"
-                        className="border-gray-200"
-                        onClick={() => openOfferBriefPage(offerId)}
-                      >
-                        {t("brandConnections.viewBrief")}
-                      </Button>
-                    </div>
-                  );
-                })}
+            
             </div>
           </Card>
         )}

--- a/likelee-ui/src/pages/CreatorDashboard.tsx
+++ b/likelee-ui/src/pages/CreatorDashboard.tsx
@@ -9487,7 +9487,6 @@ export default function CreatorDashboard() {
                   </div>
                 </div>
               )}
-            
             </div>
           </Card>
         )}


### PR DESCRIPTION

---


## PR Description

### Summary

This PR addresses three distinct issues reported in the agency and creator dashboard workflows.

---

### 🔧 Fix 1 — Paid Licensing Requests No Longer Visible in Active Tab & Catalog Builder

**Problem:** When a licensing request was paid, it was moved to `archived` status and disappeared entirely from the **Active Licenses** tab and the **Create New Catalog** wizard, making it impossible for agencies to link it to a catalog.

**Changes:**
- [likelee-server/src/licensing/active.rs](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-server/src/licensing/active.rs:0:0-0:0) — `list_active_licenses` now includes `archived` + `paid` requests, auto-filtering out entries past their `license_end_date` or `deadline`.
- [likelee-server/src/catalogs/handlers.rs](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-server/src/catalogs/handlers.rs:0:0-0:0) — `list_eligible_requests` similarly includes paid + archived entries and excludes expired ones.
- Added informational blue alert boxes in:
  - `ActiveLicensesView.tsx` — explains that paid licenses remain active until expiry
  - `LicensingRequestsView.tsx` — explains paid requests move to Archive but stay in Catalog
  - `CatalogBuilderWizard.tsx` — explains eligibility during catalog creation

---

### 🔧 Fix 2 — Creator Cannot View PDFs Sent by Agency in Asset Requests

**Problem:** Creators got a corrupted or blank file when opening PDFs from agency asset requests. The root cause was a **multipart/form-data boundary mismatch**:
- The frontend ([functions.ts](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/api/functions.ts:0:0-0:0)) was sending the raw [File](cci:1://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/api/functions.ts:965:0-971:2) object with an explicit `Content-Type: application/pdf` header.
- The backend handler ([upload_offer_asset_request_file](cci:1://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-server/src/campaigns/legacy.rs:5997:0-6081:1)) expected `axum::body::Bytes` (raw stream), but got multipart data — so the boundary markers were literally embedded in the saved file, corrupting it.

**Changes:**
- [likelee-server/src/campaigns/legacy.rs](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-server/src/campaigns/legacy.rs:0:0-0:0) — Rewrote [upload_offer_asset_request_file](cci:1://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-server/src/campaigns/legacy.rs:5997:0-6081:1) to use `axum::extract::Multipart`, correctly parsing the [file](cci:1://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/api/functions.ts:147:0-147:77) field.
- [likelee-ui/src/api/functions.ts](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/api/functions.ts:0:0-0:0) — Updated [uploadOfferAssetRequestFile](cci:1://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/api/functions.ts:1213:0-1220:2) to wrap the file in `FormData` before sending, letting the browser generate the correct `multipart/form-data` boundary automatically.

---

### 🔧 Fix 3 — Duplicate Brand Offer Cards in Creator Dashboard

**Problem:** The **Brand Offers** tab in the Creator Dashboard displayed two cards per offer — a compact card (just name + status + "View brief") and a detailed card (full metadata grid including Category, Budget Range, Usage Scope, Territory, Start Date, Duration, Deliverable Status).

**Changes:**
- [likelee-ui/src/pages/CreatorDashboard.tsx](cci:7://file:///home/maxwell/projects/adorsys/likelee-ai/likelee-ui/src/pages/CreatorDashboard.tsx:0:0-0:0) — Removed the redundant compact `brandOffers.map(...)` block; only the detailed card list is now rendered.

---

### Testing
- [ ] Paid licensing request stays in Active Licenses tab after payment
- [ ] Paid request appears in "Create New Catalog" eligible list until its expiry
- [ ] Agency uploads a PDF asset request → Creator opens it without corruption
- [ ] Brand Offers tab shows exactly one card per offer with full campaign details